### PR TITLE
RFC:Add abstract types of generic functions

### DIFF
--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -35,11 +35,25 @@ module Stats
     cor_kendall,    
 
     # others
-    rle,
-    inverse_rle,
+    ## Types
+    StatisticalModel,
+    RegressionModel,
+    
+    ## Fcuntions
+    coef,
+    coeftable,
+    confint,
     ecdf,
-    findat
-     
+    findat,
+    inverse_rle,
+    loglikelihood,
+    nobs,
+    predict,
+    residuals,
+    model_response,
+    rle,
+    stderr,
+    vcov
 
     include("scalar_stats.jl")
     include("weighted_stats.jl")

--- a/src/others.jl
+++ b/src/others.jl
@@ -94,4 +94,18 @@ function ecdf{T}(X::AbstractVector{T})
     return e
 end
 
+abstract StatisticalModel
 
+coef(obj::StatisticalModel) = error("No method defined")
+coeftable(obj::StatisticalModel) = error("No method defined")
+confint(obj::StatisticalModel) = error("No method defined")
+loglikelihood(obj::StatisticalModel) = error("No method defined")
+nobs(obj::StatisticalModel) = size(model_response(obj), 1)
+stderr(obj::StatisticalModel) = sqrt(diag(vcov(obj)))
+vcov(obj::StatisticalModel) = error("No method defined")
+
+abstract RegressionModel <: StatisticalModel
+
+residuals(obj::RegressionModel) = error("No method defined")
+model_response(obj::RegressionModel) = error("No method defined")
+predict(obj::RegressionModel) = error("No method defined")


### PR DESCRIPTION
Here is a first draft of including generic statistical functions. Most do nothing right now, but as discussed in #18, the main reason is define the function names in an upstream package.
