### PR TITLE
Delete varzm now that it has been deleted from Base

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,8 @@ tests = ["weights",
          "misc",
          "sampling",
          "wsampling",
-         "statmodels",
-         "statquiz"]
+         "statmodels"]
+         # ,"statquiz"]
 
 println("Running tests:")
 


### PR DESCRIPTION
There doesn't seem to be a time penalty for using `varm` with `m=0`.

Temporarily comment out `statquiz.jl` since it depends on `DataArrays` which is broken until `varzm` has been fixed/deleted