### PR TITLE
Deprecate findat() and findat!()

### DIFF
--- a/docs/source/misc.rst
+++ b/docs/source/misc.rst
@@ -25,24 +25,6 @@ Miscellaneous Functions
 
     Construct a dictionary that maps each distinct value in ``x`` to its first index.
 
-.. function:: findat(a, x)
-
-    For each element in ``x``, find its first index in ``a``. If the value does not appear in ``a``, the corresponding index is ``0``. 
-
-    **Examples:**
-  
-    .. code-block:: julia
-    
-        julia> findat([2,4,6], [2,3,4])
-        3-element Array{Int64,1}:
-        1
-        0
-        2
-
-.. function:: findat!(r, a, x)
-
-    Write the results of ``findat(a, x)`` to a pre-allocated array ``r``.
-
 .. function:: indicatormat(x, k[; sparse=false])  
 
     Construct a boolean matrix ``r`` of size ``(k, length(x))`` such that ``r[x[i], i] = true`` and all other elements are set to ``false``.

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -22,3 +22,5 @@ import Base.varm, Base.stdm
 @deprecate adjR2(obj::StatisticalModel, variant::Symbol) adjr2(obj, variant)
 @deprecate adjR²(obj::StatisticalModel, variant::Symbol) adjr²(obj, variant)
 
+@deprecate findat(a, x) indexin(x, a)
+@deprecate findat!(r, a, x)  copy!(r, indexin(x, a))

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -77,7 +77,6 @@ function inverse_rle{T}(vals::AbstractVector{T}, lens::IntegerVector)
 end
 
 
-# findat (get positions (within a) for elements in b)
 """
     indexmap(a)
 
@@ -114,25 +113,6 @@ function levelsmap{T}(a::AbstractArray{T})
     end
     return d
 end
-
-function findat!{T}(r::IntegerArray, a::AbstractArray{T}, b::AbstractArray{T})
-    length(r) == length(b) || raise_dimerror()
-    d = indexmap(a)
-    @inbounds for i = 1 : length(b)
-        r[i] = get(d, b[i], 0)
-    end
-    return r
-end
-
-
-"""
-    findat(a, b)
-
-For each element in `b`, find its first index in `a`. If the value does
-not occur in `a`, the corresponding index is 0.
-"""
-findat(a::AbstractArray, b::AbstractArray) = findat!(Array(Int, size(b)), a, b)
-
 
 # indicatormat
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -22,12 +22,6 @@ b = [true, false, false, true, false, true, true, false]
 @test levelsmap(a) == Dict(2=>2, 3=>3, 1=>1)
 @test levelsmap(b) == Dict(false=>2, true=>1)
 
-
-# findat
-
-findat([2, 4, 6, 8, 10], [8, 6, 4]) == [4, 3, 2]
-findat([2, 4, 6, 8, 10], [2, 3, 4]) == [1, 0, 2]
-
 # indicatormat
 
 I = [false true  false false false;


### PR DESCRIPTION
findat() is equivalent to Base.indexin(), and adds to the long list of
find* functions for no reason.

findat!() has no equivalent yet in Base, but it's not used in StatsBase
and its definition can easily be copied to private repositories until Base
gets indexin!().