### PR TITLE
Add ordered sampling without replacement algorithm

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -157,20 +157,14 @@ function sample!(a::AbstractArray, x::AbstractArray; replace::Bool=true, ordered
         k <= n || error("Cannot draw more samples without replacement.")
 
         if ordered && k > n/20
-
             ordered_sample_norep!(a, x)
-
         else
-
             if k == 1
                 @inbounds x[1] = sample(a)
-
             elseif k == 2
                 @inbounds (x[1], x[2]) = samplepair(a)
-
             elseif n < k * max(k, 100)
                 fisher_yates_sample!(a, x)
-
             else
                 self_avoid_sample!(a, x)
             end
@@ -178,7 +172,6 @@ function sample!(a::AbstractArray, x::AbstractArray; replace::Bool=true, ordered
             if ordered
                 sort!(x)
             end
-
         end
     end
     return x


### PR DESCRIPTION
This algorithm was originally merged and then later removed due to performance concerns (#45). Hopefully we can discuss those concerns and consider reinstating it.

I've already outlined the performance characteristics in #45:

> for `k << n`, Fisher-Yates+Sort is indeed faster. However, for (roughly) `k > n/20`, my algorithm becomes better; in fact, for `k > n/10` it's faster than Fisher-Yates _before you even get to the sort_.
> 
> For example, if I want `9e7` samples out of `1e8`, Fisher-Yates+Sort takes 23 seconds versus 1.5 for my code - a _15 times_ improvement. And this isn't just limited to large values of `n`; sampling 50 values out of 100 is 2.5 times faster with my code, and remains faster as low as `k = 3` (albeit not by much).

Please try `@time StatsBase.sample(1:10^8, 9*10^7, replace=false, ordered = true)` with and without the change if you're not convinced.

(Also, [here's](https://github.com/JuliaStats/StatsBase.jl/pull/54/files?w=1) a more helpful diff).
