### PR TITLE
Support Integer Printing in CoefTable

### DIFF
--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -164,10 +164,10 @@ type CoefTable
     rownms::Vector
     pvalcol::Integer
     integercols::Vector{Int}
-    function CoefTable(mat::Matrix,colnms::Vector,rownms::Vector,pvalcol::Int=0,integercols::Vector{Int}=[0;])
+    function CoefTable(mat::Matrix,colnms::Vector,rownms::Vector,pvalcol::Int=0,integercols::Vector{Int}=Int[])
         nr,nc = size(mat)
         0 <= pvalcol <= nc || error("pvalcol = $pvalcol should be in [0,...,$nc]")
-        all(0 .<= integercols .<= nc) || error("integercols = $integercols should be a vector with elements in [0,...,$nc]")
+        all(0 .<= integercols .<= nc) || error("integercols = $integercols should be a vector with elements in [1,...,$nc]")
         length(colnms) in [0,nc] || error("colnms should have length 0 or $nc")
         length(rownms) in [0,nr] || error("rownms should have length 0 or $nr")
         new(mat,colnms,rownms,pvalcol,integercols)
@@ -202,10 +202,8 @@ function show(io::IO, ct::CoefTable)
         end
     end
     for ic in ct.integercols
-        if ic != 0
-            for i in 1:nr
-                str[i,ic] = @sprintf("%u",mat[i,ic])
-            end
+        for i in 1:nr
+            str[i,ic] = sprint(showcompact,Int(mat[i,ic]))
         end
     end
     for j in 1:nc

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -170,7 +170,7 @@ type CoefTable
         all(0 .<= integercols .<= nc) || error("integercols = $integercols should be a vector with elements in [0,...,$nc]")
         length(colnms) in [0,nc] || error("colnms should have length 0 or $nc")
         length(rownms) in [0,nr] || error("rownms should have length 0 or $nr")
-        new(mat,colnms,rownms,pvalcol, integercols)
+        new(mat,colnms,rownms,pvalcol,integercols)
     end
 end
 
@@ -204,7 +204,7 @@ function show(io::IO, ct::CoefTable)
     for ic in ct.integercols
         if ic != 0
             for i in 1:nr
-                str[i, ic] = @sprintf("%u", mat[i, ic])
+                str[i,ic] = @sprintf("%u",mat[i,ic])
             end
         end
     end

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -163,12 +163,14 @@ type CoefTable
     colnms::Vector
     rownms::Vector
     pvalcol::Integer
-    function CoefTable(mat::Matrix,colnms::Vector,rownms::Vector,pvalcol::Int=0)
+    integercols::Vector{Int}
+    function CoefTable(mat::Matrix,colnms::Vector,rownms::Vector,pvalcol::Int=0,integercols::Vector{Int}=[0;])
         nr,nc = size(mat)
-        0 <= pvalcol <= nc || error("pvalcol = $pvalcol should be in 0,...,$nc]")
+        0 <= pvalcol <= nc || error("pvalcol = $pvalcol should be in [0,...,$nc]")
+        all(0 .<= integercols .<= nc) || error("integercols = $integercols should be a vector with elements in [0,...,$nc]")
         length(colnms) in [0,nc] || error("colnms should have length 0 or $nc")
         length(rownms) in [0,nr] || error("rownms should have length 0 or $nr")
-        new(mat,colnms,rownms,pvalcol)
+        new(mat,colnms,rownms,pvalcol, integercols)
     end
 end
 
@@ -197,6 +199,13 @@ function show(io::IO, ct::CoefTable)
     if pvc != 0                         # format the p-values column
         for i in 1:nr
             str[i,pvc] = format_pvc(mat[i,pvc])
+        end
+    end
+    for ic in ct.integercols
+        if ic != 0
+            for i in 1:nr
+                str[i, ic] = @sprintf("%u", mat[i, ic])
+            end
         end
     end
     for j in 1:nc

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -167,7 +167,7 @@ type CoefTable
     function CoefTable(mat::Matrix,colnms::Vector,rownms::Vector,pvalcol::Int=0,integercols::Vector{Int}=Int[])
         nr,nc = size(mat)
         0 <= pvalcol <= nc || error("pvalcol = $pvalcol should be in [0,...,$nc]")
-        all(0 .<= integercols .<= nc) || error("integercols = $integercols should be a vector with elements in [1,...,$nc]")
+        all(1 .<= integercols .<= nc) || error("integercols = $integercols should be a vector with elements in [1,...,$nc]")
         length(colnms) in [0,nc] || error("colnms should have length 0 or $nc")
         length(rownms) in [0,nr] || error("rownms should have length 0 or $nr")
         new(mat,colnms,rownms,pvalcol,integercols)


### PR DESCRIPTION
Currently the `CoefTable` does not support integer and print everything as float number. So it will print the degree of freedom of a parameter as "3.00", which can be confusing. 

The easiest way to fix this is adding a new field 

``` julia
integercols::Vector{Int}
```

Then 

``` julia
 CoefTable(rand(3,4), ["Estimate", "Stderr", "df", "p"], ["b1", "b2", "b3"], 4, [3;])
```

will print 

```
      Estimate   Stderr df      p
b1     0.51669 0.813798  1 0.8844
b2   0.0686266 0.378539  1 0.2470
b3    0.381557 0.600014  1 0.2409
```
