### PR TITLE
Made `WeightVec` a subtype of `RealVector`

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -1,24 +1,34 @@
 
 ###### Weight vector #####
 
-immutable WeightVec{T, V<:RealVector, S} <: RealVector{T}
-    values::V
-    sum::S
-end
+if VERSION < v"0.6.0-dev.2123"
+    immutable WeightVec{S<:Real, T<:Real, V<:RealVector} <: RealVector{T}
+        values::V
+        sum::S
+    end
 
-"""
-    WeightVec(vs, [wsum])
+    function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S)
+        return WeightVec{S, eltype(vs), V}(vs, s)
+    end
 
-Construct a `WeightVec` with weight values `vs` and sum of weights `wsum`.
-If omitted, `wsum` is computed.
-"""
-function WeightVec{V<:RealVector}(vs::V)
-    sum_ = sum(vs)
-    return WeightVec{eltype(vs), V, typeof(sum_)}(vs, sum_)
-end
+    function WeightVec{V<:RealVector}(vs::V)
+        sum_ = sum(vs)
+        return WeightVec{typeof(sum_), eltype(vs), V}(vs, sum_)
+    end
+else
+    immutable WeightVec{S<:Real, T<:Real, V<:AbstractVector{T}} <: AbstractVector{T}
+        values::V
+        sum::S
+    end
 
-function WeightVec{S, V<:RealVector}(vs::V, s::S)
-    return WeightVec{eltype(vs), V, S}(vs, s)
+    function WeightVec{S<:Real, T<:Real, V<:AbstractVector{T}}(vs::V, s::S)
+        return WeightVec{S, T, V}(vs, s)
+    end
+
+    function WeightVec{T<:Real, V<:AbstractVector{T}}(vs::V)
+        sum_ = sum(vs)
+        return WeightVec{typeof(sum_), T, V}(vs, sum_)
+    end
 end
 
 """

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -1,9 +1,9 @@
 
 ###### Weight vector #####
 
-immutable WeightVec{W,Vec<:RealVector}
-    values::Vec
-    sum::W
+immutable WeightVec{T, V<:RealVector, S} <: RealVector{T}
+    values::V
+    sum::S
 end
 
 """
@@ -12,8 +12,14 @@ end
 Construct a `WeightVec` with weight values `vs` and sum of weights `wsum`.
 If omitted, `wsum` is computed.
 """
-WeightVec{Vec<:RealVector,W<:Real}(vs::Vec,wsum::W) = WeightVec{W,Vec}(vs, wsum)
-WeightVec(vs::RealVector) = WeightVec(vs, sum(vs))
+function WeightVec{V<:RealVector}(vs::V)
+    sum_ = sum(vs)
+    return WeightVec{eltype(vs), V, typeof(sum_)}(vs, sum_)
+end
+
+function WeightVec{S, V<:RealVector}(vs::V, s::S)
+    return WeightVec{eltype(vs), V, S}(vs, s)
+end
 
 """
     weights(vs)
@@ -30,6 +36,7 @@ sum(wv::WeightVec) = wv.sum
 isempty(wv::WeightVec) = isempty(wv.values)
 
 Base.getindex(wv::WeightVec, i) = getindex(wv.values, i)
+Base.size(wv::WeightVec) = size(wv.values)
 
 
 ##### Weighted sum #####
@@ -281,6 +288,9 @@ Base.mean{T<:Number,W<:Real}(A::AbstractArray{T}, w::WeightVec{W}, dim::Int) =
 
 
 ###### Weighted median #####
+function Base.median(v::AbstractArray, w::WeightVec)
+    throw(MethodError(median, (typeof(v), typeof(w))))
+end
 
 function Base.median{W<:Real}(v::RealVector, w::WeightVec{W})
     isempty(v) && error("median of an empty array is undefined")

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -6,29 +6,26 @@ if VERSION < v"0.6.0-dev.2123"
         values::V
         sum::S
     end
-
-    function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S)
-        return WeightVec{S, eltype(vs), V}(vs, s)
-    end
-
-    function WeightVec{V<:RealVector}(vs::V)
-        sum_ = sum(vs)
-        return WeightVec{typeof(sum_), eltype(vs), V}(vs, sum_)
-    end
 else
     immutable WeightVec{S<:Real, T<:Real, V<:AbstractVector{T}} <: AbstractVector{T}
         values::V
         sum::S
     end
+end
 
-    function WeightVec{S<:Real, T<:Real, V<:AbstractVector{T}}(vs::V, s::S)
-        return WeightVec{S, T, V}(vs, s)
-    end
+"""
+    function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S)
 
-    function WeightVec{T<:Real, V<:AbstractVector{T}}(vs::V)
-        sum_ = sum(vs)
-        return WeightVec{typeof(sum_), T, V}(vs, sum_)
-    end
+Construct a `WeightVec` with weight values `vs` and sum of weights `wsum`.
+If omitted, `wsum` is computed.
+"""
+function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S)
+    return WeightVec{S, eltype(vs), V}(vs, s)
+end
+
+function WeightVec{V<:RealVector}(vs::V)
+    s = sum(vs)
+    return WeightVec{typeof(s), eltype(vs), V}(vs, s)
 end
 
 """

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -291,7 +291,7 @@ Base.mean{T<:Number,W<:Real}(A::AbstractArray{T}, w::WeightVec{W}, dim::Int) =
 
 ###### Weighted median #####
 function Base.median(v::AbstractArray, w::WeightVec)
-    throw(MethodError(median, (typeof(v), typeof(w))))
+    throw(MethodError(median, (v, w)))
 end
 
 function Base.median{W<:Real}(v::RealVector, w::WeightVec{W})

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -14,18 +14,13 @@ else
 end
 
 """
-    function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S)
+    WeightVec(vs, [wsum])
 
 Construct a `WeightVec` with weight values `vs` and sum of weights `wsum`.
 If omitted, `wsum` is computed.
 """
-function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S)
+function WeightVec{S<:Real, V<:RealVector}(vs::V, s::S=sum(vs))
     return WeightVec{S, eltype(vs), V}(vs, s)
-end
-
-function WeightVec{V<:RealVector}(vs::V)
-    s = sum(vs)
-    return WeightVec{typeof(s), eltype(vs), V}(vs, s)
 end
 
 """

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -5,10 +5,12 @@ import Compat: view
 
 @test isa(weights([1, 2, 3]), WeightVec{Int})
 @test isa(weights([1., 2., 3.]), WeightVec{Float64})
-
 @test isa(weights([1 2 3; 4 5 6]), WeightVec{Int})
 
+@test isa(WeightVec([1, 2, 3], 6), WeightVec{Int})
+
 @test isempty(weights(Float64[]))
+@test size(weights([1, 2, 3])) == (3,)
 
 w  = [1., 2., 3.]
 wv = weights(w)
@@ -26,6 +28,11 @@ bv = weights(b)
 @test sum(bv)    === 3
 @test !isempty(bv)
 
+ba = BitArray([true, false, true])
+sa = sparsevec([1., 0., 2.])
+
+@test sum(ba, wv) === 4.0
+@test sum(sa, wv) === 7.0
 
 ## wsum
 


### PR DESCRIPTION
Seems like `WeightVec` should support the same functionality as regular vectors.