### PR TITLE
fixes bugs in tests and a minor revision of logsumexp

### DIFF
--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -292,21 +292,12 @@ module Stats
 
     invlogit(z::Real) = 1.0 / (1.0 + exp(-clamp(z, -709.0, 745.0)))
 
+    # logsumexp
+
     function logsumexp{T <: Real}(a::Vector{T})
-        a_min = Inf
-        a_max = -Inf
-        n = length(a)
-        for i in 1:n
-            if a[i] < a_min
-                a_min = a[i]
-            end
-            if a[i] > a_max
-                a_max = a[i]
-            end
-        end
-        c = a_max
+        c = max(a)
         s = 0.0
-        for i in 1:n
+        for i in 1 : length(a)
             s += exp(a[i] - c)
         end
         return c + log(s)

--- a/test/01.jl
+++ b/test/01.jl
@@ -1,5 +1,5 @@
 using Stats
-using Test
+using Base.Test
 
 @test_approx_eq autocor([1, 2, 3, 4, 5]) 1.0
 
@@ -22,11 +22,11 @@ d = [0.0 sqrt(2); sqrt(2) 0.0]
 @test_approx_eq distances(m) d
 
 m = [3.0 1.0; 5.0 1.0]
-d = [0.0 2.0; 2.0 0.0]
+d = [0.0 sqrt(20.); sqrt(20.) 0.0]
 @test_approx_eq distances(m) d
 
 m = [1 0 0; 0 1 0 ; 1 0 1]
-d = [0.0 sqrt(2) 1.0; sqrt(2) 0.0 sqrt(3); 1.0 sqrt(3) 0.0]
+d = [0.0 sqrt(3) 1.0; sqrt(3) 0.0 sqrt(2); 1.0 sqrt(2) 0.0]
 @test_approx_eq distances(m) d
 
 # X = [1 0; 2 1; 3 0; 4 1; 5 10]

--- a/test/02.jl
+++ b/test/02.jl
@@ -1,18 +1,15 @@
 using Stats
+using Base.Test
 
-@assert norm(distances([1.0 0.0; 0.0 1.0]) - [0.0 sqrt(2); sqrt(2) 0.0]) < 1e-4
-@assert norm(distances([1.0 0.0; 0.0 1.0], [0.0 1.0; 1.0 0.0]) - [sqrt(2) 0.0; 0.0 sqrt(2)]) < 1e-4
+@test invlogit(-800) > 0.0
+@test invlogit(800) <= 1.0
+@test isinf(logit(0.0))
+@test isinf(logit(1.0))
 
-@assert invlogit(-800) > 0.0
-@assert invlogit(800) <= 1.0
+@test_approx_eq invlogit(logit(0.01)) 0.01
+@test_approx_eq invlogit(logit(0.50)) 0.50
+@test_approx_eq invlogit(logit(0.99)) 0.99
 
-@assert isinf(logit(0.0))
-@assert norm(invlogit(logit(0.01)) - 0.01) < 1e-4
-@assert norm(invlogit(logit(0.50)) - 0.50) < 1e-4
-@assert norm(invlogit(logit(0.99)) - 0.99) < 1e-4
-@assert isinf(logit(1.0))
-
-@assert isfinite(logsumexp([1.0, 1.0, 1.0]))
-@assert isfinite(logsumexp([1.0, 1.0, 1.0e7]))
-@assert isfinite(logsumexp([-1.0, -1.0, -7.5]))
-@assert isfinite(logsumexp([-10.0, -10.0, -75000.0]))
+@test_approx_eq logsumexp([1., 2., 3.]) log(sum(exp([1., 2., 3.])))
+@test isfinite(logsumexp([1000., 1000.]))
+@test_approx_eq logsumexp([1000., 1000.]) 1000. + log(2.)


### PR DESCRIPTION
Several fixes:
- use `Base.Test` instead of `Test`
- the `distances` function computes distances between columns, but the original test script seems to consider it in row-wise way
- the logsumexp does not actually use `a_min`. I remove the unnecessary computation there.
