### PR TITLE
Use StatsFuns rather than libRmath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ julia:
   - nightly
 notifications:
   email: false
-before_install:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd())'
-  - julia --check-bounds=yes -e 'Pkg.test("StatsBase"; coverage=true)'
+# Work around a Travis bug
+git:
+  depth: 999999
+# Uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Primes"); Pkg.test("Primes"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("StatsBase")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
 Compat 0.8.4
-StatsFuns 0.1.0
+StatsFuns 0.3.0

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -18,6 +18,8 @@ module StatsBase
                       softplus, invsoftplus,
                       logsumexp, softmax, softmax!
 
+    import StatsFuns: RFunctions.binomrand
+
     export
 
     ## mathfuns (TODO: removed after a certain period)

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -19,8 +19,3 @@ end
 
 randi(K::Int) = rand(RandIntSampler(K))
 randi(a::Int, b::Int) = rand(RandIntSampler(a, b))
-
-# draw a number from a binomial distribution
-
-rand_binom(n::Real, p::Real) =
-    @compat Int(ccall((:rbinom, "libRmath-julia"), Float64, (Float64, Float64), n, p))

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -57,7 +57,7 @@ function xmultinom_sample!(a::AbstractArray, x::AbstractArray)
             end
             offset = k
         else
-            m = rand_binom(rk, 1.0 / (n - i + 1))
+            m = binomrand(rk, 1.0 / (n - i + 1))
             if m > 0
                 @inbounds ai = a[i]
                 for j = 1:m
@@ -504,7 +504,7 @@ function xmultinom_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray)
             end
             offset = k
         else
-            m = rand_binom(rk, wi / wsum)
+            m = binomrand(rk, wi / wsum)
             for j = 1 : m
                 @inbounds x[offset + j] = a[i]
             end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -57,7 +57,7 @@ function xmultinom_sample!(a::AbstractArray, x::AbstractArray)
             end
             offset = k
         else
-            m = binomrand(rk, 1.0 / (n - i + 1))
+            m = Int(binomrand(rk, 1.0 / (n - i + 1)))
             if m > 0
                 @inbounds ai = a[i]
                 for j = 1:m
@@ -504,7 +504,7 @@ function xmultinom_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray)
             end
             offset = k
         else
-            m = binomrand(rk, wi / wsum)
+            m = Int(binomrand(rk, wi / wsum))
             for j = 1 : m
                 @inbounds x[offset + j] = a[i]
             end


### PR DESCRIPTION
This gets the binomial sampling (the only Rmath thing this package uses) from the most recent version of StatsFuns, which means that it doesn't require an extra dependency on Rmath.jl and should work on 0.5, where libRmath no longer exists.