### PR TITLE
Add Base.norm, normalize and normalize! for Histogram

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -297,17 +297,22 @@ end
 
 # Normalization modes:
 #
-# * `:norm`: Normalize by norm(h). Resulting histogram has norm 1. Histograms
-#    of same data but with different binning will have different weight values
-#    at same coordinates after normalization. Operation is idempotent.
-# * `:pdf`: Normalize by sum of weights and bin sizes. Resulting histogram
-#    has norm 1 and represents a PDF. Histograms of same data but with
-#    different binning will have same weight values at same coordinates
-#    after normalization. Operation is *not* idempotent.
+# * `:norm`: Normalize by norm(h). Resulting histogram has norm 1. Operation
+#    is always idempotent. For homogeneous binning, result is the same as with
+#    mode `:pdf`. For inhomogeneous binning, histograms of same data but with
+#    different binning will have different weight values at same coordinates
+#    after normalization.
+# *  `:pdf`: Normalize by sum of weights and bin sizes. Resulting histogram
+#    has norm 1 and represents a PDF. Operation is *not* idempotent for
+#    histograms with inhomogeneous binning. For homogeneous binning, result is
+#    the same as with mode `:norm`. Histograms of same data but with different
+#    binning will always have similar weight values at same coordinates after
+#    normalization.
 # * `:density`: Normalize by bin sizes only. Resulting histogram represents
-#    count density of input and does not have norm 1. Histograms of same data
-#    but with different binning will have same weight values at same
-#    coordinates after normalization. Operation is *not* idempotent.
+#    count density of input and does not have norm 1. Operation is *never*
+#    idempotent. Histograms of same data but with different binning will
+#    always have similar weight values at same coordinates after
+#    normalization.
 #
 # aux_weights may, e.g., be estimated statistical uncertainties.
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -18,7 +18,7 @@ end
 
 ## Fast getindex function for multiple arrays, returns a tuple of array elements
 @inline Base.@propagate_inbounds @generated function _multi_getindex(i::Integer, c::AbstractArray...)
-    N = length(typeof(c::Tuple).parameters)
+    N = length(c)
     result_expr = Expr(:tuple)
     for j in 1:N
         push!(result_expr.args, :(c[$j][i]))

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -223,7 +223,7 @@ fit{W}(::Type{Histogram}, v::AbstractVector, wv::WeightVec{W}, args...; kwargs..
 # N-dimensional
 
 function push!{T,N}(h::Histogram{T,N},xs::NTuple{N,Real},w::Real)
-    (h.isdensity == true) && error("Density histogram must have float-type weights")
+    h.isdensity && error("Density histogram must have float-type weights")
     idx = binindex(h, xs)
     if checkbounds(Bool, h.weights, idx...)
         @inbounds h.weights[idx...] += w

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -327,7 +327,7 @@ function float{T, N, E}(h::Histogram{T, N, E})
     if float_weights === h.weights
         h
     else
-        Histogram{eltype(float_weights), N, E}(deepcopy(h.edges), float_weights, h.closed)
+        Histogram{eltype(float_weights), N, E}(h.edges, float_weights, h.closed, h.isdensity)
     end
 end
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -374,10 +374,10 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                     end
                 end
             end
+            h.isdensity = true
         else mode != :pdf && mode != :density
             throw(ArgumentError("Normalization mode must be :pdf, :density or :none"))
         end
-        h.isdensity = true
         h
     end
 end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -311,7 +311,7 @@ Calculate the norm of histogram `h` as the absolute value of its integral.
                 $(Symbol("s_$(N)")) += (@nref $N weights i) * $(Symbol("v_$N"))
             end
         )
-        norm(s_0)
+        s_0
     end
 end
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -313,6 +313,8 @@ end
 #    idempotent. Histograms of same data but with different binning will
 #    always have similar weight values at same coordinates after
 #    normalization.
+# *  `:none`: Leaves histogram unchanged. Useful to simplify code that has to
+#    conditionally apply different modes of normalization.
 #
 # aux_weights may, e.g., be estimated statistical uncertainties.
 
@@ -340,6 +342,8 @@ end
                     (@nref $N A i) /= $(Symbol("vs_$N"))
                 end
             end
+        elseif mode == :none
+            # Do nothing.
         else
             error("mode must be :norm, :pdf or :density")
         end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -155,10 +155,11 @@ function show(io::IO, h::AbstractHistogram)
         println(io,"  ",e)
     end
     println(io,"weights: ",h.weights)
-    print(io,"closed: ",h.closed)
+    println(io,"closed: ",h.closed)
+    print(io,"isdensity: ",h.isdensity)
 end
 
-(==)(h1::Histogram,h2::Histogram) = (==)(h1.edges,h2.edges) && (==)(h1.weights,h2.weights) && (==)(h1.closed,h2.closed)
+(==)(h1::Histogram,h2::Histogram) = (==)(h1.edges,h2.edges) && (==)(h1.weights,h2.weights) && (==)(h1.closed,h2.closed) && (==)(h1.isdensity,h2.isdensity)
 
 
 binindex{T,E}(h::AbstractHistogram{T,1,E}, x::Real) = binindex(h, (x,))[1]

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -322,20 +322,9 @@ Calculate the norm of histogram `h` as the absolute value of its integral.
 end
 
 
-function _float_deepcopy(x)
-    y = float(x)
-    y === x? deepcopy(y) : y
-end
+float{T<:AbstractFloat, N, E}(h::Histogram{T, N, E}) = h
 
-
-function float{T, N, E}(h::Histogram{T, N, E})
-    float_weights = float(h.weights)
-    if float_weights === h.weights
-        h
-    else
-        Histogram{eltype(float_weights), N, E}(h.edges, float_weights, h.closed, h.isdensity)
-    end
-end
+float{T, N, E}(h::Histogram{T, N, E}) = Histogram(h.edges, float(h.weights), h.closed, h.isdensity)
 
 
 
@@ -404,7 +393,7 @@ Valid values for `mode` are:
    conditionally apply different modes of normalization.
 """
 normalize{T, N, E}(h::Histogram{T, N, E}; mode::Symbol = :pdf) =
-    normalize!(_float_deepcopy(h), mode = mode)
+    normalize!(deepcopy(float(h)), mode = mode)
 
 
 """
@@ -417,8 +406,8 @@ factor as the corresponding histogram weight values. Returns a tuple of the
 normalized histogram and scaled auxiliary weights.
 """
 function normalize{T, N, E}(h::Histogram{T, N, E}, aux_weights::Array{T,N}...; mode::Symbol = :pdf)
-    h_fltcp = _float_deepcopy(h)
-    aux_weights_fltcp = map(_float_deepcopy, aux_weights)
+    h_fltcp = deepcopy(float(h))
+    aux_weights_fltcp = map(x -> deepcopy(float(x)), aux_weights)
     normalize!(h_fltcp, aux_weights_fltcp..., mode = mode)
     (h_fltcp, aux_weights_fltcp...)
 end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -281,13 +281,13 @@ end
 
 function _float_deepcopy(x)
     y = float(x)
-    is(y, x)? deepcopy(y) : y
+    y === x? deepcopy(y) : y
 end
 
 
 function float{T, N, E}(h::Histogram{T, N, E})
     float_weights = float(h.weights)
-    if is(float_weights, h.weights)
+    if float_weights === h.weights
         h
     else
         Histogram{eltype(float_weights), N, E}(deepcopy(h.edges), float_weights, h.closed)
@@ -324,7 +324,7 @@ end
         weights = h.weights
 
         for A in aux_weights
-            (size(A) != size(weights)) && error("aux_weights must have same size as histogram weights")
+            (size(A) != size(weights)) && throw(DimensionMismatch("aux_weights must have same size as histogram weights"))
         end
 
         if mode == :norm

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -121,5 +121,7 @@ show_h = sprint(show, fit(Histogram,[0,1,2], closed=:left))  # FIXME: closed
     @test h_norm_density.weights ≈ h.weights ./ bin_vols
     @test norm(h_norm_density) ≈ weight_sum
 
+    @test normalize(h, mode = :none) == h
+
     @test normalize(normalize(h, mode = :density)).weights ≈ normalize(h, mode = :pdf).weights
 end

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -116,6 +116,7 @@ end
     @test contains(show_h, "edges:\n  0.0:1.0:3.0")
     @test contains(show_h, "weights: $([1,1,1])")
     @test contains(show_h, "closed: left")
+    @test contains(show_h, "isdensity: false")
 end
 
 

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -8,14 +8,20 @@ using Base.Test
 
 @testset "Histogram binindex and binvolume" begin
     edg1 = -2:0.5:9
+    edg1f0 = -2:0.5f0:9
     edg2 = [-2, -1, 2, 7, 19]
     h1 = Histogram(edg1, :left)
     h2 = Histogram((edg1, edg2), :left)
+    h3 = Histogram((edg1f0, edg2), :left)
     @test StatsBase.binindex(h1, -0.5) == 4
     @test StatsBase.binindex(h2, (1.5, 2)) == (8, 3)
 
     @test [StatsBase.binvolume(h1, i) for i in indices(h1.weights, 1)] ≈ diff(edg1)
     @test [StatsBase.binvolume(h2, (i,j)) for i in indices(h2.weights, 1), j in indices(h2.weights, 2)] ≈ diff(edg1) * diff(edg2)'
+
+    @test typeof(StatsBase.binvolume(h2, (1,1))) == Float64
+    @test typeof(StatsBase.binvolume(h3, (1,1))) == Float32
+    @test typeof(StatsBase.binvolume(Float64, h3, (1,1))) == Float64
 end
 
 

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -3,85 +3,122 @@
 using StatsBase
 using Base.Test
 
-# test hist
-@test sum(fit(Histogram,[1,2,3], closed=:left).weights) == 3  # FIXME: closed
-@test fit(Histogram,Int[], closed=:left).weights == Int[]  # FIXME: closed
-@test fit(Histogram,[1], closed=:left).weights == [1]  # FIXME: closed
-@test fit(Histogram,[1,2,3],[0,2,4], closed=:left) == Histogram([0,2,4],[1,2], :left)  # FIXME: closed
-@test fit(Histogram,[1,2,3],[0,2,4], closed=:left) != Histogram([0,2,4],[1,1], :left)  # FIXME: closed
-@test fit(Histogram,[1,2,3],0:2:4, closed=:left) == Histogram(0:2:4,[1,2], :left)  # FIXME: closed
-@test all(fit(Histogram,[0:99;]/100,0.0:0.01:1.0, closed=:left).weights .==1)  # FIXME: closed
-@test fit(Histogram,[1,1,1,1,1], closed=:left).weights[1] == 5  # FIXME: closed
-@test sum(fit(Histogram,(rand(100),rand(100)), closed=:left).weights) == 100  # FIXME: closed
-@test fit(Histogram,1:100,nbins=5,closed=:right).weights == [20,20,20,20,20]
-@test fit(Histogram,1:100,nbins=5,closed=:left).weights == [19,20,20,20,20,1]
-@test fit(Histogram,0:99,nbins=5,closed=:right).weights == [1,20,20,20,20,19]
-@test fit(Histogram,0:99,nbins=5,closed=:left).weights == [20,20,20,20,20]
-
-# FIXME: closed (all lines in this block):
-@test fit(Histogram,(0:99,0:99),nbins=5, closed=:left).weights == diagm([20,20,20,20,20])
-@test fit(Histogram,(0:99,0:99),nbins=(5,5), closed=:left).weights == diagm([20,20,20,20,20])
-
-# FIXME: closed (all lines in this block):
-@test fit(Histogram,0:99,weights(ones(100)),nbins=5, closed=:left).weights == [20,20,20,20,20]
-@test fit(Histogram,0:99,weights(2*ones(100)),nbins=5, closed=:left).weights == [40,40,40,40,40]
-
-# FIXME: closed (all lines in this block):
-@test eltype(fit(Histogram,1:100,weights(ones(Int,100)),nbins=5, closed=:left).weights) == Int
-@test eltype(fit(Histogram,1:100,weights(ones(Float64,100)),nbins=5, closed=:left).weights) == Float64
-
-# histrange
-# Note: atm histrange must be qualified
-@test StatsBase.histrange(Float64[], 0, :left) == 0.0:1.0:0.0
-@test StatsBase.histrange(Float64[1:5;], 1, :left) == 0.0:5.0:10.0
-@test StatsBase.histrange(Float64[1:10;], 1, :left) == 0.0:10.0:20.0
-@test StatsBase.histrange(1.0, 10.0, 1, :left) == 0.0:10.0:20.0
-
-@test StatsBase.histrange([0.201,0.299], 10, :left) == 0.2:0.01:0.3
-@test StatsBase.histrange([0.2,0.299], 10, :left) == 0.2:0.01:0.3
-@test StatsBase.histrange([0.2,0.3], 10, :left)  == 0.2:0.01:0.31
-@test StatsBase.histrange(0.2, 0.3,  10, :left)  == 0.2:0.01:0.31
-@test StatsBase.histrange([0.2,0.3], 10, :right) == 0.19:0.01:0.3
-@test StatsBase.histrange(0.2, 0.3,  10, :right) == 0.19:0.01:0.3
-
-@test StatsBase.histrange([200.1,299.9], 10, :left) == 200.0:10.0:300.0
-@test StatsBase.histrange([200.0,299.9], 10, :left) == 200.0:10.0:300.0
-@test StatsBase.histrange([200.0,300.0], 10, :left) == 200.0:10.0:310.0
-@test StatsBase.histrange([200.0,300.0], 10, :right) == 190.0:10.0:300.0
-
-@test StatsBase.histrange(Int64[1:5;], 1, :left) == 0:5:10
-@test StatsBase.histrange(Int64[1:10;], 1, :left) == 0:10:20
-
-# FIXME: closed (all lines in this block):
-@test StatsBase.histrange([0, 1, 2, 3], 4, :left) == 0.0:1.0:4.0
-@test StatsBase.histrange([0, 1, 1, 3], 4, :left) == 0.0:1.0:4.0
-@test StatsBase.histrange([0, 9], 4, :left) == 0.0:5.0:10.0
-@test StatsBase.histrange([0, 19], 4, :left) == 0.0:5.0:20.0
-@test StatsBase.histrange([0, 599], 4, :left) == 0.0:200.0:600.0
-@test StatsBase.histrange([-1, -1000], 4, :left) == -1000.0:500.0:0.0
-
-# Base issue #13326
-l,h = extrema(StatsBase.histrange([typemin(Int),typemax(Int)], 10, :left))  # FIXME: closed
-@test l <= typemin(Int)
-@test h >= typemax(Int)
-
-# FIXME: closed (all lines in this block):
-@test_throws ArgumentError StatsBase.histrange([1, 10], 0, :left)
-@test_throws ArgumentError StatsBase.histrange([1, 10], -1, :left)
-@test_throws ArgumentError StatsBase.histrange([1.0, 10.0], 0, :left)
-@test_throws ArgumentError StatsBase.histrange([1.0, 10.0], -1, :left)
-@test_throws ArgumentError StatsBase.histrange(Float64[],-1, :left)
-@test_throws ArgumentError StatsBase.histrange([0.], 0, :left)
+@testset "StatsBase.Histogram" begin
 
 
-# hist show
-show_h = sprint(show, fit(Histogram,[0,1,2], closed=:left))  # FIXME: closed
-@test contains(show_h, "edges:\n  0.0:1.0:3.0")
-@test contains(show_h, "weights: $([1,1,1])")
-@test contains(show_h, "closed: left")
+@testset "Histogram binindex and binvolume" begin
+    edg1 = -2:0.5:9
+    edg2 = [-2, -1, 2, 7, 19]
+    h1 = Histogram(edg1, :left)
+    h2 = Histogram((edg1, edg2), :left)
+    @test StatsBase.binindex(h1, -0.5) == 4
+    @test StatsBase.binindex(h2, (1.5, 2)) == (8, 3)
+
+    @test [StatsBase.binvolume(h1, i) for i in indices(h1.weights, 1)] ≈ diff(edg1)
+    @test [StatsBase.binvolume(h2, (i,j)) for i in indices(h2.weights, 1), j in indices(h2.weights, 2)] ≈ diff(edg1) * diff(edg2)'
+end
 
 
-# hist norm and normalize
+@testset "Histogram append" begin
+    # FIXME: closed (all lines in this block):
+    @test append!(Histogram(0:20:100, Float64, :left, false), 0:0.5:99.99).weights ≈ [40,40,40,40,40]
+    @test append!(Histogram(0:20:100, Float64, :left, true), 0:0.5:99.99).weights ≈ [2,2,2,2,2]
+    @test append!(Histogram(0:20:100, Float64, :left, false), 0:0.5:99.99, fill(2, 200)).weights ≈ [80,80,80,80,80]
+    @test append!(Histogram(0:20:100, Float64, :left, true), 0:0.5:99.99, fill(2, 200)).weights ≈ [4,4,4,4,4]
+end
+
+
+@testset "Histogram fit" begin
+    # FIXME: closed (all lines in this block):
+    @test sum(fit(Histogram,[1,2,3], closed=:left).weights) == 3  # FIXME: closed
+    @test fit(Histogram,Int[], closed=:left).weights == Int[]  # FIXME: closed
+    @test fit(Histogram,[1], closed=:left).weights == [1]  # FIXME: closed
+    @test fit(Histogram,[1,2,3],[0,2,4], closed=:left) == Histogram([0,2,4],[1,2], :left)  # FIXME: closed
+    @test fit(Histogram,[1,2,3],[0,2,4], closed=:left) != Histogram([0,2,4],[1,1], :left)  # FIXME: closed
+    @test fit(Histogram,[1,2,3],0:2:4, closed=:left) == Histogram(0:2:4,[1,2], :left)  # FIXME: closed
+    @test all(fit(Histogram,[0:99;]/100,0.0:0.01:1.0, closed=:left).weights .==1)  # FIXME: closed
+    @test fit(Histogram,[1,1,1,1,1], closed=:left).weights[1] == 5  # FIXME: closed
+    @test sum(fit(Histogram,(rand(100),rand(100)), closed=:left).weights) == 100  # FIXME: closed
+    @test fit(Histogram,1:100,nbins=5,closed=:right).weights == [20,20,20,20,20]
+    @test fit(Histogram,1:100,nbins=5,closed=:left).weights == [19,20,20,20,20,1]
+    @test fit(Histogram,0:99,nbins=5,closed=:right).weights == [1,20,20,20,20,19]
+    @test fit(Histogram,0:99,nbins=5,closed=:left).weights == [20,20,20,20,20]
+
+    # FIXME: closed (all lines in this block):
+    @test fit(Histogram,(0:99,0:99),nbins=5, closed=:left).weights == diagm([20,20,20,20,20])
+    @test fit(Histogram,(0:99,0:99),nbins=(5,5), closed=:left).weights == diagm([20,20,20,20,20])
+
+    # FIXME: closed (all lines in this block):
+    @test fit(Histogram,0:99,weights(ones(100)),nbins=5, closed=:left).weights == [20,20,20,20,20]
+    @test fit(Histogram,0:99,weights(2*ones(100)),nbins=5, closed=:left).weights == [40,40,40,40,40]
+    @test fit(Histogram{Int32},0:99,weights(2*ones(100)),nbins=5, closed=:left).weights == [40,40,40,40,40]
+    @test fit(Histogram{Float32},0:99,weights(2*ones(100)),nbins=5, closed=:left).weights == [40,40,40,40,40]
+end
+
+
+@testset "Histogram element type" begin
+    # FIXME: closed (all lines in this block):
+    @test eltype(fit(Histogram,1:100,weights(ones(Int,100)),nbins=5, closed=:left).weights) == Int
+    @test eltype(fit(Histogram{Float32},1:100,weights(ones(Int,100)),nbins=5, closed=:left).weights) == Float32
+    @test eltype(fit(Histogram,1:100,weights(ones(Float64,100)),nbins=5, closed=:left).weights) == Float64
+    @test eltype(fit(Histogram{Float32},1:100,weights(ones(Float64,100)),nbins=5, closed=:left).weights) == Float32
+end
+
+
+@testset "histrange" begin
+    # Note: atm histrange must be qualified
+    @test StatsBase.histrange(Float64[], 0, :left) == 0.0:1.0:0.0
+    @test StatsBase.histrange(Float64[1:5;], 1, :left) == 0.0:5.0:10.0
+    @test StatsBase.histrange(Float64[1:10;], 1, :left) == 0.0:10.0:20.0
+    @test StatsBase.histrange(1.0, 10.0, 1, :left) == 0.0:10.0:20.0
+
+    @test StatsBase.histrange([0.201,0.299], 10, :left) == 0.2:0.01:0.3
+    @test StatsBase.histrange([0.2,0.299], 10, :left) == 0.2:0.01:0.3
+    @test StatsBase.histrange([0.2,0.3], 10, :left)  == 0.2:0.01:0.31
+    @test StatsBase.histrange(0.2, 0.3,  10, :left)  == 0.2:0.01:0.31
+    @test StatsBase.histrange([0.2,0.3], 10, :right) == 0.19:0.01:0.3
+    @test StatsBase.histrange(0.2, 0.3,  10, :right) == 0.19:0.01:0.3
+
+    @test StatsBase.histrange([200.1,299.9], 10, :left) == 200.0:10.0:300.0
+    @test StatsBase.histrange([200.0,299.9], 10, :left) == 200.0:10.0:300.0
+    @test StatsBase.histrange([200.0,300.0], 10, :left) == 200.0:10.0:310.0
+    @test StatsBase.histrange([200.0,300.0], 10, :right) == 190.0:10.0:300.0
+
+    @test StatsBase.histrange(Int64[1:5;], 1, :left) == 0:5:10
+    @test StatsBase.histrange(Int64[1:10;], 1, :left) == 0:10:20
+
+    # FIXME: closed (all lines in this block):
+    @test StatsBase.histrange([0, 1, 2, 3], 4, :left) == 0.0:1.0:4.0
+    @test StatsBase.histrange([0, 1, 1, 3], 4, :left) == 0.0:1.0:4.0
+    @test StatsBase.histrange([0, 9], 4, :left) == 0.0:5.0:10.0
+    @test StatsBase.histrange([0, 19], 4, :left) == 0.0:5.0:20.0
+    @test StatsBase.histrange([0, 599], 4, :left) == 0.0:200.0:600.0
+    @test StatsBase.histrange([-1, -1000], 4, :left) == -1000.0:500.0:0.0
+
+    # Base issue #13326
+    l,h = extrema(StatsBase.histrange([typemin(Int),typemax(Int)], 10, :left))  # FIXME: closed
+    @test l <= typemin(Int)
+    @test h >= typemax(Int)
+
+    # FIXME: closed (all lines in this block):
+    @test_throws ArgumentError StatsBase.histrange([1, 10], 0, :left)
+    @test_throws ArgumentError StatsBase.histrange([1, 10], -1, :left)
+    @test_throws ArgumentError StatsBase.histrange([1.0, 10.0], 0, :left)
+    @test_throws ArgumentError StatsBase.histrange([1.0, 10.0], -1, :left)
+    @test_throws ArgumentError StatsBase.histrange(Float64[],-1, :left)
+    @test_throws ArgumentError StatsBase.histrange([0.], 0, :left)
+end
+
+
+@testset "Histogram show" begin
+    # hist show
+    show_h = sprint(show, fit(Histogram,[0,1,2], closed=:left))  # FIXME: closed
+    @test contains(show_h, "edges:\n  0.0:1.0:3.0")
+    @test contains(show_h, "weights: $([1,1,1])")
+    @test contains(show_h, "closed: left")
+end
+
+
 @testset "Histogram norm and normalize" begin
     rng = MersenneTwister(345678)
     edges = (
@@ -105,39 +142,43 @@ show_h = sprint(show, fit(Histogram,[0,1,2], closed=:left))  # FIXME: closed
 
     @test norm(h) ≈ sum(h.weights .* bin_vols)
 
-    h_norm_norm = normalize(h, mode = :norm)
-    @test normalize(h, mode = :norm) == Histogram(h.edges, h.weights ./ norm(h), h.closed)
-    @test norm(h_norm_norm) ≈ 1
-    @test normalize(h) == h_norm_norm
-    @test normalize(normalize(h)).weights ≈ normalize(h).weights
-
-    h_norm_pdf = normalize(h, mode = :pdf)
-    @test h_norm_pdf.weights ≈ h.weights ./ bin_vols ./ weight_sum
-    @test norm(h_norm_pdf) ≈ 1
-
-    h_norm_density = normalize(h, mode = :density)
-    @test h_norm_density.weights ≈ h.weights ./ bin_vols
-    @test norm(h_norm_density) ≈ weight_sum
-
     @test normalize(h, mode = :none) == h
 
-    @test normalize(normalize(h, mode = :density)).weights ≈ normalize(h, mode = :pdf).weights
+
+    h_pdf = normalize(h, mode = :pdf)
+    @test h_pdf.weights ≈ h.weights ./ bin_vols ./ weight_sum
+    @test h_pdf.isdensity == true
+    @test norm(h_pdf) ≈ 1
+    @test normalize(h_pdf, mode = :pdf) == h_pdf
+    @test normalize(h_pdf, mode = :density) == h_pdf
+
+    h_density = normalize(h, mode = :density)
+    @test h_density.weights ≈ h.weights ./ bin_vols
+    @test h_density.isdensity == true
+    @test norm(h_density) ≈ weight_sum
+    @test normalize(h_density, mode = :pdf) ==
+        Histogram(h_density.edges, h_density.weights ./ norm(h_density), h_density.closed, true)
+    @test normalize(h_density, mode = :pdf).weights ≈ h_pdf.weights
+    @test normalize(h_density, mode = :density) == h_density
 
     h2 = deepcopy(float(h))
     mod_h2 = normalize!(h2, mode = :density)
     @test mod_h2 === h2 && mod_h2.weights === h2.weights
-    @test h2.weights == h_norm_density.weights
+    @test h2.weights == h_density.weights
 
     aux_weights = sqrt.(h.weights)
     divor0 = (a,b) -> (a == 0 && b == 0) ? 0 : a/b
-    divor0_cmp = (a_n, a_d, b_n, b_d) -> maximum(abs(map(divor0, a_n, a_d) - map(divor0, b_n, b_d))) < 1e-10
+    divor0_cmp = (a_n, a_d, b_n, b_d) -> maximum(abs.(map(divor0, a_n, a_d) - map(divor0, b_n, b_d))) < 1e-10
 
-    h_norm_norm2, scaled_aux_weights = normalize(float(h), aux_weights, mode = :norm)
-    @test divor0_cmp(scaled_aux_weights, aux_weights, h_norm_norm2.weights, h.weights)
+    h_pdf2, h_pdf2_aux = normalize(float(h), aux_weights, mode = :pdf)
+    @test divor0_cmp(h_pdf2_aux, aux_weights, h_pdf2.weights, h.weights)
 
-    h_norm_pdf2, scaled_aux_weights = normalize(float(h), aux_weights, mode = :pdf)
-    @test divor0_cmp(scaled_aux_weights, aux_weights, h_norm_pdf2.weights, h.weights)
+    h_density2, h_density2_aux = normalize(float(h), aux_weights, mode = :density)
+    @test divor0_cmp(h_density2_aux, aux_weights, h_density2.weights, h.weights)
 
-    h_norm_density2, scaled_aux_weights = normalize(float(h), aux_weights, mode = :density)
-    @test divor0_cmp(scaled_aux_weights, aux_weights, h_norm_density2.weights, h.weights)
+    h_density3, h_density3_aux = normalize(h_density2, h_density2_aux, mode = :pdf)
+    @test divor0_cmp(h_density3_aux, h_density2_aux, h_density3.weights, h_density2.weights)
 end
+
+
+end # @testset "StatsBase.Histogram"

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -122,4 +122,22 @@ show_h = sprint(show, fit(Histogram,[0,1,2], closed=:left))  # FIXME: closed
     @test normalize(h, mode = :none) == h
 
     @test normalize(normalize(h, mode = :density)).weights ≈ normalize(h, mode = :pdf).weights
+
+    h2 = deepcopy(float(h))
+    mod_h2 = normalize!(h2, mode = :density)
+    @test mod_h2 === h2 && mod_h2.weights === h2.weights
+    @test h2.weights == h_norm_density.weights
+
+    aux_weights = sqrt.(h.weights)
+    divor0 = (a,b) -> (a == 0 && b == 0) ? 0 : a/b
+    divor0_cmp = (a_n, a_d, b_n, b_d) -> maximum(abs(map(divor0, a_n, a_d) - map(divor0, b_n, b_d))) < 1e-10
+
+    h_norm_norm2, scaled_aux_weights = normalize(float(h), aux_weights, mode = :norm)
+    @test divor0_cmp(scaled_aux_weights, aux_weights, h_norm_norm2.weights, h.weights)
+
+    h_norm_pdf2, scaled_aux_weights = normalize(float(h), aux_weights, mode = :pdf)
+    @test divor0_cmp(scaled_aux_weights, aux_weights, h_norm_pdf2.weights, h.weights)
+
+    h_norm_density2, scaled_aux_weights = normalize(float(h), aux_weights, mode = :density)
+    @test divor0_cmp(scaled_aux_weights, aux_weights, h_norm_density2.weights, h.weights)
 end

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -158,7 +158,7 @@ end
     @test h_density.isdensity == true
     @test norm(h_density) ≈ weight_sum
     @test normalize(h_density, mode = :pdf) ==
-        Histogram(h_density.edges, h_density.weights ./ norm(h_density), h_density.closed, true)
+        Histogram(h_density.edges, h_density.weights .* (1/norm(h_density)), h_density.closed, true)
     @test normalize(h_density, mode = :pdf).weights ≈ h_pdf.weights
     @test normalize(h_density, mode = :density) == h_density
 

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -103,8 +103,6 @@ show_h = sprint(show, fit(Histogram,[0,1,2], closed=:left))  # FIXME: closed
     weight_sum = sum(h.weights)
     bin_vols = [ x * y * z for x in diff(edges[1]), y in diff(edges[2]), z in diff(edges[3])]
 
-    normalize(h)
-
     @test norm(h) ≈ sum(h.weights .* bin_vols)
 
     h_norm_norm = normalize(h, mode = :norm)


### PR DESCRIPTION
Addresses #231.

Question: how do define the norm for histograms with potentially negative entries? While these don't occur naturally, one still encounters them from time to time the result of comparing/subtracting two histograms (e.g. signal - background). Take the abs/norm of each weight before integration? Or take abs/norm of the regular integral?