### PR TITLE
Add code coverage tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ before_install:
 script:
   - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("StatsBase"))`); Pkg.pin("StatsBase"); Pkg.resolve()'
   - julia ./runtests.jl
+after_success:
+  - julia -e 'cd(Pkg.dir("StatsBase")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
Obviously will need someone with JuliaStats-permissions to enable on Coveralls.io (and subsequently add to the README), but I thought I'd drop this here in the meantime as a reminder.

https://github.com/IainNZ/Coverage.jl
