### PR TITLE
Optionally specify RNG to use for sampling

### DIFF
--- a/docs/source/sampling.rst
+++ b/docs/source/sampling.rst
@@ -6,45 +6,59 @@ Sampling API
 
 The package provides functions for sampling from a given population (with or without replacement).
 
-.. function:: sample(a)
+.. function:: sample([rng], a)
 
     Randomly draw an element from an array ``a``.
 
-.. function:: sample(a, n[; replace=true, ordered=false])  
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
+
+.. function:: sample([rng], a, n[; replace=true, ordered=false])  
 
     Randomly draw ``n`` elements from ``a``. 
+
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
 
     **Keyword arguments**
 
     - ``replace``: indicates whether to have replacement (default = ``true``).
     - ``ordered``: indicates whether to arrange the samples in ascending order (default = ``false``).
 
-.. function:: sample!(a, x[; replace=true, ordered=false])
+.. function:: sample!([rng], a, x[; replace=true, ordered=false])
 
     Draw ``length(x)`` elements from ``a`` and write them to a pre-allocated array ``x``.
 
-.. function:: sample(wv) 
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
+
+.. function:: sample([rng], wv) 
 
     Draw an integer in ``1:length(wv)`` with probabilities proportional to the weights given in ``wv``. 
 
     Here, ``wv`` should be a weight vector of type ``WeightVec`` (see :ref:`weightvec`).
 
-.. function:: sample(a, wv)
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
+
+.. function:: sample([rng], a, wv)
 
     Draw an element from ``a`` with probabilities proportional to the corresponding weights given in ``wv``.
 
-.. function:: sample(a, wv, n[; replace=true, ordered=false])
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
+
+.. function:: sample([rng], a, wv, n[; replace=true, ordered=false])
 
     Draw ``n`` elements from ``a`` with probabilities proportional to the corresponding weights given in ``wv``.
+
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
 
     **Keyword arguments**
 
     - ``replace``: indicates whether to have replacement (default = ``true``).
     - ``ordered``: indicates whether to arrange the samples in ascending order (default = ``false``).    
 
-.. function:: sample!(a, wv, x[; replace=true, ordered=false])
+.. function:: sample!([rng], a, wv, x[; replace=true, ordered=false])
 
     Weighted sampling with results written to a pre-allocated array ``x``.
+
+    Optionally specify a random number generator ``rng`` as the first argument (defaults to ``Base.GLOBAL_RNG``).
 
 
 Algorithms
@@ -63,13 +77,14 @@ Here are a list of algorithms implemented in the package. The functions below ar
 - ``wv``: the weight vector (of type ``WeightVec``), for weighted sampling
 - ``n``: the length of ``a``
 - ``k``: the length of ``x``. For sampling without replacement, ``k`` must not exceed ``n``.
+- ``rng``: optional random number generator (defaults to ``Base.GLOBAL_RNG``)
 
 All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
 
 **Sampling Algorithms (Non-Weighted):**
 
-.. function:: direct_sample!(a, x)
+.. function:: direct_sample!([rng], a, x)
 
     *Direct sampling.*
 
@@ -77,13 +92,13 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     This algorithm consumes ``k`` random numbers.
 
-.. function:: samplepair(a)
+.. function:: samplepair([rng], a)
 
     Pick two elements at distinct positions from ``a``, and return them as a pair.
 
     This algorithm consumes exactly two random numbers.
 
-.. function:: knuths_sample!(a, x)
+.. function:: knuths_sample!([rng], a, x)
 
     *Knuth's Algorithm S* for random sampling without replacement.
 
@@ -91,7 +106,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     This algorithm consumes ``n`` random numbers. It requires no additional memory space. Suitable for the case where memory is tight.
 
-.. function:: fisher_yates_sample!(a, x)
+.. function:: fisher_yates_sample!([rng], a, x)
 
     *Fisher-Yates shuffling* (with early termination). 
 
@@ -107,7 +122,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     This algorithm consumes ``k`` random numbers. It uses an integer array of length ``n`` internally to maintain the shuffled indices. It is considerably faster than Knuth's algorithm especially when ``n`` is greater than ``k``.
 
-.. function:: self_avoid_sample!(a, x)
+.. function:: self_avoid_sample!([rng], a, x)
 
     Use a set to maintain the index that has been sampled. Each time draw a new index, if the index has already been sampled, redraw until it draws an unsampled one. 
 
@@ -115,7 +130,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     However, if ``k`` is large and approaches ``n``, the rejection rate would increase drastically, resulting in poorer performance.
 
-.. function:: seqsample_a!(a, x)
+.. function:: seqsample_a!([rng], a, x)
 
     *Algorithm A* described in the following paper (page 714).
 
@@ -123,7 +138,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     This algorithm consumes ``O(n)`` random numbers. The outputs are ordered.
 
-.. function:: seqsample_c!(a, x)
+.. function:: seqsample_c!([rng], a, x)
 
     *Algorithm C* described in the following paper (page 714).
 
@@ -134,7 +149,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
 **Weighted Sampling Algorithms:**
 
-.. function:: direct_sample!(a, wv, x)
+.. function:: direct_sample!([rng], a, wv, x)
 
     *Direct sampling.*
 
@@ -142,7 +157,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     This algorithm: (1) consumes ``k`` random numbers; (2) has time complexity ``O(n k)``, as scanning the weight vector each time takes ``O(n)``; and (3) requires no additional memory space.
 
-.. function:: alias_sample!(a, wv, x)
+.. function:: alias_sample!([rng], a, wv, x)
 
     *Alias method.*
 
@@ -152,7 +167,7 @@ All following functions write results to ``x`` (pre-allocated) and return ``x``.
 
     This algorithm takes ``O(n log n)`` time for building the alias table, and then ``O(1)`` to draw each sample. It consumes ``2 k`` random numbers.
 
-.. function:: naive_wsample_norep!(a, wv, x)
+.. function:: naive_wsample_norep!([rng], a, wv, x)
 
     Naive implementation of weighted sampling without replacement.
 

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -9,13 +9,16 @@ immutable RandIntSampler  # for generating Int samples in [0, K-1]
     @compat RandIntSampler(a::Int, b::Int) = (Ku = UInt(b-a+1); new(a, Ku, div(typemax(UInt), Ku) * Ku))
 end
 
-function rand(s::RandIntSampler, rng::AbstractRNG = Base.GLOBAL_RNG)
+function rand(rng::AbstractRNG, s::RandIntSampler)
     x = rand(rng, UInt)
     while x >= s.U
         x = rand(rng, UInt)
     end
     @compat s.a + Int(rem(x, s.Ku))
 end
+rand(s::RandIntSampler) = rand(Base.GLOBAL_RNG, s)
 
-randi(K::Int, rng::AbstractRNG = Base.GLOBAL_RNG) = rand(RandIntSampler(K), rng)
-randi(a::Int, b::Int, rng::AbstractRNG = Base.GLOBAL_RNG) = rand(RandIntSampler(a, b), rng)
+randi(rng::AbstractRNG, K::Int) = rand(rng, RandIntSampler(K))
+randi(K::Int) = randi(Base.GLOBAL_RNG, K)
+randi(rng::AbstractRNG, a::Int, b::Int) = rand(rng, RandIntSampler(a, b))
+randi(a::Int, b::Int) = randi(Base.GLOBAL_RNG, a, b)

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -9,13 +9,13 @@ immutable RandIntSampler  # for generating Int samples in [0, K-1]
     @compat RandIntSampler(a::Int, b::Int) = (Ku = UInt(b-a+1); new(a, Ku, div(typemax(UInt), Ku) * Ku))
 end
 
-function rand(s::RandIntSampler)
-    x = rand(UInt)
+function rand(s::RandIntSampler, rng::AbstractRNG = Base.GLOBAL_RNG)
+    x = rand(rng, UInt)
     while x >= s.U
-        x = rand(UInt)
+        x = rand(rng, UInt)
     end
     @compat s.a + Int(rem(x, s.Ku))
 end
 
-randi(K::Int) = rand(RandIntSampler(K))
-randi(a::Int, b::Int) = rand(RandIntSampler(a, b))
+randi(K::Int, rng::AbstractRNG = Base.GLOBAL_RNG) = rand(RandIntSampler(K), rng)
+randi(a::Int, b::Int, rng::AbstractRNG = Base.GLOBAL_RNG) = rand(RandIntSampler(a, b), rng)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -14,7 +14,7 @@
 #
 #   x[i] and x[j] are independent, when i != j
 #
-function direct_sample!(a::UnitRange, x::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function direct_sample!(a::UnitRange, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     s = RandIntSampler(length(a))
     b = a[1] - 1
     if b == 0
@@ -29,7 +29,7 @@ function direct_sample!(a::UnitRange, x::AbstractArray; rng::AbstractRNG=Base.GL
     return x
 end
 
-function direct_sample!(a::AbstractArray, x::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function direct_sample!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     s = RandIntSampler(length(a))
     for i = 1:length(x)
         @inbounds x[i] = a[rand(s, rng)]
@@ -44,7 +44,7 @@ end
 
 Draw a pair of distinct integers between 1 and `n` without replacement.
 """
-function samplepair(n::Int; rng::AbstractRNG=Base.GLOBAL_RNG)
+function samplepair(n::Int, rng::AbstractRNG=Base.GLOBAL_RNG)
     i1 = randi(n, rng)
     i2 = randi(n-1, rng)
     return (i1, ifelse(i2 == i1, n, i2))
@@ -56,7 +56,7 @@ end
 
 Draw a pair of distinct elements from the array `a` without replacement.
 """
-function samplepair(a::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function samplepair(a::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     i1, i2 = samplepair(length(a); rng=rng)
     return a[i1], a[i2]
 end
@@ -68,8 +68,8 @@ end
 #
 #   Reference: The Art of Computer Programming, Vol 2, 3.4.2, p.142
 #
-function knuths_sample!(a::AbstractArray, x::AbstractArray;
-                       rng::AbstractRNG=Base.GLOBAL_RNG, initshuffle::Bool=true)
+function knuths_sample!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
+                       initshuffle::Bool=true)
     n = length(a)
     k = length(x)
     k <= n || error("length(x) should not exceed length(a)")
@@ -110,7 +110,7 @@ end
 #
 #   O(n) for initialization + O(k) for random shuffling
 #
-function fisher_yates_sample!(a::AbstractArray, x::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function fisher_yates_sample!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     k = length(x)
     k <= n || error("length(x) should not exceed length(a)")
@@ -137,7 +137,7 @@ end
 #   each time draw a new index, if the index has already
 #   been sampled, redraw until it draws an unsampled one.
 #
-function self_avoid_sample!(a::AbstractArray, x::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function self_avoid_sample!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     k = length(x)
     k <= n || error("length(x) should not exceed length(a)")
@@ -184,7 +184,7 @@ end
 #
 #  Require O(n) random numbers.
 #
-function seqsample_a!(a::AbstractArray, x::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function seqsample_a!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     k = length(x)
     k <= n || error("length(x) should not exceed length(a)")
@@ -215,7 +215,7 @@ end
 #
 #  Require O(k^2) random numbers
 #
-function seqsample_c!(a::AbstractArray, x::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG)
+function seqsample_c!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     k = length(x)
     k <= n || error("length(x) should not exceed length(a)")
@@ -256,7 +256,7 @@ end
 Select a single random element of `a`. Sampling probabilities are proportional to
 the weights given in `wv`, if provided.
 """
-sample(a::AbstractArray; rng::AbstractRNG=Base.GLOBAL_RNG) = a[randi(length(a), rng)]
+sample(a::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG) = a[randi(length(a), rng)]
 
 
 """
@@ -269,8 +269,8 @@ if provided. `replace` dictates whether sampling is performed with
 replacement and `order` dictates whether an ordered sample, also called
 a sequential sample, should be taken.
 """
-function sample!(a::AbstractArray, x::AbstractArray;
-                rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false)
+function sample!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
+                 replace::Bool=true, ordered::Bool=false)
     n = length(a)
     k = length(x)
     k == 0 && return x
@@ -316,8 +316,8 @@ given in `wv`, if provided. `replace` dictates whether sampling is performed
 with replacement and `order` dictates whether an ordered sample, also called
 a sequential sample, should be taken.
 """
-function sample{T}(a::AbstractArray{T}, n::Integer;
-                  rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false)
+function sample{T}(a::AbstractArray{T}, n::Integer, rng::AbstractRNG=Base.GLOBAL_RNG;
+                  replace::Bool=true, ordered::Bool=false)
     sample!(a, Vector{T}(n); rng=rng, replace=replace, ordered=ordered)
 end
 
@@ -331,8 +331,8 @@ proportional to the weights given in `wv`, if provided. `replace` dictates
 whether sampling is performed with replacement and `order` dictates whether
 an ordered sample, also called a sequential sample, should be taken.
 """
-function sample{T}(a::AbstractArray{T}, dims::Dims;
-                  rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false)
+function sample{T}(a::AbstractArray{T}, dims::Dims, rng::AbstractRNG=Base.GLOBAL_RNG;
+                  replace::Bool=true, ordered::Bool=false)
     sample!(a, Array{T}(dims); rng=rng, replace=replace, ordered=ordered)
 end
 
@@ -349,7 +349,7 @@ end
 Select a single random integer in `1:length(wv)` with probabilities
 proportional to the weights given in `wv`.
 """
-function sample(wv::WeightVec; rng::AbstractRNG=Base.GLOBAL_RNG)
+function sample(wv::WeightVec, rng::AbstractRNG=Base.GLOBAL_RNG)
     t = rand(rng) * sum(wv)
     w = values(wv)
     n = length(w)
@@ -362,9 +362,9 @@ function sample(wv::WeightVec; rng::AbstractRNG=Base.GLOBAL_RNG)
     return i
 end
 
-sample(a::AbstractArray, wv::WeightVec; rng::AbstractRNG=Base.GLOBAL_RNG) = a[sample(wv; rng=rng)]
+sample(a::AbstractArray, wv::WeightVec, rng::AbstractRNG=Base.GLOBAL_RNG) = a[sample(wv; rng=rng)]
 
-function direct_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
+function direct_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
                       rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
@@ -433,7 +433,7 @@ function make_alias_table!(w::AbstractVector{Float64}, wsum::Float64,
     nothing
 end
 
-function alias_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
+function alias_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
                      rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
@@ -452,7 +452,7 @@ function alias_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
     return x
 end
 
-function naive_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
+function naive_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
                             rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
@@ -486,7 +486,7 @@ end
 #     URL http://www.sciencedirect.com/science/article/pii/S002001900500298X
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
-function efraimidis_a_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
+function efraimidis_a_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
                                    rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
@@ -515,7 +515,7 @@ end
 #     URL http://www.sciencedirect.com/science/article/pii/S002001900500298X
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
-function efraimidis_ares_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
+function efraimidis_ares_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
                                      rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
@@ -574,7 +574,7 @@ end
 #     URL http://www.sciencedirect.com/science/article/pii/S002001900500298X
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
-function efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
+function efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
                                       rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
@@ -625,8 +625,8 @@ function efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::WeightVec, x::Abs
     return x
 end
 
-function sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
-                rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false)
+function sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
+                replace::Bool=true, ordered::Bool=false)
     n = length(a)
     k = length(x)
 
@@ -656,13 +656,12 @@ function sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray;
     return x
 end
 
-sample{T}(a::AbstractArray{T}, wv::WeightVec, n::Integer;
-         rng::AbstractRNG=Base.GLOBAL_RNG,
+sample{T}(a::AbstractArray{T}, wv::WeightVec, n::Integer, rng::AbstractRNG=Base.GLOBAL_RNG;
          replace::Bool=true, ordered::Bool=false) =
     sample!(a, wv, Vector{T}(n); rng = rng, replace=replace, ordered=ordered)
 
-sample{T}(a::AbstractArray{T}, wv::WeightVec, dims::Dims;
-         rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false) =
+sample{T}(a::AbstractArray{T}, wv::WeightVec, dims::Dims, rng::AbstractRNG=Base.GLOBAL_RNG;
+         replace::Bool=true, ordered::Bool=false) =
     sample!(a, wv, Array{T}(dims); rng=rng, replace=replace, ordered=ordered)
 
 
@@ -676,8 +675,8 @@ probabilities are proportional to the weights given in `w`. `replace` dictates
 whether sampling is performed with replacement and `order` dictates whether an
 ordered sample, also called a sequential sample, should be taken.
 """
-wsample!(a::AbstractArray, w::RealVector, x::AbstractArray;
-        rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false) =
+wsample!(a::AbstractArray, w::RealVector, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
+        replace::Bool=true, ordered::Bool=false) =
     sample!(a, weights(w), x; rng = rng, replace=replace, ordered=ordered)
 
 
@@ -687,8 +686,8 @@ wsample!(a::AbstractArray, w::RealVector, x::AbstractArray;
 Select a weighted random sample of size 1 from `a` with probabilities proportional
 to the weights given in `w`. If `a` is not present, select a random weight from `w`.
 """
-wsample(w::RealVector; rng::AbstractRNG=Base.GLOBAL_RNG) = sample(weights(w); rng = rng)
-wsample(a::AbstractArray, w::RealVector; rng::AbstractRNG=Base.GLOBAL_RNG) = 
+wsample(w::RealVector, rng::AbstractRNG=Base.GLOBAL_RNG) = sample(weights(w); rng = rng)
+wsample(a::AbstractArray, w::RealVector, rng::AbstractRNG=Base.GLOBAL_RNG) = 
     sample(a, weights(w); rng=rng)
 
 
@@ -701,8 +700,8 @@ to the weights given in `w` if `a` is present, otherwise select a random sample 
 replacement and `order` dictates whether an ordered sample, also called a sequential
 sample, should be taken.
 """
-wsample{T}(a::AbstractArray{T}, w::RealVector, n::Integer;
-          rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false) =
+wsample{T}(a::AbstractArray{T}, w::RealVector, n::Integer, rng::AbstractRNG=Base.GLOBAL_RNG;
+          replace::Bool=true, ordered::Bool=false) =
     wsample!(a, w, Vector{T}(n); rng = rng, replace=replace, ordered=ordered)
 
 
@@ -713,7 +712,7 @@ Select a weighted random sample from `a` with probabilities proportional to the
 weights given in `w` if `a` is present, otherwise select a random sample of size
 `n` of the weights given in `w`. The dimensions of the output are given by `dims`.
 """
-wsample{T}(a::AbstractArray{T}, w::RealVector, dims::Dims;
-          rng::AbstractRNG=Base.GLOBAL_RNG, replace::Bool=true, ordered::Bool=false) =
+wsample{T}(a::AbstractArray{T}, w::RealVector, dims::Dims rng::AbstractRNG=Base.GLOBAL_RNG;
+          replace::Bool=true, ordered::Bool=false) =
     wsample!(a, w, Array{T}(dims); rng = rng, replace=replace, ordered=ordered)
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -133,7 +133,8 @@ function fisher_yates_sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArr
     end
     return x
 end
-fisher_yates_sample!(a::AbstractArray, x::AbstractArray) = fisher_yates_sample!(Base.GLOBAL_RNG, a, x)
+fisher_yates_sample!(a::AbstractArray, x::AbstractArray) =
+    fisher_yates_sample!(Base.GLOBAL_RNG, a, x)
 
 # Self-avoid sampling
 #
@@ -167,7 +168,8 @@ function self_avoid_sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray
     end
     return x
 end
-self_avoid_sample!(a::AbstractArray, x::AbstractArray) = self_avoid_sample!(Base.GLOBAL_RNG, a, x)
+self_avoid_sample!(a::AbstractArray, x::AbstractArray) =
+    self_avoid_sample!(Base.GLOBAL_RNG, a, x)
 
 # Random subsequence sampling
 #
@@ -379,7 +381,8 @@ sample(wv::WeightVec) = sample(Base.GLOBAL_RNG, wv)
 sample(rng::AbstractRNG, a::AbstractArray, wv::WeightVec) = a[sample(rng, wv)]
 sample(a::AbstractArray, wv::WeightVec) = sample(Base.GLOBAL_RNG, a, wv)
 
-function direct_sample!(rng::AbstractRNG, a::AbstractArray, wv::WeightVec, x::AbstractArray)
+function direct_sample!(rng::AbstractRNG, a::AbstractArray,
+                        wv::WeightVec, x::AbstractArray)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
     for i = 1:length(x)
@@ -469,7 +472,8 @@ end
 alias_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray) =
     alias_sample!(Base.GLOBAL_RNG, a, wv, x)
 
-function naive_wsample_norep!(rng::AbstractRNG, a::AbstractArray, wv::WeightVec, x::AbstractArray)
+function naive_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
+                              wv::WeightVec, x::AbstractArray)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
     k = length(x)
@@ -504,9 +508,11 @@ naive_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray) =
 #     URL http://www.sciencedirect.com/science/article/pii/S002001900500298X
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
-function efraimidis_a_wsample_norep!(rng::AbstractRNG, a::AbstractArray, wv::WeightVec, x::AbstractArray)
+function efraimidis_a_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
+                                     wv::WeightVec, x::AbstractArray)
     n = length(a)
-    length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
+    length(wv) == n || throw(DimensionMismatch(
+	    "a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
 
     # calculate keys for all items
@@ -534,9 +540,11 @@ efraimidis_a_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray) =
 #     URL http://www.sciencedirect.com/science/article/pii/S002001900500298X
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
-function efraimidis_ares_wsample_norep!(rng::AbstractRNG, a::AbstractArray, wv::WeightVec, x::AbstractArray)
+function efraimidis_ares_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
+                                        wv::WeightVec, x::AbstractArray)
     n = length(a)
-    length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
+    length(wv) == n || throw(DimensionMismatch(
+        "a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
     k > 0 || return x
 
@@ -594,9 +602,11 @@ efraimidis_ares_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray
 #     URL http://www.sciencedirect.com/science/article/pii/S002001900500298X
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
-function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray, wv::WeightVec, x::AbstractArray)
+function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
+                                         wv::WeightVec, x::AbstractArray)
     n = length(a)
-    length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
+    length(wv) == n || throw(DimensionMismatch(
+        "a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
     k > 0 || return x
 
@@ -676,18 +686,21 @@ function sample!(rng::AbstractRNG, a::AbstractArray, wv::WeightVec, x::AbstractA
     end
     return x
 end
-sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray) = sample!(Base.GLOBAL_RNG, a, wv, x)
+sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray) =
+    sample!(Base.GLOBAL_RNG, a, wv, x)
 
 sample{T}(rng::AbstractRNG, a::AbstractArray{T}, wv::WeightVec, n::Integer;
           replace::Bool=true, ordered::Bool=false) =
     sample!(rng, a, wv, Vector{T}(n); replace=replace, ordered=ordered)
-sample(a::AbstractArray, wv::WeightVec, n::Integer; replace::Bool=true, ordered::Bool=false) =
+sample(a::AbstractArray, wv::WeightVec, n::Integer;
+       replace::Bool=true, ordered::Bool=false) =
     sample(Base.GLOBAL_RNG, a, wv, n; replace=replace, ordered=ordered)
 
 sample{T}(rng::AbstractRNG, a::AbstractArray{T}, wv::WeightVec, dims::Dims;
           replace::Bool=true, ordered::Bool=false) =
     sample!(rng, a, wv, Array{T}(dims); replace=replace, ordered=ordered)
-sample(a::AbstractArray, wv::WeightVec, dims::Dims; replace::Bool=true, ordered::Bool=false) =
+sample(a::AbstractArray, wv::WeightVec, dims::Dims;
+       replace::Bool=true, ordered::Bool=false) =
     sample!(Base.GLOBAL_RNG, a, wv, Array{T}(dims); replace=replace, ordered=ordered)
 
 # wsample interface
@@ -731,7 +744,8 @@ sample, should be taken.
 wsample{T}(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, n::Integer;
            replace::Bool=true, ordered::Bool=false) =
     wsample!(rng, a, w, Vector{T}(n); replace=replace, ordered=ordered)
-wsample(a::AbstractArray, w::RealVector, n::Integer; replace::Bool=true, ordered::Bool=false) =
+wsample(a::AbstractArray, w::RealVector, n::Integer;
+        replace::Bool=true, ordered::Bool=false) =
     wsample(Base.GLOBAL_RNG, a, w, n; replace=replace, ordered=ordered)
 
 """
@@ -744,5 +758,6 @@ weights given in `w` if `a` is present, otherwise select a random sample of size
 wsample{T}(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, dims::Dims;
            replace::Bool=true, ordered::Bool=false) =
     wsample!(rng, a, w, Array{T}(dims); replace=replace, ordered=ordered)
-wsample(a::AbstractArray, w::RealVector, dims::Dims; replace::Bool=true, ordered::Bool=false) =
+wsample(a::AbstractArray, w::RealVector, dims::Dims;
+        replace::Bool=true, ordered::Bool=false) =
     wsample(Base.GLOBAL_RNG, a, w, dims; replace=replace, ordered=ordered)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -511,8 +511,7 @@ naive_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray) =
 function efraimidis_a_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
                                      wv::WeightVec, x::AbstractArray)
     n = length(a)
-    length(wv) == n || throw(DimensionMismatch(
-	    "a and wv must be of same length (got $n and $(length(wv)))."))
+    length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
 
     # calculate keys for all items
@@ -543,8 +542,7 @@ efraimidis_a_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray) =
 function efraimidis_ares_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
                                         wv::WeightVec, x::AbstractArray)
     n = length(a)
-    length(wv) == n || throw(DimensionMismatch(
-        "a and wv must be of same length (got $n and $(length(wv)))."))
+    length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
     k > 0 || return x
 
@@ -605,8 +603,7 @@ efraimidis_ares_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray
 function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
                                          wv::WeightVec, x::AbstractArray)
     n = length(a)
-    length(wv) == n || throw(DimensionMismatch(
-        "a and wv must be of same length (got $n and $(length(wv)))."))
+    length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
     k > 0 || return x
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -45,6 +45,9 @@ direct_sample!(a::AbstractArray, x::AbstractArray) = direct_sample!(Base.GLOBAL_
     samplepair([rng], n)
 
 Draw a pair of distinct integers between 1 and `n` without replacement.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 function samplepair(rng::AbstractRNG, n::Int)
     i1 = randi(rng, n)
@@ -57,6 +60,9 @@ samplepair(n::Int) = samplepair(Base.GLOBAL_RNG, n)
     samplepair([rng], a)
 
 Draw a pair of distinct elements from the array `a` without replacement.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 function samplepair(rng::AbstractRNG, a::AbstractArray)
     i1, i2 = samplepair(rng, length(a))
@@ -264,6 +270,9 @@ seqsample_c!(a::AbstractArray, x::AbstractArray) = seqsample_c!(Base.GLOBAL_RNG,
 
 Select a single random element of `a`. Sampling probabilities are proportional to
 the weights given in `wv`, if provided.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 sample(rng::AbstractRNG, a::AbstractArray) = a[randi(rng, length(a))]
 sample(a::AbstractArray) = sample(Base.GLOBAL_RNG, a)
@@ -278,6 +287,9 @@ Sampling probabilities are proportional to the weights given in `wv`,
 if provided. `replace` dictates whether sampling is performed with
 replacement and `order` dictates whether an ordered sample, also called
 a sequential sample, should be taken.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
                  replace::Bool=true, ordered::Bool=false)
@@ -327,6 +339,9 @@ using a polyalgorithm. Sampling probabilities are proportional to the weights
 given in `wv`, if provided. `replace` dictates whether sampling is performed
 with replacement and `order` dictates whether an ordered sample, also called
 a sequential sample, should be taken.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 function sample{T}(rng::AbstractRNG, a::AbstractArray{T}, n::Integer;
                    replace::Bool=true, ordered::Bool=false)
@@ -344,6 +359,9 @@ the dimensions `dims` of the output array. Sampling probabilities are
 proportional to the weights given in `wv`, if provided. `replace` dictates
 whether sampling is performed with replacement and `order` dictates whether
 an ordered sample, also called a sequential sample, should be taken.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 function sample{T}(rng::AbstractRNG, a::AbstractArray{T}, dims::Dims;
                    replace::Bool=true, ordered::Bool=false)
@@ -363,6 +381,9 @@ sample(a::AbstractArray, dims::Dims; replace::Bool=true, ordered::Bool=false) =
 
 Select a single random integer in `1:length(wv)` with probabilities
 proportional to the weights given in `wv`.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 function sample(rng::AbstractRNG, wv::WeightVec)
     t = rand(rng) * sum(wv)
@@ -709,6 +730,9 @@ Select a weighted sample from an array `a` and store the result in `x`. Sampling
 probabilities are proportional to the weights given in `w`. `replace` dictates
 whether sampling is performed with replacement and `order` dictates whether an
 ordered sample, also called a sequential sample, should be taken.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 wsample!(rng::AbstractRNG, a::AbstractArray, w::RealVector, x::AbstractArray;
          replace::Bool=true, ordered::Bool=false) =
@@ -722,6 +746,9 @@ wsample!(a::AbstractArray, w::RealVector, x::AbstractArray;
 
 Select a weighted random sample of size 1 from `a` with probabilities proportional
 to the weights given in `w`. If `a` is not present, select a random weight from `w`.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 wsample(rng::AbstractRNG, w::RealVector) = sample(rng, weights(w))
 wsample(w::RealVector) = wsample(Base.GLOBAL_RNG, w)
@@ -737,6 +764,9 @@ to the weights given in `w` if `a` is present, otherwise select a random sample 
 `n` of the weights given in `w`. `replace` dictates whether sampling is performed with
 replacement and `order` dictates whether an ordered sample, also called a sequential
 sample, should be taken.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 wsample{T}(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, n::Integer;
            replace::Bool=true, ordered::Bool=false) =
@@ -751,6 +781,9 @@ wsample(a::AbstractArray, w::RealVector, n::Integer;
 Select a weighted random sample from `a` with probabilities proportional to the
 weights given in `w` if `a` is present, otherwise select a random sample of size
 `n` of the weights given in `w`. The dimensions of the output are given by `dims`.
+
+Optionally specify a random number generator ``rng`` as the first argument
+(defaults to ``Base.GLOBAL_RNG``).
 """
 wsample{T}(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, dims::Dims;
            replace::Bool=true, ordered::Bool=false) =

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -69,7 +69,7 @@ end
 #   Reference: The Art of Computer Programming, Vol 2, 3.4.2, p.142
 #
 function knuths_sample!(a::AbstractArray, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
-                       initshuffle::Bool=true)
+                        initshuffle::Bool=true)
     n = length(a)
     k = length(x)
     k <= n || error("length(x) should not exceed length(a)")
@@ -317,7 +317,7 @@ with replacement and `order` dictates whether an ordered sample, also called
 a sequential sample, should be taken.
 """
 function sample{T}(a::AbstractArray{T}, n::Integer, rng::AbstractRNG=Base.GLOBAL_RNG;
-                  replace::Bool=true, ordered::Bool=false)
+                   replace::Bool=true, ordered::Bool=false)
     sample!(a, Vector{T}(n), rng; replace=replace, ordered=ordered)
 end
 
@@ -332,7 +332,7 @@ whether sampling is performed with replacement and `order` dictates whether
 an ordered sample, also called a sequential sample, should be taken.
 """
 function sample{T}(a::AbstractArray{T}, dims::Dims, rng::AbstractRNG=Base.GLOBAL_RNG;
-                  replace::Bool=true, ordered::Bool=false)
+                   replace::Bool=true, ordered::Bool=false)
     sample!(a, Array{T}(dims), rng; replace=replace, ordered=ordered)
 end
 
@@ -365,7 +365,7 @@ end
 sample(a::AbstractArray, wv::WeightVec, rng::AbstractRNG=Base.GLOBAL_RNG) = a[sample(wv, rng)]
 
 function direct_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
-                      rng::AbstractRNG=Base.GLOBAL_RNG)
+                        rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
     for i = 1:length(x)
@@ -434,7 +434,7 @@ function make_alias_table!(w::AbstractVector{Float64}, wsum::Float64,
 end
 
 function alias_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
-                     rng::AbstractRNG=Base.GLOBAL_RNG)
+                       rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
 
@@ -453,7 +453,7 @@ function alias_sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
 end
 
 function naive_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
-                            rng::AbstractRNG=Base.GLOBAL_RNG)
+                              rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
     k = length(x)
@@ -487,7 +487,7 @@ end
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
 function efraimidis_a_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
-                                   rng::AbstractRNG=Base.GLOBAL_RNG)
+                                     rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
@@ -516,7 +516,7 @@ end
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
 function efraimidis_ares_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
-                                     rng::AbstractRNG=Base.GLOBAL_RNG)
+                                        rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
@@ -575,7 +575,7 @@ end
 #
 # Instead of keys u^(1/w) where u = random(0,1) keys w/v where v = randexp(1) are used.
 function efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::WeightVec, x::AbstractArray,
-                                      rng::AbstractRNG=Base.GLOBAL_RNG)
+                                         rng::AbstractRNG=Base.GLOBAL_RNG)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
@@ -626,7 +626,7 @@ function efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::WeightVec, x::Abs
 end
 
 function sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
-                replace::Bool=true, ordered::Bool=false)
+                 replace::Bool=true, ordered::Bool=false)
     n = length(a)
     k = length(x)
 
@@ -657,11 +657,11 @@ function sample!(a::AbstractArray, wv::WeightVec, x::AbstractArray, rng::Abstrac
 end
 
 sample{T}(a::AbstractArray{T}, wv::WeightVec, n::Integer, rng::AbstractRNG=Base.GLOBAL_RNG;
-         replace::Bool=true, ordered::Bool=false) =
+          replace::Bool=true, ordered::Bool=false) =
     sample!(a, wv, Vector{T}(n), rng; replace=replace, ordered=ordered)
 
 sample{T}(a::AbstractArray{T}, wv::WeightVec, dims::Dims, rng::AbstractRNG=Base.GLOBAL_RNG;
-         replace::Bool=true, ordered::Bool=false) =
+          replace::Bool=true, ordered::Bool=false) =
     sample!(a, wv, Array{T}(dims), rng; replace=replace, ordered=ordered)
 
 
@@ -676,7 +676,7 @@ whether sampling is performed with replacement and `order` dictates whether an
 ordered sample, also called a sequential sample, should be taken.
 """
 wsample!(a::AbstractArray, w::RealVector, x::AbstractArray, rng::AbstractRNG=Base.GLOBAL_RNG;
-        replace::Bool=true, ordered::Bool=false) =
+         replace::Bool=true, ordered::Bool=false) =
     sample!(a, weights(w), x, rng; replace=replace, ordered=ordered)
 
 
@@ -701,7 +701,7 @@ replacement and `order` dictates whether an ordered sample, also called a sequen
 sample, should be taken.
 """
 wsample{T}(a::AbstractArray{T}, w::RealVector, n::Integer, rng::AbstractRNG=Base.GLOBAL_RNG;
-          replace::Bool=true, ordered::Bool=false) =
+           replace::Bool=true, ordered::Bool=false) =
     wsample!(a, w, Vector{T}(n), rng; replace=replace, ordered=ordered)
 
 
@@ -713,6 +713,6 @@ weights given in `w` if `a` is present, otherwise select a random sample of size
 `n` of the weights given in `w`. The dimensions of the output are given by `dims`.
 """
 wsample{T}(a::AbstractArray{T}, w::RealVector, dims::Dims, rng::AbstractRNG=Base.GLOBAL_RNG;
-          replace::Bool=true, ordered::Bool=false) =
+           replace::Bool=true, ordered::Bool=false) =
     wsample!(a, w, Array{T}(dims), rng; replace=replace, ordered=ordered)
 

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -13,7 +13,7 @@ x = [randi(10) for i = 1:n]
 @test isa(x, Vector{Int})
 @test extrema(x) == (1, 10)
 @test isapprox(proportions(x, 1:10), fill(0.1, 10), atol=5.0e-3)
-@test randi(1000, MersenneTwister(1)) == randi(1000, MersenneTwister(1))
+@test randi(MersenneTwister(1), 1000) == randi(MersenneTwister(1), 1000)
 
 
 x = [randi(3, 12) for i = 1:n]
@@ -59,8 +59,8 @@ check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 a = direct_sample!([11:20;], zeros(Int, n, 3))
 check_sample_wrep(a, (11, 20), 5.0e-3; ordered=false)
 
-@test direct_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) ==
-      direct_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
+@test direct_sample!(MersenneTwister(1), 1:10, zeros(Int, 6)) ==
+      direct_sample!(MersenneTwister(1), 1:10, zeros(Int, 6))
 
 a = sample(3:12, n)
 check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
@@ -71,7 +71,7 @@ check_sample_wrep(a, (3, 12), 5.0e-3; ordered=true)
 a = sample(3:12, 10; ordered=true)
 check_sample_wrep(a, (3, 12), 0; ordered=true)
 
-@test sample(1:10, 10, MersenneTwister(1)) == sample(1:10, 10, MersenneTwister(1))
+@test sample(MersenneTwister(1), 1:10, 10) == sample(MersenneTwister(1), 1:10, 10)
 
 #### sampling pairs
 
@@ -83,7 +83,7 @@ srand(1);
 @test samplepair([3, 4, 2, 6, 8]) === (4, 3)
 @test samplepair([1, 2])          === (1, 2)
 
-@test samplepair(1000, MersenneTwister(1)) == samplepair(1000, MersenneTwister(1))
+@test samplepair(MersenneTwister(1), 1000) == samplepair(MersenneTwister(1), 1000)
 
 #### sample without replacement
 
@@ -125,40 +125,40 @@ for j = 1:size(a,2)
     knuths_sample!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
-@test knuths_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
-      knuths_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
+@test knuths_sample!(MersenneTwister(1), 1:10, zeros(Int, 6)) == 
+      knuths_sample!(MersenneTwister(1), 1:10, zeros(Int, 6))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     fisher_yates_sample!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
-@test fisher_yates_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
-      fisher_yates_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
+@test fisher_yates_sample!(MersenneTwister(1), 1:10, zeros(Int, 6)) == 
+      fisher_yates_sample!(MersenneTwister(1), 1:10, zeros(Int, 6))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     self_avoid_sample!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
-@test self_avoid_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
-      self_avoid_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
+@test self_avoid_sample!(MersenneTwister(1), 1:10, zeros(Int, 6)) == 
+      self_avoid_sample!(MersenneTwister(1), 1:10, zeros(Int, 6))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     seqsample_a!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=true)
-@test seqsample_a!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
-      seqsample_a!(1:10, zeros(Int, 6), MersenneTwister(1))
+@test seqsample_a!(MersenneTwister(1), 1:10, zeros(Int, 6)) == 
+      seqsample_a!(MersenneTwister(1), 1:10, zeros(Int, 6))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     seqsample_c!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=true)
-@test seqsample_c!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
-      seqsample_c!(1:10, zeros(Int, 6), MersenneTwister(1))
+@test seqsample_c!(MersenneTwister(1), 1:10, zeros(Int, 6)) == 
+      seqsample_c!(MersenneTwister(1), 1:10, zeros(Int, 6))
 
 a = sample(3:12, 5; replace=false)
 check_sample_norep(a, (3, 12), 0; ordered=false)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -13,6 +13,7 @@ x = [randi(10) for i = 1:n]
 @test isa(x, Vector{Int})
 @test extrema(x) == (1, 10)
 @test isapprox(proportions(x, 1:10), fill(0.1, 10), atol=5.0e-3)
+@test randi(1000, MersenneTwister(1)) == randi(1000, MersenneTwister(1))
 
 
 x = [randi(3, 12) for i = 1:n]
@@ -58,6 +59,9 @@ check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 a = direct_sample!([11:20;], zeros(Int, n, 3))
 check_sample_wrep(a, (11, 20), 5.0e-3; ordered=false)
 
+@test direct_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) ==
+      direct_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
+
 a = sample(3:12, n)
 check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 
@@ -67,6 +71,7 @@ check_sample_wrep(a, (3, 12), 5.0e-3; ordered=true)
 a = sample(3:12, 10; ordered=true)
 check_sample_wrep(a, (3, 12), 0; ordered=true)
 
+@test sample(1:10, 10, MersenneTwister(1)) == sample(1:10, 10, MersenneTwister(1))
 
 #### sampling pairs
 
@@ -78,6 +83,7 @@ srand(1);
 @test samplepair([3, 4, 2, 6, 8]) === (4, 3)
 @test samplepair([1, 2])          === (1, 2)
 
+@test samplepair(1000, MersenneTwister(1)) == samplepair(1000, MersenneTwister(1))
 
 #### sample without replacement
 
@@ -119,30 +125,40 @@ for j = 1:size(a,2)
     knuths_sample!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
+@test knuths_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
+      knuths_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     fisher_yates_sample!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
+@test fisher_yates_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
+      fisher_yates_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     self_avoid_sample!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
+@test self_avoid_sample!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
+      self_avoid_sample!(1:10, zeros(Int, 6), MersenneTwister(1))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     seqsample_a!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=true)
+@test seqsample_a!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
+      seqsample_a!(1:10, zeros(Int, 6), MersenneTwister(1))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
     seqsample_c!(3:12, view(a,:,j))
 end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=true)
+@test seqsample_c!(1:10, zeros(Int, 6), MersenneTwister(1)) == 
+      seqsample_c!(1:10, zeros(Int, 6), MersenneTwister(1))
 
 a = sample(3:12, 5; replace=false)
 check_sample_norep(a, (3, 12), 0; ordered=false)

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -39,13 +39,13 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 
 a = direct_sample!(4:7, wv, zeros(Int, n, 3))
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
-@test direct_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1)) == 
-      direct_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1))
+@test direct_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000)) == 
+      direct_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000))
 
 a = alias_sample!(4:7, wv, zeros(Int, n, 3))
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
-@test alias_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1)) == 
-      alias_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1))
+@test alias_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000)) == 
+      alias_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000))
 
 a = sample(4:7, wv, n; ordered=false)
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
@@ -87,32 +87,32 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 a = zeros(Int, 3, n)
 for j = 1:n
     naive_wsample_norep!(4:7, wv, view(a,:,j))
-	@test naive_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
-          naive_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
+	@test naive_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
+          naive_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_a_wsample_norep!(4:7, wv, view(a,:,j))
-	@test efraimidis_a_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
-          efraimidis_a_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
+	@test efraimidis_a_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
+          efraimidis_a_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_ares_wsample_norep!(4:7, wv, view(a,:,j))
-	@test efraimidis_ares_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
-          efraimidis_ares_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
+	@test efraimidis_ares_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
+          efraimidis_ares_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_aexpj_wsample_norep!(4:7, wv, view(a,:,j))
-	@test efraimidis_aexpj_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
-          efraimidis_aexpj_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
+	@test efraimidis_aexpj_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
+          efraimidis_aexpj_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -39,13 +39,10 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 
 a = direct_sample!(4:7, wv, zeros(Int, n, 3))
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
-@test direct_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000)) == 
-      direct_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000))
+test_rng_use(direct_sample!, 4:7, wv, zeros(Int, 100))
 
 a = alias_sample!(4:7, wv, zeros(Int, n, 3))
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
-@test alias_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000)) == 
-      alias_sample!(MersenneTwister(1), 4:7, wv, zeros(Int, 10000))
 
 a = sample(4:7, wv, n; ordered=false)
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
@@ -87,34 +84,30 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 a = zeros(Int, 3, n)
 for j = 1:n
     naive_wsample_norep!(4:7, wv, view(a,:,j))
-	@test naive_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
-          naive_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
+test_rng_use(naive_wsample_norep!, 4:7, wv, zeros(Int, 2))
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_a_wsample_norep!(4:7, wv, view(a,:,j))
-	@test efraimidis_a_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
-          efraimidis_a_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
+test_rng_use(efraimidis_a_wsample_norep!, 4:7, wv, zeros(Int, 2))
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_ares_wsample_norep!(4:7, wv, view(a,:,j))
-	@test efraimidis_ares_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
-          efraimidis_ares_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
+test_rng_use(efraimidis_ares_wsample_norep!, 4:7, wv, zeros(Int, 2))
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_aexpj_wsample_norep!(4:7, wv, view(a,:,j))
-	@test efraimidis_aexpj_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2)) == 
-          efraimidis_aexpj_wsample_norep!(MersenneTwister(j), 4:7, wv, zeros(Int, 2))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
+test_rng_use(efraimidis_aexpj_wsample_norep!, 4:7, wv, zeros(Int, 2))
 
 a = sample(4:7, wv, 3; replace=false, ordered=false)
 check_wsample_norep(a, (4, 7), wv, -1; ordered=false)

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -39,9 +39,13 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 
 a = direct_sample!(4:7, wv, zeros(Int, n, 3))
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
+@test direct_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1)) == 
+      direct_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1))
 
 a = alias_sample!(4:7, wv, zeros(Int, n, 3))
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
+@test alias_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1)) == 
+      alias_sample!(4:7, wv, zeros(Int, 10000), MersenneTwister(1))
 
 a = sample(4:7, wv, n; ordered=false)
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
@@ -83,24 +87,32 @@ wv = weights([0.2, 0.8, 0.4, 0.6])
 a = zeros(Int, 3, n)
 for j = 1:n
     naive_wsample_norep!(4:7, wv, view(a,:,j))
+	@test naive_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
+          naive_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_a_wsample_norep!(4:7, wv, view(a,:,j))
+	@test efraimidis_a_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
+          efraimidis_a_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_ares_wsample_norep!(4:7, wv, view(a,:,j))
+	@test efraimidis_ares_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
+          efraimidis_ares_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
 a = zeros(Int, 3, n)
 for j = 1:n
     efraimidis_aexpj_wsample_norep!(4:7, wv, view(a,:,j))
+	@test efraimidis_aexpj_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1)) == 
+          efraimidis_aexpj_wsample_norep!(4:7, wv, zeros(Int, 2), MersenneTwister(1))
 end
 check_wsample_norep(a, (4, 7), wv, 5.0e-3; ordered=false)
 


### PR DESCRIPTION
Addresses #240.

I tried to follow the style already in place in `src/sampling.jl`. Passing the RNG by keyword argument was a bit clearer but seemed to impose a slight performance penaltiy.