### PR TITLE
Bump version requirement to 0.4 and remove evaluate function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 ArrayViews 0.4.12
 Compat 0.4.0
 StatsFuns 0.1.0

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+__precompile__(true)
 
 module StatsBase
     using Compat
@@ -9,19 +9,9 @@ module StatsBase
     import Base: rand, rand!
     import Base: Func, IdFun, Abs2Fun
     import Base.LinAlg: BlasReal, BlasFloat
-    if VERSION < v"0.4.0-dev+3184"
-        import Base.Cartesian: @ngenerate
-    end
     import Base.Cartesian: @nloops, @nref, @nextract
 
     ## tackle compatibility issues
-
-    if VERSION < v"0.4.0-dev+1258"
-        import Base: evaluate
-    else
-        evaluate(f::Func{1}, x) = call(f, x)
-        evaluate(f::Func{2}, x, y) = call(f, x, y)
-    end
 
     ## import mathfuns, which were migrated to StatsFuns
     import StatsFuns: xlogx, xlogy, logistic, logit,

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -141,7 +141,7 @@ end
         @nloops N i d->(d>1? (1:size(A,d)) : (1:1)) d->(j_d = sizeR_d==1 ? 1 : i_d) begin
             @inbounds r = (@nref N R j)
             for i_1 = 1:sizA1
-                @inbounds r += evaluate(f, (@nref N A i)) * w[i_1]
+                @inbounds r += f(@nref N A i) * w[i_1]
             end
             @inbounds (@nref N R j) = r
         end 
@@ -151,7 +151,7 @@ end
                                j_d = 1
                            else
                                j_d = i_d
-                           end) @inbounds (@nref N R j) += evaluate(f, (@nref N A i)) * wi
+                           end) @inbounds (@nref N R j) += f(@nref N A i) * wi
     end
     return R
 end
@@ -168,7 +168,7 @@ end
             @inbounds r = (@nref N R j)
             @inbounds m = (@nref N means j)
             for i_1 = 1:sizA1
-                @inbounds r += evaluate(f, (@nref N A i) - m) * w[i_1]
+                @inbounds r += f((@nref N A i) - m) * w[i_1]
             end
             @inbounds (@nref N R j) = r
         end 
@@ -178,7 +178,7 @@ end
                                j_d = 1
                            else
                                j_d = i_d
-                           end) @inbounds (@nref N R j) += evaluate(f, (@nref N A i) - (@nref N means j)) * wi
+                           end) @inbounds (@nref N R j) += f((@nref N A i) - (@nref N means j)) * wi
     end
     return R
 end


### PR DESCRIPTION
This eliminates a ton of deprecation warnings for call on 0.5.

cc: @nalimilan Maybe these caused the failures you saw in #146