### PR TITLE
Adds mean(A, v) where v is a vector of dimensions.

### DIFF
--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -22,9 +22,9 @@ module Stats
            weighted_mean
 
     # tensor mean along a vector of dimensions
-    # For example, if A is an array with dimension M x N x P, then mean(A, [2 3])
-    # returns a M x 1 x 1 array after taking the mean along the 2nd and 3rd dimension.
-    mean(v::AbstractArray, dims::Union(Int, AbstractArray{Int})) = sum(v, dims) / prod(size(v)[dims])
+    # For example, if A is an array with dimension M x N x P, then mean(A, 1) returns
+    # a 1 X N X P array, while mean(A, [2 3]) returns a M x 1 x 1 array.
+    mean(v::AbstractArray, region) = sum(v, region) / prod(size(v)[region])
 
     weighted_mean(v::AbstractArray, w::AbstractArray) = sum(v .* w) / sum(w)
 


### PR DESCRIPTION
Also modifies `mean(A, d)` for scalar d to squeeze the result along the dimension
of the mean. Or in other words, mean of N-dim A has N-1 dims.

This latter change breaks conformity with MATLAB, but I cannot think of a use case where I would expect `mean(v, d)` to preserve the dimension of `v`, except for the case where I want to take a mean along several axes. But, by extending mean to accept a vector of dimensions, this other use case goes away.
