### PR TITLE
Move weights argument before mean in stdm(), varm() and moment()

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,2 +1,14 @@
 import Base.@deprecate
 import Base.depwarn
+
+import Base.varm, Base.stdm
+@deprecate varm(v::RealArray, m::Real, wv::WeightVec) varm(v, wv, m)
+@deprecate varm(A::RealArray, M::RealArray, wv::WeightVec, dim::Int) varm(v, wv, m, dim)
+@deprecate stdm(v::RealArray, m::Real, wv::WeightVec) stdm(v, wv, m)
+@deprecate stdm(v::RealArray, m::RealArray, wv::WeightVec, dim::Int) stdm(v, wv, m, dim)
+
+@deprecate _moment2(v::RealArray, m::Real, wv::WeightVec) _moment2(v, wv, m)
+@deprecate _moment3(v::RealArray, m::Real, wv::WeightVec) _moment3(v, wv, m)
+@deprecate _moment4(v::RealArray, m::Real, wv::WeightVec) _moment4(v, wv, m)
+@deprecate _momentk(v::RealArray, k::Int, m::Real, wv::WeightVec) _momentk(v, k, wv, m)
+@deprecate moment(v::RealArray, k::Int, m::Real, wv::WeightVec) moment(v, k, wv, m)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -157,7 +157,7 @@ end
 end
 
 @ngenerate N typeof(R) function _wsum_centralize!{T,RT,WT,N}(R::AbstractArray{RT}, f::Func{1},
-                                                             A::AbstractArray{T,N}, means, w::AbstractVector{WT}, 
+                                                             A::AbstractArray{T,N}, w::AbstractVector{WT}, means,
                                                              dim::Int, init::Bool)
     init && fill!(R, zero(RT))
     wi = zero(WT)


### PR DESCRIPTION
This is consistent with mean(), skewness() and kurtosis().

I was struck by this inconsistency while reviewing these lines: https://github.com/JuliaStats/StatsBase.jl/pull/117/files#diff-87bbeceb1714b7f9134da828801ba6d9R440

I realize I could as well have chosen to follow the convention of `stdm`, `varm` and `moment` of putting means before, but it sounded more logical to me to put the weight before, as they are more common (means are only accepted by some functions, and likely used less often). Any thoughts?