### PR TITLE
Update sampling.jl

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -71,7 +71,7 @@ function self_avoid_sample!{T}(a::AbstractArray{T}, x::AbstractArray)
     x
 end
 
-# Ordered sampling without replacement
+# Ordered sampling with replacement
 # Original author: Mike Innes
 
 function ordered_sample!(a::AbstractArray, x::AbstractArray)


### PR DESCRIPTION
The code this comment refers to was removed, I've just updated it so it's not confusing.

@lindahua While I'm here, mind if I ask why the dedicated ordered sampling without replacement algorithm was removed? I included it originally because it's faster than fisher-yates + sort in most cases. I'm sure there's a good reason for it's removal, I'm just curious.
