### PR TITLE
Move some `describe` code from DataFrames/Tables -> StatsBase

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -554,12 +554,12 @@ end
 
 function Base.show(io::IO, ss::SummaryStats)
     println(io, "Summary Stats:")
-    @printf(io, "Mean:         %.6f\n", ss.mean)
-    @printf(io, "Minimum:      %.6f\n", ss.min)
-    @printf(io, "1st Quartile: %.6f\n", ss.q25)
-    @printf(io, "Median:       %.6f\n", ss.median)
-    @printf(io, "3rd Quartile: %.6f\n", ss.q75)
-    @printf(io, "Maximum:      %.6f\n", ss.max)
+    @printf(io, "Mean:           %.6f\n", ss.mean)
+    @printf(io, "Minimum:        %.6f\n", ss.min)
+    @printf(io, "1st Quartile:   %.6f\n", ss.q25)
+    @printf(io, "Median:         %.6f\n", ss.median)
+    @printf(io, "3rd Quartile:   %.6f\n", ss.q75)
+    @printf(io, "Maximum:        %.6f\n", ss.max)
 end
 
 
@@ -570,4 +570,16 @@ Pretty-print the summary statistics provided by `summarystats`:
 the mean, minimum, 25th percentile, median, 75th percentile, and
 maximum.
 """
-describe{T<:Real}(a::AbstractArray{T}) = show(summarystats(a))
+describe(a::AbstractArray) = describe(STDOUT, a)
+function describe{T<:Real}(io::IO, a::AbstractArray{T})
+    show(io, summarystats(a))
+    println(io, "Length:         $(length(a))")
+    println(io, "Type:           $(string(eltype(a)))")
+end
+function describe(io::IO, a::AbstractArray)
+    println(io, "Summary Stats:")
+    println(io, "Length:         $(length(a))")
+    println(io, "Type:           $(string(eltype(a)))")
+    println(io, "Number Unique:  $(length(unique(a)))")
+    return
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -35,3 +35,25 @@ x = [2, 1, 3, 3, 2]
 x = ["b", "a", "c", "c", "b"]
 @test indicatormat(x) == I
 @test full(indicatormat(x; sparse=true)) == I
+
+io = IOBuffer()
+describe(io, collect(1:10))
+@test String(take!(io)) == """
+                           Summary Stats:
+                           Mean:           5.500000
+                           Minimum:        1.000000
+                           1st Quartile:   3.250000
+                           Median:         5.500000
+                           3rd Quartile:   7.750000
+                           Maximum:        10.000000
+                           Length:         10
+                           Type:           $Int
+                           """
+
+describe(io, fill("s", 3))
+@test String(take!(io)) == """
+                           Summary Stats:
+                           Length:         3
+                           Type:           String
+                           Number Unique:  1
+                           """


### PR DESCRIPTION
DataFrames/Tables both implement their own functionality to extend `describe` and their functions overwrite one another and throw warnings https://github.com/JuliaData/DataTables.jl/issues/33. This moves some of the functionality:
- specify an IO source in `describe`
- return very basic info on non-numeric arrays (length, type, # unique)

to StatsBase. Next steps will be to move DataArrays functionality out of DataFrames and into DataArrays and the same for NullableArrays & DataTables.

This PR does not contain the code to count nulls and compute the % of nulls, which exists in DataFrames/Tables. I'll propose that I add that to this PR, but I thought I'd get feedback on the conservative changes first.

```julia
julia> using StatsBase
INFO: Recompiling stale cache file /Users/Cameron/.julia/lib/v0.6/StatsBase.ji for module StatsBase.

julia> describe(collect(1:10))
Summary Stats:
Mean:         5.500000
Minimum:      1.000000
1st Quartile: 3.250000
Median:       5.500000
3rd Quartile: 7.750000
Maximum:      10.000000

julia> describe(["s", "s", "s"])
Summary Stats:
Length:       3
Type:         String
Unique:       1
```