### PR TITLE
Allow one to call `histrange` with just the endpoints & nbins

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -11,8 +11,12 @@ function histrange{T}(v::AbstractArray{T}, n::Integer, closed::Symbol=:right)
     elseif nv == 0
         return zero(F):zero(F)
     end
-    
+
     lo, hi = extrema(v)
+    histrange(F(lo), F(hi), n, closed)
+end
+
+function histrange{F}(lo::F, hi::F, n::Integer, closed::Symbol=:right)
     if hi == lo
         start = F(hi)
         step = one(F)

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -30,11 +30,14 @@ using Base.Test
 @test StatsBase.histrange(Float64[], 0, :left) == 0.0:1.0:0.0
 @test StatsBase.histrange(Float64[1:5;], 1, :left) == 0.0:5.0:10.0
 @test StatsBase.histrange(Float64[1:10;], 1, :left) == 0.0:10.0:20.0
+@test StatsBase.histrange(1.0, 10.0, 1, :left) == 0.0:10.0:20.0
 
 @test StatsBase.histrange([0.201,0.299], 10, :left) == 0.2:0.01:0.3
 @test StatsBase.histrange([0.2,0.299], 10, :left) == 0.2:0.01:0.3
-@test StatsBase.histrange([0.2,0.3], 10, :left) == 0.2:0.01:0.31
+@test StatsBase.histrange([0.2,0.3], 10, :left)  == 0.2:0.01:0.31
+@test StatsBase.histrange(0.2, 0.3,  10, :left)  == 0.2:0.01:0.31
 @test StatsBase.histrange([0.2,0.3], 10, :right) == 0.19:0.01:0.3
+@test StatsBase.histrange(0.2, 0.3,  10, :right) == 0.19:0.01:0.3
 
 @test StatsBase.histrange([200.1,299.9], 10, :left) == 200.0:10.0:300.0
 @test StatsBase.histrange([200.0,299.9], 10, :left) == 200.0:10.0:300.0


### PR DESCRIPTION
This makes `histrange` more modular, allowing one to use just the endpoints rather than needing the whole vector.