### PR TITLE
Fix most depwarn/error on 0.6

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -96,10 +96,11 @@ type Histogram{T<:Real,N,E} <: AbstractHistogram{T,N,E}
     edges::E
     weights::Array{T,N}
     closed::Symbol
-    function Histogram(edges::NTuple{N,AbstractArray},weights::Array{T,N},closed::Symbol)
+    function (::Type{Histogram{T,N,E}}){T,N,E}(edges::NTuple{N,AbstractArray},
+                                               weights::Array{T,N}, closed::Symbol)
         closed == :right || closed == :left || error("closed must :left or :right")
         map(x -> length(x)-1,edges) == size(weights) || error("Histogram edge vectors must be 1 longer than corresponding weight dimensions")
-        new(edges,weights,closed)
+        new{T,N,E}(edges,weights,closed)
     end
 end
 

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -70,5 +70,5 @@ l,h = extrema(StatsBase.histrange([typemin(Int),typemax(Int)], 10))
 # hist show
 show_h = sprint(show, fit(Histogram,[1,2,3]))
 @test contains(show_h, "edges:\n  0.0:1.0:3.0")
-@test contains(show_h, "weights: [1,1,1]")
+@test contains(show_h, "weights: $([1,1,1])")
 @test contains(show_h, "closed: right")


### PR DESCRIPTION
This does not include the `FloatRange` deprecation/error, which should probably go in `Compat` first.