### PR TITLE
Renyi entropy support

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -72,6 +72,7 @@ module StatsBase
     iqr,         # interquatile range
 
     entropy,        # the entropy of a probability vector
+    renyientropy,   # the Rényi (generalised) entropy of a probability vector
     crossentropy,   # cross entropy between two probability vectors
     kldivergence,   # K-L divergence between two probability vectors
 

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -390,6 +390,44 @@ function entropy{T<:Real}(p::AbstractArray{T}, b::Real)
     return entropy(p) / log(b)
 end
 
+"""
+    renyientropy(p, α)
+
+Compute the Rényi (generalised) entropy of order `α` of an array `p`.
+"""
+function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
+    α < 0 && throw(ArgumentError("Order of Rényi entropy not legal, $(α) < 0."))
+    
+    s = zero(T)
+    z = zero(T)
+    if α ≈ 0
+        for i = 1:length(p)
+            @inbounds pi = p[i]
+            if pi > z
+                s += 1
+            end
+        end
+        s = log(s)
+    elseif α ≈ 1
+        for i = 1:length(p)
+            @inbounds pi = p[i]
+            if pi > z
+                s -= pi * log(pi)
+            end
+        end
+    elseif (isinf(α))
+        s = -log(maximum(p))
+    else # a normal Rényi entropy
+        for i = 1:length(p)
+            @inbounds pi = p[i]
+            if pi > z
+                s += pi ^ α
+            end
+        end
+        s = log(s) / (1 - α)
+    end
+    return s
+end
 
 """
     crossentropy(p, q, [b])

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -400,6 +400,8 @@ function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
     
     s = zero(T)
     z = zero(T)
+    scale = sum(p)
+    
     if α ≈ 0
         for i = 1:length(p)
             @inbounds pi = p[i]
@@ -407,7 +409,7 @@ function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
                 s += 1
             end
         end
-        s = log(s)
+        s = log(s / scale)
     elseif α ≈ 1
         for i = 1:length(p)
             @inbounds pi = p[i]
@@ -415,6 +417,7 @@ function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
                 s -= pi * log(pi)
             end
         end
+        s = s / scale
     elseif (isinf(α))
         s = -log(maximum(p))
     else # a normal Rényi entropy
@@ -424,7 +427,7 @@ function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
                 s += pi ^ α
             end
         end
-        s = log(s) / (1 - α)
+        s = log(s / scale) / (1 - α)
     end
     return s
 end

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -393,7 +393,7 @@ end
 """
     renyientropy(p, α)
 
-Compute the Rényi (generalised) entropy of order `α` of an array `p`.
+Compute the Rényi (generalized) entropy of order `α` of an array `p`.
 """
 function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
     α < 0 && throw(ArgumentError("Order of Rényi entropy not legal, $(α) < 0."))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
+Distributions
 DataFrames
 GLM

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
-Distributions
 DataFrames
 GLM

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -125,6 +125,13 @@ order = rand() * 49 + 1 # And over 1
 udist = ones(nindiv) / nindiv
 @test_approx_eq renyientropy(udist, order) log(nindiv)
 
+# And test generalised probability distributions (sum(p) != 1)
+scale = rand()
+@test_approx_eq renyientropy(udist * scale, 0) renyientropy(udist, 0) - log(scale)
+@test_approx_eq renyientropy(udist * scale, 1) renyientropy(udist, 1) - log(scale)
+@test_approx_eq renyientropy(udist * scale, Inf) renyientropy(udist, Inf) - log(scale)
+@test_approx_eq renyientropy(udist * scale, order) renyientropy(udist, order) - log(scale)
+
 ##### Cross entropy
 @test_approx_eq crossentropy([0.2, 0.3, 0.5], [0.3, 0.4, 0.3]) 1.1176681825904018
 @test_approx_eq crossentropy([0.2, 0.3, 0.5], [0.3, 0.4, 0.3], 2) 1.6124543443825532

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -1,5 +1,6 @@
 using StatsBase
 using Base.Test
+using Distributions
 
 ##### Location
 
@@ -71,7 +72,7 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 
 ##### Dispersion
 
-@test span([3, 4, 5, 6, 2]) == (2:6)
+@test StatsBase.span([3, 4, 5, 6, 2]) == (2:6)
 
 @test_approx_eq variation([1:5;]) 0.527046276694730
 

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -95,7 +95,7 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 @test_approx_eq entropy([0.2, 0.3, 0.5], 2) 1.4854752972273344
 
 ##### Renyi entropies
-# Generate a random probability distribution of variable length
+# Generate a random probability distribution
 nindiv = 50
 dist = rand(nindiv)
 dist /= sum(dist)

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -95,6 +95,34 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 @test_approx_eq entropy([0.5, 0.5],2) 1.0
 @test_approx_eq entropy([0.2, 0.3, 0.5], 2) 1.4854752972273344
 
+##### Renyi entropies
+# Generate a random probability distribution of variable length
+nindiv = rand(DiscreteUniform(2, 100))
+dist = rand(Dirichlet(ones(nindiv)))
+
+# Check Shannon entropy against Renyi entropy of order 1
+@test_approx_eq entropy(dist) renyientropy(dist, 1)
+@test_approx_eq renyientropy(dist, 1) renyientropy(dist, 1.0)
+
+# Check Renyi entropy of order 0 is the natural log of the count of non-zeros
+@test_approx_eq renyientropy(dist, 0) log(mapreduce(x -> x > 0 ? 1 : 0, +, dist))
+
+# And is therefore not affected by the addition of non-zeros
+zdist = dist
+zdist = append!(dist, zeros(rand(DiscreteUniform(1, 100))))
+@test_approx_eq renyientropy(dist, 0) renyientropy(zdist, 0)
+
+# Indeed no Renyi entropy should be
+order = rand(Uniform(0, 100))
+@test_approx_eq renyientropy(dist, order) renyientropy(zdist, order)
+
+# Renyi entropy of order infinity is -log(maximum(dist))
+@test_approx_eq renyientropy(dist, Inf) -log(maximum(dist))
+
+# And all Renyi entropies of uniform probabilities should be log n, where n is the length
+udist = ones(nindiv) / nindiv
+@test_approx_eq renyientropy(udist, order) log(nindiv)
+
 ##### Cross entropy
 @test_approx_eq crossentropy([0.2, 0.3, 0.5], [0.3, 0.4, 0.3]) 1.1176681825904018
 @test_approx_eq crossentropy([0.2, 0.3, 0.5], [0.3, 0.4, 0.3], 2) 1.6124543443825532

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -1,6 +1,5 @@
 using StatsBase
 using Base.Test
-using Distributions
 
 ##### Location
 
@@ -97,8 +96,9 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 
 ##### Renyi entropies
 # Generate a random probability distribution of variable length
-nindiv = rand(DiscreteUniform(2, 100))
-dist = rand(Dirichlet(ones(nindiv)))
+nindiv = 50
+dist = rand(nindiv)
+dist /= sum(dist)
 
 # Check Shannon entropy against Renyi entropy of order 1
 @test_approx_eq entropy(dist) renyientropy(dist, 1)
@@ -109,11 +109,13 @@ dist = rand(Dirichlet(ones(nindiv)))
 
 # And is therefore not affected by the addition of non-zeros
 zdist = dist
-zdist = append!(dist, zeros(rand(DiscreteUniform(1, 100))))
+zdist = append!(dist, zeros(rand(50)))
 @test_approx_eq renyientropy(dist, 0) renyientropy(zdist, 0)
 
 # Indeed no Renyi entropy should be
-order = rand(Uniform(0, 100))
+loworder = rand() # Between 0 and 1
+@test_approx_eq renyientropy(dist, loworder) renyientropy(zdist, loworder)
+order = rand() * 49 + 1 # And over 1
 @test_approx_eq renyientropy(dist, order) renyientropy(zdist, order)
 
 # Renyi entropy of order infinity is -log(maximum(dist))

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -71,7 +71,7 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 
 ##### Dispersion
 
-@test StatsBase.span([3, 4, 5, 6, 2]) == (2:6)
+@test span([3, 4, 5, 6, 2]) == (2:6)
 
 @test_approx_eq variation([1:5;]) 0.527046276694730
 

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -94,9 +94,11 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 @test_approx_eq entropy([0.5, 0.5],2) 1.0
 @test_approx_eq entropy([0.2, 0.3, 0.5], 2) 1.4854752972273344
 
+##### Cross entropy
 @test_approx_eq crossentropy([0.2, 0.3, 0.5], [0.3, 0.4, 0.3]) 1.1176681825904018
 @test_approx_eq crossentropy([0.2, 0.3, 0.5], [0.3, 0.4, 0.3], 2) 1.6124543443825532
 
+##### KL divergence
 @test_approx_eq kldivergence([0.2, 0.3, 0.5], [0.3, 0.4, 0.3]) 0.08801516852582819
 @test_approx_eq kldivergence([0.2, 0.3, 0.5], [0.3, 0.4, 0.3], 2) 0.12697904715521868
 


### PR DESCRIPTION
I've added in support for Renyi entropies here to go with Renyi divergences / relative entropies which will go into StatsBase/Distances.jl. This follows up #131 and [StatsBase/Distances.jl:#45](https://github.com/JuliaStats/Distances.jl/issues/45).

The tests all work with v0.4, but Rmath problems in v0.5 stop them there.