### PR TITLE
Implement v0.5 sub->view change

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -3,6 +3,7 @@ __precompile__(true)
 module StatsBase
     using Compat
     import Compat.String
+    import Compat.view
     using ArrayViews
     using StatsFuns
 
@@ -18,10 +19,12 @@ module StatsBase
                       softplus, invsoftplus,
                       logsumexp, softmax, softmax!
 
-    export
+    if VERSION < v"0.5.0-dev"
+        # reexport from ArrayViews
+        export view
+    end
 
-    # reexport from ArrayViews
-    view,
+    export
 
     ## mathfuns (TODO: removed after a certain period)
     xlogx,       # x * log(x)

--- a/src/rankcorr.jl
+++ b/src/rankcorr.jl
@@ -126,8 +126,8 @@ function swaps!(x::RealVector)
     n = length(x)
     if n == 1 return 0 end
     n2 = div(n, 2)
-    xl = sub(x, 1:n2)
-    xr = sub(x, n2+1:n)
+    xl = Compat.view(x, 1:n2)
+    xr = Compat.view(x, n2+1:n)
     nsl = swaps!(xl)
     nsr = swaps!(xr)
     sort!(xl)
@@ -150,4 +150,3 @@ function mswaps(x::RealVector, y::RealVector)
     end
     return nSwaps
 end
-

--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -457,8 +457,8 @@ function pacf_regress!{T<:RealFP}(r::RealMatrix, X::AbstractMatrix{T}, lags::Int
         end
         for i = 1 : length(lags)
             l = lags[i]
-            sX = sub(tmpX, 1+l:lx, 1:l+1)
-            r[i,j] = (cholfact!(sX'sX)\(sX'sub(X, 1+l:lx, j)))[end]
+            sX = Compat.view(tmpX, 1+l:lx, 1:l+1)
+            r[i,j] = (cholfact!(sX'sX)\(sX'Compat.view(X, 1+l:lx, j)))[end]
         end
     end
     r
@@ -470,7 +470,7 @@ function pacf_yulewalker!{T<:RealFP}(r::RealMatrix, X::Matrix{T}, lags::IntegerV
         acfs = autocor(X[:,j], 1:mk)
         for i = 1 : length(lags)
             l = lags[i]
-            r[i,j] = l == 0 ? one(T) : l == 1 ? acfs[i] : -durbin!(sub(acfs, 1:l), tmp)[l]
+            r[i,j] = l == 0 ? one(T) : l == 1 ? acfs[i] : -durbin!(Compat.view(acfs, 1:l), tmp)[l]
         end
     end
 end
@@ -519,4 +519,3 @@ end
 function pacf{T<:Real}(x::Vector{T}, lags::IntegerVector; method::Symbol=:regression)
     vec(pacf(reshape(x, length(x), 1), lags, method=method))
 end
-

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -106,11 +106,11 @@ function _wsumN!{T<:BlasReal,N}(R::ContiguousArray{T}, A::ContiguousArray{T,N}, 
     if dim == 1
         m = size(A, 1)
         n = div(length(A), m)
-        _wsum2_blas!(view(R,:), reshape_view(A, (m, n)), w, 1, init)
+        _wsum2_blas!(ArrayViews.view(R,:), reshape_view(A, (m, n)), w, 1, init)
     elseif dim == N
         n = size(A, N)
         m = div(length(A), n)
-        _wsum2_blas!(view(R,:), reshape_view(A, (m, n)), w, 2, init)
+        _wsum2_blas!(ArrayViews.view(R,:), reshape_view(A, (m, n)), w, 2, init)
     else # 1 < dim < N
         m = 1
         for i = 1:dim-1; m *= size(A, i); end
@@ -120,7 +120,7 @@ function _wsumN!{T<:BlasReal,N}(R::ContiguousArray{T}, A::ContiguousArray{T,N}, 
         Av = reshape_view(A, (m, n, k))
         Rv = reshape_view(R, (m, k))
         for i = 1:k
-            _wsum2_blas!(view(Rv,:,i), view(Av,:,:,i), w, 2, init)
+            _wsum2_blas!(ArrayViews.view(Rv,:,i), ArrayViews.view(Av,:,:,i), w, 2, init)
         end
     end
     return R
@@ -138,7 +138,7 @@ function _wsumN!{T<:BlasReal,N}(R::ContiguousArray{T}, A::DenseArray{T,N}, w::St
         rlen = ifelse(dim == 1, n, m)
         Rv = reshape_view(R, (rlen, npages))
         for i = 1:npages
-            _wsum2_blas!(view(Rv,:,i), view(A,:,:,i), w, dim, init)
+            _wsum2_blas!(ArrayViews.view(Rv,:,i), ArrayViews.view(A,:,:,i), w, dim, init)
         end
     else
         _wsum_general!(R, @functorize(identity), A, w, dim, init)
@@ -206,7 +206,7 @@ _wsum!{T<:BlasReal}(R::ContiguousArray{T}, A::DenseArray{T,1}, w::StridedVector{
 
 # N = 2
 _wsum!{T<:BlasReal}(R::ContiguousArray{T}, A::DenseArray{T,2}, w::StridedVector{T}, dim::Int, init::Bool) =
-    (_wsum2_blas!(view(R,:), A, w, dim, init); R)
+    (_wsum2_blas!(ArrayViews.view(R,:), A, w, dim, init); R)
 
 # N >= 3
 _wsum!{T<:BlasReal,N}(R::ContiguousArray{T}, A::DenseArray{T,N}, w::StridedVector{T}, dim::Int, init::Bool) =

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -40,7 +40,7 @@ function check_sample_wrep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=fal
             @test_approx_eq_eps proportions(a, vmin:vmax) p0 ptol
         else
             for j = 1:ncols
-                aj = view(a, :, j)
+                aj = ArrayViews.view(a, :, j)
                 @test_approx_eq_eps proportions(aj, vmin:vmax) p0 ptol
             end
         end
@@ -96,7 +96,7 @@ function check_sample_norep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=fa
     n = vmax - vmin + 1
 
     for j = 1:size(a,2)
-        aj = view(a,:,j)
+        aj = ArrayViews.view(a,:,j)
         @assert norepeat(aj)
         if ordered
             @assert issorted(aj)
@@ -110,7 +110,7 @@ function check_sample_norep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=fa
         else
             b = transpose(a)
             for j = 1:size(b,2)
-                bj = view(b,:,j)
+                bj = ArrayViews.view(b,:,j)
                 @test_approx_eq_eps proportions(bj, vmin:vmax) p0 ptol
             end
         end
@@ -122,31 +122,31 @@ import StatsBase: seqsample_a!, seqsample_c!
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
-    knuths_sample!(3:12, view(a,:,j))
+    knuths_sample!(3:12, ArrayViews.view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
-    fisher_yates_sample!(3:12, view(a,:,j))
+    fisher_yates_sample!(3:12, ArrayViews.view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
-    self_avoid_sample!(3:12, view(a,:,j))
+    self_avoid_sample!(3:12, ArrayViews.view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
-    seqsample_a!(3:12, view(a,:,j))
+    seqsample_a!(3:12, ArrayViews.view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=true)
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
-    seqsample_c!(3:12, view(a,:,j))
+    seqsample_c!(3:12, ArrayViews.view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=true)
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -64,7 +64,7 @@ w3 = rand(4)
 @test_approx_eq wsum(x, w2, 2) sum(x .* w2', 2)
 @test_approx_eq wsum(x, w3, 3) sum(x .* reshape(w3, 1, 1, 4), 3)
 
-v = view(x, 2:4, :, :)
+v = ArrayViews.view(x, 2:4, :, :)
 
 @test_approx_eq wsum(v, w1[1:3], 1) sum(v .* w1[1:3], 1)
 @test_approx_eq wsum(v, w2, 2) sum(v .* w2', 2)

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -25,7 +25,7 @@ function check_wsample_wrep(a::AbstractArray, vrgn, wv::WeightVec, ptol::Real; o
             @test_approx_eq_eps proportions(a, vmin:vmax) p0 ptol
         else
             for j = 1:ncols
-                aj = view(a, :, j)
+                aj = ArrayViews.view(a, :, j)
                 @test_approx_eq_eps proportions(aj, vmin:vmax) p0 ptol
             end
         end
@@ -64,7 +64,7 @@ function check_wsample_norep(a::AbstractArray, vrgn, wv::WeightVec, ptol::Real; 
     n = vmax - vmin + 1
 
     for j = 1:size(a,2)
-        aj = view(a,:,j)
+        aj = ArrayViews.view(a,:,j)
         @assert norepeat(aj)
         if ordered
             @assert issorted(aj)
@@ -84,6 +84,6 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 
 a = zeros(Int, 3, n)
 for j = 1:n
-    naive_wsample_norep!(4:7, wv, view(a,:,j))
+    naive_wsample_norep!(4:7, wv, ArrayViews.view(a,:,j))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)


### PR DESCRIPTION
Recent julia-v0.5 implements `view()` which replaces both `sub()` and `slice()` as far as I understand. 

This PR refactors `sub` to `Compat.view` and `view` to `ArrayViews.view`.  
