### PR TITLE
`range` and `midrange` were throwing undefined errors because of an argu...

### DIFF
--- a/src/scalar_stats.jl
+++ b/src/scalar_stats.jl
@@ -109,13 +109,13 @@ end
 
 
 # Mid-range
-function midrange{T<:Real}(x::AbstractArray{T})
+function midrange{T<:Real}(a::AbstractArray{T})
     xmin, xmax = minmax(a)
     return xmin + (xmax - xmin) / 2
 end
 
 # Range: xmax - xmin
-function range{T<:Real}(x::AbstractArray{T})
+function range{T<:Real}(a::AbstractArray{T})
     xmin, xmax = minmax(a)
     return xmax - xmin
 end


### PR DESCRIPTION
...ment/variable mismatch.
