### PR TITLE
Make `rle` avoid exception on empty vector

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -17,6 +17,8 @@ function rle{T}(v::Vector{T})
     vals = T[]
     lens = Int[]
 
+    n>0 || return (vals,lens)
+    
     cv = v[1]
     cl = 1
 


### PR DESCRIPTION
Make `rle` return an empty vector pair when given an empty vector.
`inverse_rle` already works correctly (note length vector needs to be of an Integer eltype).