### PR TITLE
fix bug in self-avoiding sampling

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -50,7 +50,7 @@ fisher_yates_sample!(a::AbstractArray, x::AbstractArray) = rand!(FisherYatesSamp
 function self_avoid_sample!{T}(a::AbstractArray{T}, x::AbstractArray)
     # This algorithm is suitable when length(x) << length(a)
 
-    s = Set{T}()
+    s = Set{Int}()
     # sizehint(s, length(x))
     rgen = RandIntSampler(length(a))
 


### PR DESCRIPTION
Tiny bug fix

```
>a = rep("blabla", 1000)
>sample(a,7; replace=false)

no method convert(Type{ASCIIString}, Int64)
while loading In[111], in expression starting on line 2
 in setindex! at dict.jl:517
 in self_avoid_sample! at /home/nikos/.julia/StatsBase/src/sampling.jl:60
 in sample! at /home/nikos/.julia/StatsBase/src/sampling.jl:141
 in sample at /home/nikos/.julia/StatsBase/src/sampling.jl:152
```
