### PR TITLE
Revert "Temporarily comment out statquiz.jl since it depends on DataArrays"

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,8 @@ tests = ["weights",
          "misc",
          "sampling",
          "wsampling",
-         "statmodels"]
-         # ,"statquiz"]
+         "statmodels",
+         "statquiz"]
 
 println("Running tests:")
 


### PR DESCRIPTION
This reverts commit c56727c57df2b00a09a3ed6eccc116ebbad351ef.

Now that `DataArrays.jl` has been tagged a version that works with master, these tests can be reenabled.