### PR TITLE
Minor type change in entropy function

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -280,7 +280,7 @@ zscore{T<:Real}(X::AbstractArray{T}, dim::Int) = ((μ, σ) = mean_and_std(X, dim
 #############################
 
 function entropy{T<:Real}(p::AbstractArray{T})
-    s = 0.
+    s = zero(T)
     z = zero(T)
     for i = 1:length(p)
         @inbounds pi = p[i]


### PR DESCRIPTION
Changed s = 0. to s = zero(T) to resolve type instability while working on Distributions package