### PR TITLE
Default levels for counts and proportions

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -51,11 +51,15 @@ counts(x::IntegerArray, levels::IntRange1) = addcounts!(zeros(Int, length(levels
 counts(x::IntegerArray, levels::IntRange1, wv::WeightVec) = addcounts!(zeros(eltype(wv), length(levels)), x, levels, wv)
 counts(x::IntegerArray, k::Integer) = counts(x, 1:k)
 counts(x::IntegerArray, k::Integer, wv::WeightVec) = counts(x, 1:k, wv)
+counts(x::IntegerArray) = counts(x, minimum(x):maximum(x))
+counts(x::IntegerArray, wv::WeightVec) = counts(x, minimum(x):maximum(x), wv)
 
 proportions(x::IntegerArray, levels::IntRange1) = counts(x, levels) .* inv(length(x))
 proportions(x::IntegerArray, levels::IntRange1, wv::WeightVec) = counts(x, levels, wv) .* inv(sum(wv))
 proportions(x::IntegerArray, k::Integer) = proportions(x, 1:k)
 proportions(x::IntegerArray, k::Integer, wv::WeightVec) = proportions(x, 1:k, wv)
+proportions(x::IntegerArray) = proportions(x, minimum(x):maximum(x))
+proportions(x::IntegerArray, wv::WeightVec) = proportions(x, minimum(x):maximum(x), wv)
 
 #### functions for counting a single list of integers (2D)
 
@@ -137,6 +141,8 @@ counts(x::IntegerArray, y::IntegerArray, ks::(Integer, Integer)) = counts(x, y, 
 counts(x::IntegerArray, y::IntegerArray, ks::(Integer, Integer), wv::WeightVec) = counts(x, y, (1:ks[1], 1:ks[2]), wv)
 counts(x::IntegerArray, y::IntegerArray, k::Integer) = counts(x, y, (1:k, 1:k))
 counts(x::IntegerArray, y::IntegerArray, k::Integer, wv::WeightVec) = counts(x, y, (1:k, 1:k), wv)
+counts(x::IntegerArray, y::IntegerArray) = counts(x, y, (minimum(x):maximum(x), minimum(y):maximum(y)))
+counts(x::IntegerArray, y::IntegerArray, wv::WeightVec) = counts(x, y, (minimum(x):maximum(x),minimum(y):maximum(y)), wv)
 
 proportions(x::IntegerArray, y::IntegerArray, levels::(IntRange1, IntRange1)) = counts(x, y, levels) .* inv(length(x))
 proportions(x::IntegerArray, y::IntegerArray, levels::(IntRange1, IntRange1), wv::WeightVec) = counts(x, y, levels, wv) .* inv(sum(wv))
@@ -145,6 +151,8 @@ proportions(x::IntegerArray, y::IntegerArray, ks::(Integer, Integer)) = proporti
 proportions(x::IntegerArray, y::IntegerArray, ks::(Integer, Integer), wv::WeightVec) = proportions(x, y, (1:ks[1], 1:ks[2]), wv)
 proportions(x::IntegerArray, y::IntegerArray, k::Integer) = proportions(x, y, (1:k, 1:k))
 proportions(x::IntegerArray, y::IntegerArray, k::Integer, wv::WeightVec) = proportions(x, y, (1:k, 1:k), wv)
+proportions(x::IntegerArray, y::IntegerArray) = proportions(x, y, (minimum(x):maximum(x), minimum(y):maximum(y)))
+proportions(x::IntegerArray, y::IntegerArray, wv::WeightVec) = proportions(x, y, (minimum(x):maximum(x),minimum(y):maximum(y)), wv)
 
 
 #################################################

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -17,6 +17,13 @@ c0 = Int[countnz(x .== i) for i in 1 : 5]
 @test counts(x .+ 1, 2:6) == c0
 @test_approx_eq proportions(x, 1:5) (c0 ./ n)
 
+c = counts(x)
+@test size(c) == (5,)
+c0 = Int[countnz(x .== i) for i in 1 : 5]
+@test c == c0
+@test counts(x .+ 1, 2:6) == c0
+@test_approx_eq proportions(x) (c0 ./ n)
+
 c = counts(x, 5, w)
 @test size(c) == (5,)
 c0 = Float64[sum(w.values[x .== i]) for i in 1 : 5]
@@ -24,6 +31,12 @@ c0 = Float64[sum(w.values[x .== i]) for i in 1 : 5]
 @test_approx_eq counts(x .+ 1, 2:6, w) c0
 @test_approx_eq proportions(x, 1:5, w) (c0 ./ sum(w))
 
+c = counts(x, w)
+@test size(c) == (5,)
+c0 = Float64[sum(w.values[x .== i]) for i in 1 : 5]
+@test_approx_eq c c0
+@test_approx_eq counts(x .+ 1, 2:6, w) c0
+@test_approx_eq proportions(x, w) (c0 ./ sum(w))
 
 # 2D integer counts
 
@@ -38,12 +51,26 @@ c0 = Int[countnz((x .== i) & (y .== j)) for i in 1 : 4, j in 1 : 5]
 @test counts(x .+ 2, y .+ 3, (3:6, 4:8)) == c0
 @test_approx_eq proportions(x, y, (1:4, 1:5)) (c0 ./ n)
 
+c = counts(x, y)
+@test size(c) == (4, 5)
+c0 = Int[countnz((x .== i) & (y .== j)) for i in 1 : 4, j in 1 : 5]
+@test c == c0
+@test counts(x .+ 2, y .+ 3, (3:6, 4:8)) == c0
+@test_approx_eq proportions(x, y,) (c0 ./ n)
+
 c = counts(x, y, (4, 5), w)
 @test size(c) == (4, 5)
 c0 = Float64[sum(w.values[(x .== i) & (y .== j)]) for i in 1 : 4, j in 1 : 5]
 @test_approx_eq c c0
 @test_approx_eq counts(x .+ 2, y .+ 3, (3:6, 4:8), w) c0
 @test_approx_eq proportions(x, y, (1:4, 1:5), w) (c0 ./ sum(w))
+
+c = counts(x, y, w)
+@test size(c) == (4, 5)
+c0 = Float64[sum(w.values[(x .== i) & (y .== j)]) for i in 1 : 4, j in 1 : 5]
+@test_approx_eq c c0
+@test_approx_eq counts(x .+ 2, y .+ 3, (3:6, 4:8), w) c0
+@test_approx_eq proportions(x, y, w) (c0 ./ sum(w))
 
 
 # count map


### PR DESCRIPTION
I found it a bit cumbersome to always have to pass in the levels. This makes default levels be ``minimum(x):maximum(x)`` and ``(minimum(x):maximum(x), minimum(y):maximum(y))`` for 1D and 2D respectively. 
