### PR TITLE
RFC: amap was deprecated, using mapslices instead

### DIFF
--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -151,7 +151,7 @@ module Stats
     end
     tiedrank(X::AbstractMatrix) = tiedrank(reshape(X, length(X)))
     function tiedrank(X::AbstractMatrix, dim::Int)
-        retmat = apply(hcat, amap(tiedrank, X, 3 - dim))
+        retmat = apply(hcat, mapslices(tiedrank, X, 3 - dim))
         return dim == 1 ? retmat : retmat'
     end
 


### PR DESCRIPTION
First time I use `mapslices`, but looks fine, comparison with R (using Rif):

```
julia> cor_spearman([1.5,1.5,2.2,2,3.5,3.55] , [1,2,3,4,5,6])
0.9276336570439175

julia> R("cor(c(1.5,1.5,2.2,2,3.5,3.55),c(1,2,3,4,5,6),method=\"spearman\")")[1]
0.9276336570439175
```
