### PR TITLE
Introduce dependency on SpecialFunctions for erfcinv

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 Compat 0.17.0
 DataStructures 0.5.0
+SpecialFunctions 0.1.0

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -10,6 +10,8 @@ module StatsBase
     import Base.Cartesian: @nloops, @nref, @nextract
     import DataStructures: heapify!, heappop!, percolate_down!
 
+    import SpecialFunctions: erfcinv
+
     ## tackle compatibility issues
 
     export


### PR DESCRIPTION
Should fix the failure on nightly. Special functions were recently removed from Base and put into a SpecialFunctions.jl package.