### PR TITLE
Fix incorrect findat() deprecation

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -22,8 +22,24 @@ import Base.varm, Base.stdm
 @deprecate adjR2(obj::StatisticalModel, variant::Symbol) adjr2(obj, variant)
 @deprecate adjR²(obj::StatisticalModel, variant::Symbol) adjr²(obj, variant)
 
-@deprecate findat(a, x) indexin(x, a)
-@deprecate findat!(r, a, x)  copy!(r, indexin(x, a))
+function findat!{T}(r::IntegerArray, a::AbstractArray{T}, b::AbstractArray{T})
+    Base.depwarn("findat! is deprecated, use indexin instead", :findat!)
+    length(r) == length(b) || raise_dimerror()
+    d = indexmap(a)
+    @inbounds for i = 1 : length(b)
+        r[i] = get(d, b[i], 0)
+    end
+    return r
+end
+
+
+"""
+    findat(a, b)
+
+For each element in `b`, find its first index in `a`. If the value does
+not occur in `a`, the corresponding index is 0.
+"""
+findat(a::AbstractArray, b::AbstractArray) = findat!(Array(Int, size(b)), a, b)
 
 @deprecate df(obj::StatisticalModel) dof(obj)
 @deprecate df_residual(obj::StatisticalModel) dof_residual(obj)


### PR DESCRIPTION
indexin() returns the last matching index, while findat() returns the first one.
In practice this distinction is not always useful for callers, keep the old code
to prevent breakage and leave users time to adapt.