### PR TITLE
add df_residuals

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -155,7 +155,7 @@ module StatsBase
     coeftable,
     confint,
     deviance,
-    df_residuals,
+    df_residual,
     fit,
     fit!,
     fitted,

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -155,6 +155,7 @@ module StatsBase
     coeftable,
     confint,
     deviance,
+    df_residuals,
     fit,
     fit!,
     fitted,

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -20,7 +20,7 @@ model_response(obj::RegressionModel) = error("model_response is not defined for 
 residuals(obj::RegressionModel) = error("residuals is not defined for $(typeof(obj)).")
 predict(obj::RegressionModel) = error("predict is not defined for $(typeof(obj)).")
 predict!(obj::RegressionModel) = error("predict! is not defined for $(typeof(obj)).")
-
+df_residuals(obj::RegressionModel) = error("df_residuals is not defined for $(typeof(obj)).")
 ## coefficient tables with specialized show method
 
 ## Nms are the coefficient names, corresponding to rows in the table

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -20,7 +20,7 @@ model_response(obj::RegressionModel) = error("model_response is not defined for 
 residuals(obj::RegressionModel) = error("residuals is not defined for $(typeof(obj)).")
 predict(obj::RegressionModel) = error("predict is not defined for $(typeof(obj)).")
 predict!(obj::RegressionModel) = error("predict! is not defined for $(typeof(obj)).")
-df_residuals(obj::RegressionModel) = error("df_residuals is not defined for $(typeof(obj)).")
+df_residual(obj::RegressionModel) = error("df_residual is not defined for $(typeof(obj)).")
 ## coefficient tables with specialized show method
 
 ## Nms are the coefficient names, corresponding to rows in the table


### PR DESCRIPTION
`df_residual` is defined in GLM. I think it should be defined in StatsBase for every `RegressionModel`:
- The only way (I think) to add a `df_residual` method in another package without overwriting it is to import GLM.
- GLM defines a `coeftable` function for `LinearModel`
https://github.com/JuliaStats/GLM.jl/blob/831f5a5ea3613e342e5a63cd4051e1a437b7df2e/src/lm.jl#L68
which only requires `coef`, `nobs`, `stderr` and  `df_residuals`, If `df_residuals` was defined for every RegressionModel, the `coeftable` function would work on every `RegressionModel` (and could even be moved to `StatsBase`). The bottom line is that `df_residuals` is needed to do any kind of test so it would be nice to add it generically.

I've just changed the GLM name `df_residual` to `df_residuals` since it seems more consistent with the `s` of `residuals`.