### PR TITLE
Updated CI to use 0.5 as a release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 *StatsBase.jl* is a Julia package that provides basic support for statistics. Particularly, it implements a variety of statistics-related functions, such as scalar statistics, high-order moment computation, counting, ranking, covariances, sampling, and empirical density estimation.
 
 - **Current Release**: 
-  [![StatsBase](http://pkg.julialang.org/badges/StatsBase_0.3.svg)](http://pkg.julialang.org/?pkg=StatsBase&ver=0.3)
   [![StatsBase](http://pkg.julialang.org/badges/StatsBase_0.4.svg)](http://pkg.julialang.org/?pkg=StatsBase&ver=0.4)
   [![StatsBase](http://pkg.julialang.org/badges/StatsBase_0.5.svg)](http://pkg.julialang.org/?pkg=StatsBase)
 - **Build & Testing Status:**


### PR DESCRIPTION
I also removed the 0.3 PkgEvaluator badge from the README because it was out of date; 0.3 is no longer supported here.