### PR TITLE
sample call fails with error

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -719,7 +719,7 @@ sample{T}(rng::AbstractRNG, a::AbstractArray{T}, wv::AbstractWeights, dims::Dims
     sample!(rng, a, wv, Array{T}(dims); replace=replace, ordered=ordered)
 sample(a::AbstractArray, wv::AbstractWeights, dims::Dims;
        replace::Bool=true, ordered::Bool=false) =
-    sample!(Base.GLOBAL_RNG, a, wv, Array{T}(dims); replace=replace, ordered=ordered)
+    sample(Base.GLOBAL_RNG, a, wv, dims; replace=replace, ordered=ordered)
 
 # wsample interface
 

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -208,3 +208,10 @@ x = vcat([sample(a, wv, 4, replace=false) for j in 1:10000]...)
 
 wv = Weights([zeros(5); 1:4; -1])
 @test_throws ErrorException sample(a, wv, 1, replace=false)
+
+#### weighted sampling with dimension
+srand(1);
+
+@test sample([1, 2], Weights([1, 1]), (2,2)) == ones(2,2)
+@test sample([1, 2], Weights([0, 1]), (2,2)) == [2 2 ; 2 2]
+@test sample(collect(1:4), Weights(1:4), (2,2), replace=false) == [4 1; 3 2]


### PR DESCRIPTION
Since v0.15.0 was released sample doesn't seem to work any longer, e.g.:

```julia
sample([1.0,2.0], WeightVec([0.5,0.5]), (2, 1))
```

Fails with an error at line 722 of src/sampling.jl. There seemed to be a couple of problems and I have fixed this to match the lines above and it now works.