### PR TITLE
Also set target when deploying Documenter manual

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,7 @@ makedocs(
 
 deploydocs(
     repo = "github.com/JuliaStats/StatsBase.jl.git",
+    target = "build",
     julia  = "0.6",
     deps   = nothing,
     make   = nothing


### PR DESCRIPTION
Without this doc files are not committed.