### PR TITLE
[RFC] Add levelsmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ This package implements various stragies for computing ranks. Please refer to [W
 
   Inversed run-length encoding. It takes the results of ``rle`` and reconstructs the original sequence. 
 
+* **levelsmap**(x)
+
+  Construct a dictionary that maps each of the ``n`` distinct values in ``x`` to a number between ``1`` and ``n``.
+
 * **indexmap**(x)
 
   Construct a dictionary that maps each distinct value in ``x`` to its first index.

--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -64,6 +64,7 @@ module Stats
     rle,            # run-length encoding
     inverse_rle,    # inverse run-length encoding
     indexmap,       # construct a map from element to index
+    levelsmap,      # construct a map from n unique elements to [1, ..., n]
     findat,         # find the position within a for elements in b
     indicatormat,   # construct indicator matrix
         

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -62,6 +62,19 @@ function indexmap{T}(a::AbstractArray{T})
     return d
 end
 
+function levelsmap{T}(a::AbstractArray{T})
+    d = (T=>Int)[]
+    index = 1
+    for i = 1 : length(a)
+        @inbounds k = a[i]
+        if !haskey(d, k)
+            d[k] = index
+            index += 1
+        end
+    end
+    return d
+end
+
 function findat!{T}(r::IntegerArray, a::AbstractArray{T}, b::AbstractArray{T})
     length(r) == length(b) || raise_dimerror()
     d = indexmap(a)


### PR DESCRIPTION
This implements a variant of `indexmap` that maps the `n` unique elements of an `AbstractArray` to the numbers `1` through `n`.

The name `levelsmap` was chosen instead of `uniquemap` to be consistent with a distinction in DataArrays between `unique`, which can include `NA`, and `levels`, which never includes `NA`.

Please ignore the stupid branch name I chose.
