### PR TITLE
Make the trimmean function consistent with R.

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -136,6 +136,13 @@ module StatsBase
     hist,
     # histrange,
     midpoints,
+    
+    ## robust
+    trim,           # trimmed set
+    trim!,          # trimmed set
+    winsor,         # Winsorized set
+    winsor!,        # Winsorized set
+    trimvar,        # variance of the mean of a trimmed set
 
     ## misc
     rle,            # run-length encoding
@@ -194,6 +201,7 @@ module StatsBase
     include("empirical.jl")
     include("hist.jl")
     include("misc.jl")
+    include("robust.jl")
 
     include("sampling.jl")
     include("statmodels.jl")

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -2,6 +2,8 @@ import Base.@deprecate
 import Base.depwarn
 
 import Base.varm, Base.stdm
+@deprecate trimmean(x::RealArray, p::Real)
+
 @deprecate varm(v::RealArray, m::Real, wv::WeightVec) varm(v, wv, m)
 @deprecate varm(A::RealArray, M::RealArray, wv::WeightVec, dim::Int) varm(v, wv, m, dim)
 @deprecate stdm(v::RealArray, m::Real, wv::WeightVec) stdm(v, wv, m)

--- a/src/robust.jl
+++ b/src/robust.jl
@@ -1,0 +1,98 @@
+# Robust Statistics
+
+#############################
+#
+#   Trimming outliers
+#
+#############################
+
+# Trimmed set
+"""
+    trim(x, p=0.2)
+
+Remove a proportion `p` of its highest elements, and `p` of its lowest elements and return the result. If you want to compute the variance of `mean(trim(x,p))`, use `trimvar`.
+
+# Example
+```julia
+julia> trim([1,2,3,4,5] , 0.2)
+ 2
+ 3
+ 4
+```
+"""
+trim(x,p::Real=0.2) = trim!(copy(x),p)
+trim!(x,p::Real=0.2) = trim!(collect(x), p)
+
+"""
+    trim!(x, p=0.2)
+
+A variant of `trim` that modifies vector `x` in place. See also `trimvar`.
+"""
+function trim!(x::RealArray, p::Real=0.2)
+    n = length(x)
+    n > 0 || error("x can not be empty.")
+    0 <= p < 0.5 || error("p must be in 0 <= p < 0.5.")
+    g = floor(Int, n * p)
+    
+    return select!(x, (g+1):(n-g))
+end
+
+"""
+    winsor(x, p=0.2)
+
+Replace  the proportion `p` of the lowest elements with the next-lowest element, and the proportion `p` of the highest elements with the next highest elements. This function is typically used to compute the variance of `mean(trim(x,p))`.
+
+# Example
+```julia
+julia> winsor([1,2,3,4,5] , 0.2)
+ 2
+ 2
+ 3
+ 4
+ 4
+```
+"""
+winsor(x,p::Real=0.2) = winsor!(copy(x),p)
+winsor!(x,p::Real=0.2) = winsor!(collect(x), p)
+
+"""
+    winsor!(x, p=0.2)
+
+A variant of `winsor` that modifies vector `x` in place.
+"""
+function winsor!(x::RealArray, p::Real=0.2)
+    n = length(x)
+    n > 0 || error("x can not be empty.")
+    0 <= p < 0.5 || error("p must be in 0 <= p < 0.5.")
+    g = floor(Int, n * p)
+    
+    select!(x, 1:g)
+    select!(x, (n-g+1):n)
+    x[1:g] = x[g+1]
+    x[n-g+1:end] = x[n-g]
+    
+    return x
+end
+
+
+#############################
+#
+#   Other
+#
+#############################
+
+# Variance of a trimmed set.
+"""
+    trimvar(x,p=0.2)
+
+Compute the variance of `mean(trim(x,p))` using the Winsorized variance, as described in Wilcox (2010).
+"""
+function trimvar(x::RealArray,p::Real=0.2)
+    n = length(x)
+    n > 0 || error("x can not be empty.")
+    0 <= p < 0.5 || error("p must be in 0 <= p < 0.5.")
+    
+    return var(winsor(x,p)) / (n * (1 - 2p)^2)
+end
+
+

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -42,22 +42,20 @@ end
     trimmean(x, p)
 
 Compute the trimmed mean of `x`, i.e. the mean after removing a
-proportion `p` of its highest- and lowest-valued elements.
+proportion `p` of both its highest- and lowest-valued elements.
 """
 function trimmean(x::RealArray, p::Real)
     n = length(x)
     n > 0 || error("x can not be empty.")
-    0 <= p < 1 || error("p must be non-negative and less than 1.")
-    rn = min(round(Int, n * p), n-1)
+    0 <= p < 0.5 || error("p must be non-negative and less than 0.5.")
+    g = floor(Int, n * p)
 
     sx = sort(x)
-    nl = rn >> 1
-    nh = (rn - nl)
     s = 0.0
-    for i = (1+nl) : (n-nh)
+    for i = (g+1) : (n-g)
         @inbounds s += sx[i]
     end
-    return s / (n - rn)
+    return s / (n - 2g)
 end
 
 # compute mode, given the range of integer values

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -42,20 +42,22 @@ end
     trimmean(x, p)
 
 Compute the trimmed mean of `x`, i.e. the mean after removing a
-proportion `p` of both its highest- and lowest-valued elements.
+proportion `p` of its highest- and lowest-valued elements.
 """
 function trimmean(x::RealArray, p::Real)
     n = length(x)
     n > 0 || error("x can not be empty.")
-    0 <= p < 0.5 || error("p must be non-negative and less than 0.5.")
-    g = floor(Int, n * p)
+    0 <= p < 1 || error("p must be non-negative and less than 1.")
+    rn = min(round(Int, n * p), n-1)
 
     sx = sort(x)
+    nl = rn >> 1
+    nh = (rn - nl)
     s = 0.0
-    for i = (g+1) : (n-g)
+    for i = (1+nl) : (n-nh)
         @inbounds s += sx[i]
     end
-    return s / (n - 2g)
+    return s / (n - rn)
 end
 
 # compute mode, given the range of integer values


### PR DESCRIPTION
The trimmed mean should remove an equal number of elements from the high- and low-value ends.