### PR TITLE
RFC:Change autocor

### DIFF
--- a/test/01.jl
+++ b/test/01.jl
@@ -1,7 +1,7 @@
 using Stats
 using Base.Test
 
-@test_approx_eq autocor([1, 2, 3, 4, 5]) 1.0
+@test_approx_eq autocor([1, 2, 3, 4, 5], 1) 0.4
 
 @test iqr([1, 2, 3, 4, 5]) == [2.0, 4.0]
 


### PR DESCRIPTION
to use same mean and s.d. for both samples making it behave as the similar functions in MATLAB and R. I have also written a method for `Ranges` which is also chosen as the default. Lag length is chosen similarly to R.
