### PR TITLE
Handle NaN in formatting of p-values

### DIFF
--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -40,6 +40,9 @@ end
 
 ## format numbers in the p-value column
 function format_pvc(pv::Number)
+    if isnan(pv)
+        return @sprintf("%d", pv)
+    end
     0. <= pv <= 1. || error("p-values must be in [0.,1.]")
     if pv >= 1e-4
         return @sprintf("%.4f", pv)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,8 @@ tests = ["weights",
          "signalcorr",
          "misc",
          "sampling",
-         "wsampling"]
+         "wsampling",
+         "statmodels"]
 
 println("Running tests:")
 

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -1,0 +1,10 @@
+using StatsBase
+using Base.Test
+
+## format_pvc: Formatting of p-values
+@test StatsBase.format_pvc(1.0) == "1.0000"
+@test StatsBase.format_pvc(1e-1) == "0.1000"
+@test StatsBase.format_pvc(1e-5) == "<1e-4"
+@test StatsBase.format_pvc(NaN) == "NaN"
+@test_throws ErrorException StatsBase.format_pvc(-0.1)
+@test_throws ErrorException StatsBase.format_pvc(1.1)


### PR DESCRIPTION
Displays the value instead of throwing an error expception if p-value is a NaN. A NaN is a valid value that can occur e.g. due to estimate and standard error both being 0.

Here a short example (please note that different platforms give me different results here, the results here were produced with julia 3.11 from juliabox):

```julia
using GLM
using DataFrames

df = DataFrame(x = [1, 2, 3], y = [2, 4, 6])

ls = lm(y ~ x, df); ## perfect fit, with slope 2 and intercept 0
coeftable(ls)
```

The p-value for the estimated intercept will be `NaN`. Before, displaying the coefficient table used to fail, since the value was outside the allowed range `[0, 1]`.