### PR TITLE
Updates for Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.5
-Compat 0.18.0
+julia 0.6
 DataStructures 0.5.0
 SpecialFunctions 0.1.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/perf/sampling.jl
+++ b/perf/sampling.jl
@@ -3,7 +3,6 @@
 # require the BenchmarkLite package
 using BenchmarkLite
 using StatsBase
-using Compat
 
 import StatsBase: direct_sample!, xmultinom_sample!
 import StatsBase: knuths_sample!, fisher_yates_sample!, self_avoid_sample!
@@ -11,55 +10,55 @@ import StatsBase: seqsample_a!, seqsample_c!
 
 ### generic sampling benchmarking
 
-type SampleProc{Alg} <: Proc end
+mutable struct SampleProc{Alg} <: Proc end
 
-@compat abstract type WithRep end
-@compat abstract type NoRep end
+abstract type WithRep end
+abstract type NoRep end
 
-type Direct <: WithRep end
+mutable struct Direct <: WithRep end
 tsample!(s::Direct, a, x) = direct_sample!(a, x)
 
-type Xmultinom <: WithRep end
+mutable struct Xmultinom <: WithRep end
 tsample!(s::Xmultinom, a, x) = xmultinom_sample!(a, x)
 
-type Sample_WRep <: WithRep end
+mutable struct Sample_WRep <: WithRep end
 tsample!(s::Sample_WRep, a, x) = sample!(a, x; replace=true, ordered=false)
 
-type Sample_WRep_Ord <: WithRep end
+mutable struct Sample_WRep_Ord <: WithRep end
 tsample!(s::Sample_WRep_Ord, a, x) = sample!(a, x; replace=true, ordered=true)
 
-type Knuths <: NoRep end
+mutable struct Knuths <: NoRep end
 tsample!(s::Knuths, a, x) = knuths_sample!(a, x)
 
-type Fisher_Yates <: NoRep end
+mutable struct Fisher_Yates <: NoRep end
 tsample!(s::Fisher_Yates, a, x) = fisher_yates_sample!(a, x)
 
-type Self_Avoid <: NoRep end
+mutable struct Self_Avoid <: NoRep end
 tsample!(s::Self_Avoid, a, x) = self_avoid_sample!(a, x)
 
-type Seq_A <: NoRep end
+mutable struct Seq_A <: NoRep end
 tsample!(s::Seq_A, a, x) = seqsample_a!(a, x)
 
-type Seq_C <: NoRep end
+mutable struct Seq_C <: NoRep end
 tsample!(s::Seq_C, a, x) = seqsample_c!(a, x)
 
-type Sample_NoRep <: NoRep end
+mutable struct Sample_NoRep <: NoRep end
 tsample!(s::Sample_NoRep, a, x) = sample!(a, x; replace=false, ordered=false)
 
-type Sample_NoRep_Ord <: NoRep end
+mutable struct Sample_NoRep_Ord <: NoRep end
 tsample!(s::Sample_NoRep_Ord, a, x) = sample!(a, x; replace=false, ordered=true)
 
 
 # config is in the form of (n, k)
 
-Base.string{Alg}(p::SampleProc{Alg}) = lowercase(string(Alg))
+Base.string(p::SampleProc{Alg}) where {Alg} = lowercase(string(Alg))
 
-Base.length(p::SampleProc, cfg::(Int, Int)) = cfg[2]
-Base.isvalid{Alg<:WithRep}(p::SampleProc{Alg}, cfg::(Int, Int)) = ((n, k) = cfg; n >= 1 && k >= 1)
-Base.isvalid{Alg<:NoRep}(p::SampleProc{Alg}, cfg::(Int, Int)) = ((n, k) = cfg; n >= k >= 1)
+Base.length(p::SampleProc, cfg::Tuple{Int,Int}) = cfg[2]
+Base.isvalid(p::SampleProc{<:WithRep}, cfg::Tuple{Int,Int}) = ((n, k) = cfg; n >= 1 && k >= 1)
+Base.isvalid(p::SampleProc{<:NoRep}, cfg::Tuple{Int,Int}) = ((n, k) = cfg; n >= k >= 1)
 
-Base.start(p::SampleProc, cfg::(Int, Int)) = Vector{Int}(cfg[2])
-Base.run{Alg}(p::SampleProc{Alg}, cfg::(Int, Int), s::Vector{Int}) = tsample!(Alg(), 1:cfg[1], s)
+Base.start(p::SampleProc, cfg::Tuple{Int,Int}) = Vector{Int}(cfg[2])
+Base.run(p::SampleProc{Alg}, cfg::Tuple{Int,Int}, s::Vector{Int}) where {Alg} = tsample!(Alg(), 1:cfg[1], s)
 Base.done(p::SampleProc, cfg, s) = nothing
 
 
@@ -70,9 +69,9 @@ const ks = 2 .^ [1:16]
 
 ## with replacement
 
-const procs1 = Proc[ SampleProc{Direct}(), 
+const procs1 = Proc[ SampleProc{Direct}(),
                      SampleProc{Sample_WRep}(),
-                     SampleProc{Xmultinom}(), 
+                     SampleProc{Xmultinom}(),
                      SampleProc{Sample_WRep_Ord}() ]
 
 const cfgs1 = vec([(n, k) for k in ks, n in ns])
@@ -82,7 +81,7 @@ println()
 
 ## without replacement
 
-const procs2 = Proc[ SampleProc{Knuths}(), 
+const procs2 = Proc[ SampleProc{Knuths}(),
                      SampleProc{Fisher_Yates}(),
                      SampleProc{Self_Avoid}(),
                      SampleProc{Sample_NoRep}(),

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -1,9 +1,6 @@
 __precompile__()
 
 module StatsBase
-    using Compat
-    import Compat: String, view
-
     import Base: length, isempty, eltype, values, sum, mean, mean!, show, quantile
     import Base: rand, rand!
     import Base.LinAlg: BlasReal, BlasFloat

--- a/src/common.jl
+++ b/src/common.jl
@@ -10,25 +10,25 @@
 # covariant type notation, i.e. AbstractVector{<:Real}
 #
 
-@compat RealArray{T<:Real,N} = AbstractArray{T,N}
-@compat RealVector{T<:Real} = AbstractArray{T,1}
-@compat RealMatrix{T<:Real} = AbstractArray{T,2}
+const RealArray{T<:Real,N} = AbstractArray{T,N}
+const RealVector{T<:Real} = AbstractArray{T,1}
+const RealMatrix{T<:Real} = AbstractArray{T,2}
 
-@compat IntegerArray{T<:Integer,N} = AbstractArray{T,N}
-@compat IntegerVector{T<:Integer} = AbstractArray{T,1}
-@compat IntegerMatrix{T<:Integer} = AbstractArray{T,2}
+const IntegerArray{T<:Integer,N} = AbstractArray{T,N}
+const IntegerVector{T<:Integer} = AbstractArray{T,1}
+const IntegerMatrix{T<:Integer} = AbstractArray{T,2}
 
-@compat const RealFP = Union{Float32, Float64}
+const RealFP = Union{Float32, Float64}
 
 ## conversion from real to fp types
 
-@compat fptype{T<:Union{Float32,Bool,Int8,UInt8,Int16,UInt16}}(::Type{T}) = Float32
-@compat fptype{T<:Union{Float64,Int32,UInt32,Int64,UInt64,Int128,UInt128}}(::Type{T}) = Float64
+fptype{T<:Union{Float32,Bool,Int8,UInt8,Int16,UInt16}}(::Type{T}) = Float32
+fptype{T<:Union{Float64,Int32,UInt32,Int64,UInt64,Int128,UInt128}}(::Type{T}) = Float64
 fptype(::Type{Complex64}) = Complex64
 fptype(::Type{Complex128}) = Complex128
 
 # A convenient typealias for deprecating default corrected Bool
-@compat const DepBool = Union{Bool, Void}
+const DepBool = Union{Bool, Void}
 
 function depcheck(fname::Symbol, b::DepBool)
     if b == nothing

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -6,7 +6,7 @@
 #
 #################################################
 
-@compat IntUnitRange{T<:Integer} = UnitRange{T}
+const IntUnitRange{T<:Integer} = UnitRange{T}
 
 #### functions for counting a single list of integers (1D)
 """
@@ -219,7 +219,7 @@ proportions(x::IntegerArray, y::IntegerArray, wv::AbstractWeights) =
 
 ## auxiliary functions
 
-function _normalize_countmap{T}(cm::Dict{T}, s::Real)
+function _normalize_countmap(cm::Dict{T}, s::Real) where T
     r = Dict{T,Float64}()
     for (k, c) in cm
         r[k] = c / s
@@ -237,14 +237,14 @@ Add counts based on `x` to a count map. New entries will be added if new values 
 If a weighting vector `wv` is specified, the sum of the weights is used rather than the
 raw counts.
 """
-function addcounts!{T}(cm::Dict{T}, x::AbstractArray{T})
+function addcounts!(cm::Dict{T}, x::AbstractArray{T}) where T
     for v in x
         cm[v] = get(cm, v, 0) + 1
     end
     return cm
 end
 
-function addcounts!{T,W}(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractWeights{W})
+function addcounts!(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractWeights{W}) where {T,W}
     n = length(x)
     length(wv) == n || throw(DimensionMismatch())
     w = values(wv)
@@ -265,8 +265,8 @@ end
 Return a dictionary mapping each unique value in `x` to its number
 of occurrences.
 """
-countmap{T}(x::AbstractArray{T}) = addcounts!(Dict{T,Int}(), x)
-countmap{T,W}(x::AbstractArray{T}, wv::AbstractWeights{W}) = addcounts!(Dict{T,W}(), x, wv)
+countmap(x::AbstractArray{T}) where {T} = addcounts!(Dict{T,Int}(), x)
+countmap(x::AbstractArray{T}, wv::AbstractWeights{W}) where {T,W} = addcounts!(Dict{T,W}(), x, wv)
 
 
 """

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -25,7 +25,7 @@ import Base.varm, Base.stdm
 @deprecate adjR2(obj::StatisticalModel, variant::Symbol) adjr2(obj, variant)
 @deprecate adjR²(obj::StatisticalModel, variant::Symbol) adjr²(obj, variant)
 
-function findat!{T}(r::IntegerArray, a::AbstractArray{T}, b::AbstractArray{T})
+function findat!(r::IntegerArray, a::AbstractArray{T}, b::AbstractArray{T}) where T
     Base.depwarn("findat! is deprecated, use indexin instead", :findat!)
     length(r) == length(b) || raise_dimerror()
     d = indexmap(a)
@@ -49,7 +49,7 @@ findat(a::AbstractArray, b::AbstractArray) = findat!(Array{Int}(size(b)), a, b)
 
 @deprecate_binding WeightVec Weights
 
-immutable RandIntSampler  # for generating Int samples in [0, K-1]
+struct RandIntSampler  # for generating Int samples in [0, K-1]
     a::Int
     Ku::UInt
     U::UInt

--- a/src/deviation.jl
+++ b/src/deviation.jl
@@ -46,7 +46,7 @@ end
 Compute the squared L2 distance between two arrays: ``\\sum_{i=1}^n |a_i - b_i|^2``.
 Efficient equivalent of `sumabs2(a - b)`.
 """
-function sqL2dist{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T})
+function sqL2dist(a::AbstractArray{T}, b::AbstractArray{T}) where T<:Number
     n = length(a)
     length(b) == n || throw(DimensionMismatch("Input dimension mismatch"))
     r = 0.0
@@ -64,7 +64,7 @@ end
 Compute the L2 distance between two arrays: ``\\sqrt{\\sum_{i=1}^n |a_i - b_i|^2}``.
 Efficient equivalent of `sqrt(sumabs2(a - b))`.
 """
-L2dist{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = sqrt(sqL2dist(a, b))
+L2dist(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = sqrt(sqL2dist(a, b))
 
 
 # L1 distance
@@ -74,7 +74,7 @@ L2dist{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = sqrt(sqL2dist(a, b
 Compute the L1 distance between two arrays: ``\\sum_{i=1}^n |a_i - b_i|``.
 Efficient equivalent of `sum(abs, a - b)`.
 """
-function L1dist{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T})
+function L1dist(a::AbstractArray{T}, b::AbstractArray{T}) where T<:Number
     n = length(a)
     length(b) == n || throw(DimensionMismatch("Input dimension mismatch"))
     r = 0.0
@@ -93,7 +93,7 @@ Compute the L∞ distance, also called the Chebyshev distance, between
 two arrays: ``\\max_{i\\in1:n} |a_i - b_i|``.
 Efficient equivalent of `maxabs(a - b)`.
 """
-function Linfdist{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T})
+function Linfdist(a::AbstractArray{T}, b::AbstractArray{T}) where T<:Number
     n = length(a)
     length(b) == n || throw(DimensionMismatch("Input dimension mismatch"))
     r = 0.0
@@ -115,7 +115,7 @@ Compute the generalized Kullback-Leibler divergence between two arrays:
 ``\\sum_{i=1}^n (a_i \\log(a_i/b_i) - a_i + b_i)``.
 Efficient equivalent of `sum(a*log(a/b)-a+b)`.
 """
-function gkldiv{T<:AbstractFloat}(a::AbstractArray{T}, b::AbstractArray{T})
+function gkldiv(a::AbstractArray{T}, b::AbstractArray{T}) where T<:AbstractFloat
     n = length(a)
     r = 0.0
     for i = 1:n
@@ -137,7 +137,7 @@ end
 
 Return the mean absolute deviation between two arrays: `mean(abs(a - b))`.
 """
-meanad{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = L1dist(a, b) / length(a)
+meanad(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = L1dist(a, b) / length(a)
 
 
 # MaxAD: maximum absolute deviation
@@ -146,7 +146,7 @@ meanad{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = L1dist(a, b) / len
 
 Return the maximum absolute deviation between two arrays: `maxabs(a - b)`.
 """
-maxad{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = Linfdist(a, b)
+maxad(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = Linfdist(a, b)
 
 
 # MSD: mean squared deviation
@@ -155,7 +155,7 @@ maxad{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = Linfdist(a, b)
 
 Return the mean squared deviation between two arrays: `mean(abs2(a - b))`.
 """
-msd{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}) = sqL2dist(a, b) / length(a)
+msd(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = sqL2dist(a, b) / length(a)
 
 
 # RMSD: root mean squared deviation
@@ -166,7 +166,7 @@ Return the root mean squared deviation between two optionally
 normalized arrays. The root mean squared deviation is computed
 as `sqrt(msd(a, b))`.
 """
-function rmsd{T<:Number}(a::AbstractArray{T}, b::AbstractArray{T}; normalize::Bool=false)
+function rmsd(a::AbstractArray{T}, b::AbstractArray{T}; normalize::Bool=false) where T<:Number
     v = sqrt(msd(a, b))
     if normalize
         amin, amax = extrema(a)
@@ -184,6 +184,6 @@ Compute the peak signal-to-noise ratio between two arrays `a` and `b`.
 `maxv` is the maximum possible value either array can take. The PSNR
 is computed as `10 * log10(maxv^2 / msd(a, b))`.
 """
-function psnr{T<:Real}(a::AbstractArray{T}, b::AbstractArray{T}, maxv::Real)
+function psnr(a::AbstractArray{T}, b::AbstractArray{T}, maxv::Real) where T<:Real
     20. * log10(maxv) - 10. * log10(msd(a, b))
 end

--- a/src/deviation.jl
+++ b/src/deviation.jl
@@ -137,7 +137,8 @@ end
 
 Return the mean absolute deviation between two arrays: `mean(abs(a - b))`.
 """
-meanad(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = L1dist(a, b) / length(a)
+meanad(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} =
+    L1dist(a, b) / length(a)
 
 
 # MaxAD: maximum absolute deviation
@@ -155,7 +156,8 @@ maxad(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = Linfdist(a, 
 
 Return the mean squared deviation between two arrays: `mean(abs2(a - b))`.
 """
-msd(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = sqL2dist(a, b) / length(a)
+msd(a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} =
+    sqL2dist(a, b) / length(a)
 
 
 # RMSD: root mean squared deviation

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -11,7 +11,7 @@ given in `X`.
 Note: this is a higher-level function that returns a function, which can then be applied
 to evaluate CDF values on other samples.
 """
-function ecdf{T<:Real}(X::RealVector{T})
+function ecdf(X::RealVector{T}) where T<:Real
     Xs = sort(X)
     n = length(X)
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -149,13 +149,16 @@ mutable struct Histogram{T<:Real,N,E} <: AbstractHistogram{T,N,E}
     end
 end
 
-Histogram(edges::NTuple{N,AbstractVector},weights::AbstractArray{T,N},closed::Symbol=:default_left, isdensity::Bool=false) where {T,N} =
+Histogram(edges::NTuple{N,AbstractVector}, weights::AbstractArray{T,N},
+          closed::Symbol=:default_left, isdensity::Bool=false) where {T,N} =
     Histogram{T,N,typeof(edges)}(edges,weights,_check_closed_arg(closed,:Histogram),isdensity)
 
-Histogram(edges::NTuple{N,AbstractVector},::Type{T},closed::Symbol=:default_left, isdensity::Bool=false) where {T,N} =
+Histogram(edges::NTuple{N,AbstractVector}, ::Type{T}, closed::Symbol=:default_left,
+          isdensity::Bool=false) where {T,N} =
     Histogram(edges,zeros(T,_edges_nbins(edges)...),_check_closed_arg(closed,:Histogram),isdensity)
 
-Histogram(edges::NTuple{N,AbstractVector},closed::Symbol=:default_left, isdensity::Bool=false) where {N} =
+Histogram(edges::NTuple{N,AbstractVector}, closed::Symbol=:default_left,
+          isdensity::Bool=false) where {N} =
     Histogram(edges,Int,_check_closed_arg(closed,:Histogram),isdensity)
 
 function show(io::IO, h::AbstractHistogram)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -29,7 +29,7 @@ julia> rle([1,1,1,2,2,3,3,3,3,2,2,2])
 ([1, 2, 3, 2], [3, 2, 4, 3])
 ```
 """
-function rle{T}(v::Vector{T})
+function rle(v::Vector{T}) where T
     n = length(v)
     vals = T[]
     lens = Int[]
@@ -68,7 +68,7 @@ Reconstruct a vector from its run-length encoding (see [`rle`](@ref)).
 `vals` is a vector of the values and `lens` is a vector of the corresponding
 run lengths.
 """
-function inverse_rle{T}(vals::AbstractVector{T}, lens::IntegerVector)
+function inverse_rle(vals::AbstractVector{T}, lens::IntegerVector) where T
     m = length(vals)
     length(lens) == m || raise_dimerror()
 
@@ -92,7 +92,7 @@ end
 Construct a dictionary that maps each unique value in `a` to
 the index of its first occurrence in `a`.
 """
-function indexmap{T}(a::AbstractArray{T})
+function indexmap(a::AbstractArray{T}) where T
     d = Dict{T,Int}()
     for i = 1 : length(a)
         @inbounds k = a[i]
@@ -110,7 +110,7 @@ end
 Construct a dictionary that maps each of the `n` unique values
 in `a` to a number between 1 and `n`.
 """
-function levelsmap{T}(a::AbstractArray{T})
+function levelsmap(a::AbstractArray{T}) where T
     d = Dict{T,Int}()
     index = 1
     for i = 1 : length(a)
@@ -171,7 +171,7 @@ function _indicatormat_dense(x::IntegerArray, k::Integer)
     return r
 end
 
-function _indicatormat_dense{T}(x::AbstractArray{T}, c::AbstractArray{T})
+function _indicatormat_dense(x::AbstractArray{T}, c::AbstractArray{T}) where T
     d = indexmap(c)
     m = length(c)
     n = length(x)
@@ -187,7 +187,7 @@ end
 
 _indicatormat_sparse(x::IntegerArray, k::Integer) = (n = length(x); sparse(x, 1:n, true, k, n))
 
-function _indicatormat_sparse{T}(x::AbstractArray{T}, c::AbstractArray{T})
+function _indicatormat_sparse(x::AbstractArray{T}, c::AbstractArray{T}) where T
     d = indexmap(c)
     m = length(c)
     n = length(x)

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -85,27 +85,15 @@ end
 function Base.varm(A::RealArray, w::AbstractWeights, M::RealArray, dim::Int;
                    corrected::DepBool=nothing)
     corrected = depcheck(:varm, corrected)
-
-    @static if VERSION < v"0.6.0-dev.1121"
-        Base.varm!(similar(A, Float64, Base.reduced_dims(size(A), dim)), A, w, M, dim;
-                   corrected=corrected)
-    else
-        Base.varm!(similar(A, Float64, Base.reduced_indices(indices(A), dim)), A, w, M,
-                   dim; corrected=corrected)
-    end
+    Base.varm!(similar(A, Float64, Base.reduced_indices(indices(A), dim)), A, w, M,
+               dim; corrected=corrected)
 end
 
 function Base.var(A::RealArray, w::AbstractWeights, dim::Int; mean=nothing,
                   corrected::DepBool=nothing)
     corrected = depcheck(:var, corrected)
-
-    @static if VERSION < v"0.6.0-dev.1121"
-        var!(similar(A, Float64, Base.reduced_dims(size(A), dim)), A, w, dim; mean=mean,
-             corrected=corrected)
-    else
-        var!(similar(A, Float64, Base.reduced_indices(indices(A), dim)), A, w, dim;
-             mean=mean, corrected=corrected)
-    end
+    var!(similar(A, Float64, Base.reduced_indices(indices(A), dim)), A, w, dim;
+         mean=mean, corrected=corrected)
 end
 
 ## std

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -368,8 +368,8 @@ a sequential sample, should be taken.
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Base.GLOBAL_RNG`).
 """
-function sample{T}(rng::AbstractRNG, a::AbstractArray{T}, n::Integer;
-                   replace::Bool=true, ordered::Bool=false)
+function sample(rng::AbstractRNG, a::AbstractArray{T}, n::Integer;
+                replace::Bool=true, ordered::Bool=false) where T
     sample!(rng, a, Vector{T}(n); replace=replace, ordered=ordered)
 end
 sample(a::AbstractArray, n::Integer; replace::Bool=true, ordered::Bool=false) =
@@ -388,8 +388,8 @@ an ordered sample, also called a sequential sample, should be taken.
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Base.GLOBAL_RNG`).
 """
-function sample{T}(rng::AbstractRNG, a::AbstractArray{T}, dims::Dims;
-                   replace::Bool=true, ordered::Bool=false)
+function sample(rng::AbstractRNG, a::AbstractArray{T}, dims::Dims;
+                replace::Bool=true, ordered::Bool=false) where T
     sample!(rng, a, Array{T}(dims), rng; replace=replace, ordered=ordered)
 end
 sample(a::AbstractArray, dims::Dims; replace::Bool=true, ordered::Bool=false) =
@@ -780,15 +780,15 @@ end
 sample!(a::AbstractArray, wv::AbstractWeights, x::AbstractArray) =
     sample!(Base.GLOBAL_RNG, a, wv, x)
 
-sample{T}(rng::AbstractRNG, a::AbstractArray{T}, wv::AbstractWeights, n::Integer;
-          replace::Bool=true, ordered::Bool=false) =
+sample(rng::AbstractRNG, a::AbstractArray{T}, wv::AbstractWeights, n::Integer;
+       replace::Bool=true, ordered::Bool=false) where {T} =
     sample!(rng, a, wv, Vector{T}(n); replace=replace, ordered=ordered)
 sample(a::AbstractArray, wv::AbstractWeights, n::Integer;
        replace::Bool=true, ordered::Bool=false) =
     sample(Base.GLOBAL_RNG, a, wv, n; replace=replace, ordered=ordered)
 
-sample{T}(rng::AbstractRNG, a::AbstractArray{T}, wv::AbstractWeights, dims::Dims;
-          replace::Bool=true, ordered::Bool=false) =
+sample(rng::AbstractRNG, a::AbstractArray{T}, wv::AbstractWeights, dims::Dims;
+       replace::Bool=true, ordered::Bool=false) where {T} =
     sample!(rng, a, wv, Array{T}(dims); replace=replace, ordered=ordered)
 sample(a::AbstractArray, wv::AbstractWeights, dims::Dims;
        replace::Bool=true, ordered::Bool=false) =
@@ -841,8 +841,8 @@ sample, should be taken.
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Base.GLOBAL_RNG`).
 """
-wsample{T}(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, n::Integer;
-           replace::Bool=true, ordered::Bool=false) =
+wsample(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, n::Integer;
+        replace::Bool=true, ordered::Bool=false) where {T} =
     wsample!(rng, a, w, Vector{T}(n); replace=replace, ordered=ordered)
 wsample(a::AbstractArray, w::RealVector, n::Integer;
         replace::Bool=true, ordered::Bool=false) =
@@ -858,8 +858,8 @@ weights given in `w` if `a` is present, otherwise select a random sample of size
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Base.GLOBAL_RNG`).
 """
-wsample{T}(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, dims::Dims;
-           replace::Bool=true, ordered::Bool=false) =
+wsample(rng::AbstractRNG, a::AbstractArray{T}, w::RealVector, dims::Dims;
+        replace::Bool=true, ordered::Bool=false) where {T} =
     wsample!(rng, a, w, Array{T}(dims); replace=replace, ordered=ordered)
 wsample(a::AbstractArray, w::RealVector, dims::Dims;
         replace::Bool=true, ordered::Bool=false) =

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -67,7 +67,7 @@ Return the mode (most common number) of an array, optionally
 over a specified range `r`. If several modes exist, the first
 one (in order of appearance) is returned.
 """
-function mode{T<:Integer}(a::AbstractArray{T}, r::UnitRange{T})
+function mode(a::AbstractArray{T}, r::UnitRange{T}) where T<:Integer
     isempty(a) && error("mode: input array cannot be empty.")
     len = length(a)
     r0 = r[1]
@@ -94,7 +94,7 @@ end
 Return all modes (most common numbers) of an array, optionally over a
 specified range `r`.
 """
-function modes{T<:Integer}(a::AbstractArray{T}, r::UnitRange{T})
+function modes(a::AbstractArray{T}, r::UnitRange{T}) where T<:Integer
     r0 = r[1]
     r1 = r[end]
     n = length(r)
@@ -121,7 +121,7 @@ function modes{T<:Integer}(a::AbstractArray{T}, r::UnitRange{T})
 end
 
 # compute mode over arbitrary array
-function mode{T}(a::AbstractArray{T})
+function mode(a::AbstractArray{T}) where T
     isempty(a) && error("mode: input array cannot be empty.")
     cnts = Dict{T,Int}()
     # first element
@@ -145,7 +145,7 @@ function mode{T}(a::AbstractArray{T})
     return mv
 end
 
-function modes{T}(a::AbstractArray{T})
+function modes(a::AbstractArray{T}) where T
     isempty(a) && error("modes: input array cannot be empty.")
     cnts = Dict{T,Int}()
     # first element
@@ -186,9 +186,9 @@ end
 
 Return the `p`th percentile of a real-valued array `v`, i.e. `quantile(x, p / 100)`.
 """
-percentile{T<:Real}(v::AbstractArray{T}, p) = quantile(v, p * 0.01)
+percentile(v::AbstractArray{<:Real}, p) = quantile(v, p * 0.01)
 
-quantile{T<:Real}(v::AbstractArray{T}) = quantile(v, [.0, .25, .5, .75, 1.0])
+quantile(v::AbstractArray{<:Real}) = quantile(v, [.0, .25, .5, .75, 1.0])
 
 """
     nquantile(v, n)
@@ -199,7 +199,7 @@ partition `v` into `n` subsets of nearly equal size.
 Equivalent to `quantile(v, [0:n]/n)`. For example, `nquantiles(x, 5)`
 returns a vector of quantiles, respectively at `[0.0, 0.2, 0.4, 0.6, 0.8, 1.0]`.
 """
-nquantile{T<:Real}(v::AbstractArray{T}, n::Integer) = quantile(v, (0:n)/n)
+nquantile(v::AbstractArray{<:Real}, n::Integer) = quantile(v, (0:n)/n)
 
 
 #############################
@@ -215,7 +215,7 @@ nquantile{T<:Real}(v::AbstractArray{T}, n::Integer) = quantile(v, (0:n)/n)
 Return the span of an integer array, i.e. the range `minimum(x):maximum(x)`.
 The minimum and maximum of `x` are computed in one-pass using `extrema`.
 """
-span{T<:Integer}(x::AbstractArray{T}) = ((a, b) = extrema(x); a:b)
+span(x::AbstractArray{<:Integer}) = ((a, b) = extrema(x); a:b)
 
 # Variation coefficient: std / mean
 """
@@ -225,8 +225,8 @@ Return the coefficient of variation of an array `x`, optionally specifying
 a precomputed mean `m`. The coefficient of variation is the ratio of the
 standard deviation to the mean.
 """
-variation{T<:Real}(x::AbstractArray{T}, m::Real) = stdm(x, m) / m
-variation{T<:Real}(x::AbstractArray{T}) = variation(x, mean(x))
+variation(x::AbstractArray{<:Real}, m::Real) = stdm(x, m) / m
+variation(x::AbstractArray{<:Real}) = variation(x, mean(x))
 
 # Standard error of the mean: std(a) / sqrt(len)
 """
@@ -234,7 +234,7 @@ variation{T<:Real}(x::AbstractArray{T}) = variation(x, mean(x))
 
 Return the standard error of the mean of `a`, i.e. `sqrt(var(a) / length(a))`.
 """
-sem{T<:Real}(a::AbstractArray{T}) = sqrt(var(a) / length(a))
+sem(a::AbstractArray{<:Real}) = sqrt(var(a) / length(a))
 
 # Median absolute deviation
 """
@@ -242,7 +242,7 @@ sem{T<:Real}(a::AbstractArray{T}) = sqrt(var(a) / length(a))
 
 Compute the median absolute deviation of `v`.
 """
-function mad{T<:Real}(v::AbstractArray{T})
+function mad(v::AbstractArray{T}) where T<:Real
     isempty(v) && throw(ArgumentError("mad is not defined for empty arrays"))
 
     S = promote_type(T, typeof(middle(first(v))))
@@ -260,8 +260,8 @@ of the standard deviation requires a scaling factor that depends on the underlyi
 distribution. For normally distributed data, `k` is chosen as
 `1 / quantile(Normal(), 3/4) ≈ 1.4826`, which is used as the default here.
 """
-function mad!{T<:Real}(v::AbstractArray{T}, center::Real=median!(v);
-                       constant::Real = 1 / (-sqrt(2 * one(T)) * erfcinv(3 * one(T) / 2)))
+function mad!(v::AbstractArray{T}, center::Real=median!(v);
+              constant::Real = 1 / (-sqrt(2 * one(T)) * erfcinv(3 * one(T) / 2))) where T<:Real
     for i in 1:length(v)
         @inbounds v[i] = abs(v[i]-center)
     end
@@ -275,7 +275,7 @@ end
 Compute the interquartile range (IQR) of an array, i.e. the 75th percentile
 minus the 25th percentile.
 """
-iqr{T<:Real}(v::AbstractArray{T}) = (q = quantile(v, [.25, .75]); q[2] - q[1])
+iqr(v::AbstractArray{<:Real}) = (q = quantile(v, [.25, .75]); q[2] - q[1])
 
 
 #############################
@@ -299,8 +299,8 @@ function _zscore!(Z::AbstractArray, X::AbstractArray, μ::Real, σ::Real)
     return Z
 end
 
-@generated function _zscore!{S,T,N}(Z::AbstractArray{S,N}, X::AbstractArray{T,N},
-                                    μ::AbstractArray, σ::AbstractArray)
+@generated function _zscore!(Z::AbstractArray{S,N}, X::AbstractArray{T,N},
+                             μ::AbstractArray, σ::AbstractArray) where {S,T,N}
     quote
         # Z and X are assumed to have the same size
         # μ and σ are assumed to have the same size, that is compatible with size(X)
@@ -342,21 +342,21 @@ observation lies, i.e. ``(x - μ) / σ``.
 If a destination array `Z` is provided, the scores are stored
 in `Z` and it must have the same shape as `X`. Otherwise `X` is overwritten.
 """
-function zscore!{ZT<:AbstractFloat,T<:Real}(Z::AbstractArray{ZT}, X::AbstractArray{T}, μ::Real, σ::Real)
+function zscore!(Z::AbstractArray{ZT}, X::AbstractArray{T}, μ::Real, σ::Real) where {ZT<:AbstractFloat,T<:Real}
     size(Z) == size(X) || throw(DimensionMismatch("Z and X must have the same size."))
     _zscore!(Z, X, μ, σ)
 end
 
-function zscore!{ZT<:AbstractFloat,T<:Real,U<:Real,S<:Real}(Z::AbstractArray{ZT}, X::AbstractArray{T},
-                                                            μ::AbstractArray{U}, σ::AbstractArray{S})
+function zscore!(Z::AbstractArray{<:AbstractFloat}, X::AbstractArray{<:Real},
+                 μ::AbstractArray{<:Real}, σ::AbstractArray{<:Real})
     size(Z) == size(X) || throw(DimensionMismatch("Z and X must have the same size."))
     _zscore_chksize(X, μ, σ)
     _zscore!(Z, X, μ, σ)
 end
 
-zscore!{T<:AbstractFloat}(X::AbstractArray{T}, μ::Real, σ::Real) = _zscore!(X, X, μ, σ)
+zscore!(X::AbstractArray{<:AbstractFloat}, μ::Real, σ::Real) = _zscore!(X, X, μ, σ)
 
-zscore!{T<:AbstractFloat,U<:Real,S<:Real}(X::AbstractArray{T}, μ::AbstractArray{U}, σ::AbstractArray{S}) =
+zscore!(X::AbstractArray{<:AbstractFloat}, μ::AbstractArray{<:Real}, σ::AbstractArray{<:Real}) =
     (_zscore_chksize(X, μ, σ); _zscore!(X, X, μ, σ))
 
 
@@ -371,19 +371,19 @@ above the mean that an observation lies, i.e. ``(x - μ) / σ``.
 In particular, when `μ` and `σ` are arrays, they should have the same size, and
 `size(μ, i) == 1  || size(μ, i) == size(X, i)` for each dimension.
 """
-function zscore{T<:Real}(X::AbstractArray{T}, μ::Real, σ::Real)
+function zscore(X::AbstractArray{T}, μ::Real, σ::Real) where T<:Real
     ZT = typeof((zero(T) - zero(μ)) / one(σ))
     _zscore!(Array{ZT}(size(X)), X, μ, σ)
 end
 
-function zscore{T<:Real,U<:Real,S<:Real}(X::AbstractArray{T}, μ::AbstractArray{U}, σ::AbstractArray{S})
+function zscore(X::AbstractArray{T}, μ::AbstractArray{U}, σ::AbstractArray{S}) where {T<:Real,U<:Real,S<:Real}
     _zscore_chksize(X, μ, σ)
     ZT = typeof((zero(T) - zero(U)) / one(S))
     _zscore!(Array{ZT}(size(X)), X, μ, σ)
 end
 
-zscore{T<:Real}(X::AbstractArray{T}) = ((μ, σ) = mean_and_std(X); zscore(X, μ, σ))
-zscore{T<:Real}(X::AbstractArray{T}, dim::Int) = ((μ, σ) = mean_and_std(X, dim); zscore(X, μ, σ))
+zscore(X::AbstractArray{<:Real}) = ((μ, σ) = mean_and_std(X); zscore(X, μ, σ))
+zscore(X::AbstractArray{<:Real}, dim::Int) = ((μ, σ) = mean_and_std(X, dim); zscore(X, μ, σ))
 
 
 
@@ -399,7 +399,7 @@ zscore{T<:Real}(X::AbstractArray{T}, dim::Int) = ((μ, σ) = mean_and_std(X, dim
 Compute the entropy of an array `p`, optionally specifying a real number
 `b` such that the entropy is scaled by `1/log(b)`.
 """
-function entropy{T<:Real}(p::AbstractArray{T})
+function entropy(p::AbstractArray{T}) where T<:Real
     s = zero(T)
     z = zero(T)
     for i = 1:length(p)
@@ -411,16 +411,14 @@ function entropy{T<:Real}(p::AbstractArray{T})
     return -s
 end
 
-function entropy{T<:Real}(p::AbstractArray{T}, b::Real)
-    return entropy(p) / log(b)
-end
+entropy(p::AbstractArray{<:Real}, b::Real) = entropy(p) / log(b)
 
 """
     renyientropy(p, α)
 
 Compute the Rényi (generalized) entropy of order `α` of an array `p`.
 """
-function renyientropy{T<:Real, U<:Real}(p::AbstractArray{T}, α::U)
+function renyientropy(p::AbstractArray{T}, α::Real) where T<:Real
     α < 0 && throw(ArgumentError("Order of Rényi entropy not legal, $(α) < 0."))
 
     s = zero(T)
@@ -463,7 +461,7 @@ end
 Compute the cross entropy between `p` and `q`, optionally specifying a real
 number `b` such that the result is scaled by `1/log(b)`.
 """
-function crossentropy{T<:Real}(p::AbstractArray{T}, q::AbstractArray{T})
+function crossentropy(p::AbstractArray{T}, q::AbstractArray{T}) where T<:Real
     length(p) == length(q) || throw(DimensionMismatch("Inconsistent array length."))
     s = 0.
     z = zero(T)
@@ -477,9 +475,8 @@ function crossentropy{T<:Real}(p::AbstractArray{T}, q::AbstractArray{T})
     return -s
 end
 
-function crossentropy{T<:Real}(p::AbstractArray{T}, q::AbstractArray{T}, b::Real)
-    return crossentropy(p,q) / log(b)
-end
+crossentropy(p::AbstractArray{T}, q::AbstractArray{T}, b::Real) where {T<:Real} =
+    crossentropy(p,q) / log(b)
 
 
 """
@@ -488,7 +485,7 @@ end
 Compute the Kullback-Leibler divergence of `q` from `p`, optionally specifying
 a real number `b` such that the divergence is scaled by `1/log(b)`.
 """
-function kldivergence{T<:Real}(p::AbstractArray{T}, q::AbstractArray{T})
+function kldivergence(p::AbstractArray{T}, q::AbstractArray{T}) where T<:Real
     length(p) == length(q) || throw(DimensionMismatch("Inconsistent array length."))
     s = 0.
     z = zero(T)
@@ -502,9 +499,8 @@ function kldivergence{T<:Real}(p::AbstractArray{T}, q::AbstractArray{T})
     return s
 end
 
-function kldivergence{T<:Real}(p::AbstractArray{T}, q::AbstractArray{T}, b::Real)
-    return kldivergence(p,q) / log(b)
-end
+kldivergence(p::AbstractArray{T}, q::AbstractArray{T}, b::Real) where {T<:Real} =
+    kldivergence(p,q) / log(b)
 
 #############################
 #
@@ -512,7 +508,7 @@ end
 #
 #############################
 
-immutable SummaryStats{T<:AbstractFloat}
+struct SummaryStats{T<:AbstractFloat}
     mean::T
     min::T
     q25::T
@@ -529,7 +525,7 @@ Compute summary statistics for a real-valued array `a`. Returns a
 `SummaryStats` object containing the mean, minimum, 25th percentile,
 median, 75th percentile, and maxmimum.
 """
-function summarystats{T<:Real}(a::AbstractArray{T})
+function summarystats(a::AbstractArray{T}) where T<:Real
     m = mean(a)
     qs = quantile(a, [0.00, 0.25, 0.50, 0.75, 1.00])
     R = typeof(convert(AbstractFloat, zero(T)))

--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -14,7 +14,7 @@
 default_laglen(lx::Int) = min(lx-1, round(Int,10*log10(lx)))
 check_lags(lx::Int, lags::AbstractVector) = (maximum(lags) < lx || error("lags must be less than the sample length."))
 
-function demean_col!{T<:RealFP}(z::AbstractVector{T}, x::AbstractMatrix{T}, j::Int, demean::Bool)
+function demean_col!(z::AbstractVector{T}, x::AbstractMatrix{T}, j::Int, demean::Bool) where T<:RealFP
     m = size(x, 1)
     @assert m == length(z)
     b = m * (j-1)
@@ -42,7 +42,7 @@ end
 
 default_autolags(lx::Int) = 0 : default_laglen(lx)
 
-_autodot{T<:RealFP}(x::AbstractVector{T}, lx::Int, l::Int) = dot(x, 1:lx-l, x, 1+l:lx)
+_autodot(x::AbstractVector{<:RealFP}, lx::Int, l::Int) = dot(x, 1:lx-l, x, 1+l:lx)
 
 
 ## autocov
@@ -57,7 +57,7 @@ If `x` is a vector, `r` must be a vector of the same length as `x`.
 If `x` is a matrix, `r` must be a matrix of size `(length(lags), size(x,2))`, and
 where each column in the result will correspond to a column in `x`.
 """
-function autocov!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function autocov!(r::RealVector, x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = length(x)
     m = length(lags)
     length(r) == m || throw(DimensionMismatch())
@@ -70,7 +70,7 @@ function autocov!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, lags::IntegerV
     return r
 end
 
-function autocov!{T<:RealFP}(r::RealMatrix, x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function autocov!(r::RealMatrix, x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = size(x, 1)
     ns = size(x, 2)
     m = length(lags)
@@ -102,15 +102,15 @@ where each column in the result corresponds to a column in `x`.
 When left unspecified, the lags used are the integers from 0 to
 `min(size(x,1)-1, 10*log10(size(x,1)))`.
 """
-function autocov{T<:Real}(x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function autocov(x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     autocov!(Vector{fptype(T)}(length(lags)), float(x), lags; demean=demean)
 end
 
-function autocov{T<:Real}(x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function autocov(x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     autocov!(Matrix{fptype(T)}(length(lags), size(x,2)), float(x), lags; demean=demean)
 end
 
-autocov{T<:Real}(x::AbstractVecOrMat{T}; demean::Bool=true) = autocov(x, default_autolags(size(x,1)); demean=demean)
+autocov(x::AbstractVecOrMat{<:Real}; demean::Bool=true) = autocov(x, default_autolags(size(x,1)); demean=demean)
 
 ## autocor
 
@@ -125,7 +125,7 @@ If `x` is a vector, `r` must be a vector of the same length as `x`.
 If `x` is a matrix, `r` must be a matrix of size `(length(lags), size(x,2))`, and
 where each column in the result will correspond to a column in `x`.
 """
-function autocor!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function autocor!(r::RealVector, x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = length(x)
     m = length(lags)
     length(r) == m || throw(DimensionMismatch())
@@ -139,7 +139,7 @@ function autocor!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, lags::IntegerV
     return r
 end
 
-function autocor!{T<:RealFP}(r::RealMatrix, x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function autocor!(r::RealMatrix, x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = size(x, 1)
     ns = size(x, 2)
     m = length(lags)
@@ -172,15 +172,15 @@ where each column in the result corresponds to a column in `x`.
 When left unspecified, the lags used are the integers from 0 to
 `min(size(x,1)-1, 10*log10(size(x,1)))`.
 """
-function autocor{T<:Real}(x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function autocor(x::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     autocor!(Vector{fptype(T)}(length(lags)), float(x), lags; demean=demean)
 end
 
-function autocor{T<:Real}(x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function autocor(x::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     autocor!(Matrix{fptype(T)}(length(lags), size(x,2)), float(x), lags; demean=demean)
 end
 
-autocor{T<:Real}(x::AbstractVecOrMat{T}; demean::Bool=true) = autocor(x, default_autolags(size(x,1)); demean=demean)
+autocor(x::AbstractVecOrMat{<:Real}; demean::Bool=true) = autocor(x, default_autolags(size(x,1)); demean=demean)
 
 
 #######################################
@@ -191,7 +191,8 @@ autocor{T<:Real}(x::AbstractVecOrMat{T}; demean::Bool=true) = autocor(x, default
 
 default_crosslags(lx::Int) = (l=default_laglen(lx); -l:l)
 
-_crossdot{T<:RealFP}(x::AbstractVector{T}, y::AbstractVector{T}, lx::Int, l::Int) = (l >= 0 ? dot(x, 1:lx-l, y, 1+l:lx) : dot(x, 1-l:lx, y, 1:lx+l))
+_crossdot(x::AbstractVector{T}, y::AbstractVector{T}, lx::Int, l::Int) where {T<:RealFP} =
+    (l >= 0 ? dot(x, 1:lx-l, y, 1+l:lx) : dot(x, 1-l:lx, y, 1:lx+l))
 
 ## crosscov
 
@@ -209,7 +210,7 @@ If both `x` and `y` are vectors, `r` must be a vector of the same length as
 of size `(length(lags), size(y, 2))`. If both `x` and `y` are matrices, `r` must be a
 three-dimensional array of size `(length(lags), size(x, 2), size(y, 2))`.
 """
-function crosscov!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov!(r::RealVector, x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = length(x)
     m = length(lags)
     (length(y) == lx && length(r) == m) || throw(DimensionMismatch())
@@ -223,7 +224,7 @@ function crosscov!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, y::AbstractVe
     return r
 end
 
-function crosscov!{T<:RealFP}(r::RealMatrix, x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov!(r::RealMatrix, x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = size(x, 1)
     ns = size(x, 2)
     m = length(lags)
@@ -241,7 +242,7 @@ function crosscov!{T<:RealFP}(r::RealMatrix, x::AbstractMatrix{T}, y::AbstractVe
     return r
 end
 
-function crosscov!{T<:RealFP}(r::RealMatrix, x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov!(r::RealMatrix, x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = length(x)
     ns = size(y, 2)
     m = length(lags)
@@ -259,7 +260,7 @@ function crosscov!{T<:RealFP}(r::RealMatrix, x::AbstractVector{T}, y::AbstractMa
     return r
 end
 
-function crosscov!{T<:RealFP}(r::AbstractArray{T,3}, x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov!(r::AbstractArray{T,3}, x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = size(x, 1)
     nx = size(x, 2)
     ny = size(y, 2)
@@ -310,23 +311,23 @@ If both `x` and `y` are vectors, return a vector of the same length as
 When left unspecified, the lags used are the integers from
 `-min(size(x,1)-1, 10*log10(size(x,1)))` to `min(size(x,1), 10*log10(size(x,1)))`.
 """
-function crosscov{T<:Real}(x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov(x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscov!(Vector{fptype(T)}(length(lags)), float(x), float(y), lags; demean=demean)
 end
 
-function crosscov{T<:Real}(x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov(x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscov!(Matrix{fptype(T)}(length(lags), size(x,2)), float(x), float(y), lags; demean=demean)
 end
 
-function crosscov{T<:Real}(x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov(x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscov!(Matrix{fptype(T)}(length(lags), size(y,2)), float(x), float(y), lags; demean=demean)
 end
 
-function crosscov{T<:Real}(x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscov(x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscov!(Array{fptype(T),3}(length(lags), size(x,2), size(y,2)), float(x), float(y), lags; demean=demean)
 end
 
-crosscov{T<:Real}(x::AbstractVecOrMat{T}, y::AbstractVecOrMat{T}; demean::Bool=true) = crosscov(x, y, default_crosslags(size(x,1)); demean=demean)
+crosscov(x::AbstractVecOrMat{T}, y::AbstractVecOrMat{T}; demean::Bool=true) where {T<:Real} = crosscov(x, y, default_crosslags(size(x,1)); demean=demean)
 
 
 ## crosscor
@@ -343,7 +344,7 @@ If both `x` and `y` are vectors, `r` must be a vector of the same length as
 of size `(length(lags), size(y, 2))`. If both `x` and `y` are matrices, `r` must be a
 three-dimensional array of size `(length(lags), size(x, 2), size(y, 2))`.
 """
-function crosscor!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor!(r::RealVector, x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = length(x)
     m = length(lags)
     (length(y) == lx && length(r) == m) || throw(DimensionMismatch())
@@ -358,7 +359,7 @@ function crosscor!{T<:RealFP}(r::RealVector, x::AbstractVector{T}, y::AbstractVe
     return r
 end
 
-function crosscor!{T<:RealFP}(r::RealMatrix, x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor!(r::RealMatrix, x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = size(x, 1)
     ns = size(x, 2)
     m = length(lags)
@@ -378,7 +379,7 @@ function crosscor!{T<:RealFP}(r::RealMatrix, x::AbstractMatrix{T}, y::AbstractVe
     return r
 end
 
-function crosscor!{T<:RealFP}(r::RealMatrix, x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor!(r::RealMatrix, x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = length(x)
     ns = size(y, 2)
     m = length(lags)
@@ -398,7 +399,7 @@ function crosscor!{T<:RealFP}(r::RealMatrix, x::AbstractVector{T}, y::AbstractMa
     return r
 end
 
-function crosscor!{T<:RealFP}(r::AbstractArray{T,3}, x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor!(r::AbstractArray{T,3}, x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:RealFP
     lx = size(x, 1)
     nx = size(x, 2)
     ny = size(y, 2)
@@ -453,23 +454,23 @@ If both `x` and `y` are vectors, return a vector of the same length as
 When left unspecified, the lags used are the integers from
 `-min(size(x,1)-1, 10*log10(size(x,1)))` to `min(size(x,1), 10*log10(size(x,1)))`.
 """
-function crosscor{T<:Real}(x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor(x::AbstractVector{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscor!(Vector{fptype(T)}(length(lags)), float(x), float(y), lags; demean=demean)
 end
 
-function crosscor{T<:Real}(x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor(x::AbstractMatrix{T}, y::AbstractVector{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscor!(Matrix{fptype(T)}(length(lags), size(x,2)), float(x), float(y), lags; demean=demean)
 end
 
-function crosscor{T<:Real}(x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor(x::AbstractVector{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscor!(Matrix{fptype(T)}(length(lags), size(y,2)), float(x), float(y), lags; demean=demean)
 end
 
-function crosscor{T<:Real}(x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true)
+function crosscor(x::AbstractMatrix{T}, y::AbstractMatrix{T}, lags::IntegerVector; demean::Bool=true) where T<:Real
     crosscor!(Array{fptype(T),3}(length(lags), size(x,2), size(y,2)), float(x), float(y), lags; demean=demean)
 end
 
-crosscor{T<:Real}(x::AbstractVecOrMat{T}, y::AbstractVecOrMat{T}; demean::Bool=true) = crosscor(x, y, default_crosslags(size(x,1)); demean=demean)
+crosscor(x::AbstractVecOrMat{T}, y::AbstractVecOrMat{T}; demean::Bool=true) where {T<:Real} = crosscor(x, y, default_crosslags(size(x,1)); demean=demean)
 
 
 #######################################
@@ -480,7 +481,7 @@ crosscor{T<:Real}(x::AbstractVecOrMat{T}, y::AbstractVecOrMat{T}; demean::Bool=t
 #
 #######################################
 
-function pacf_regress!{T<:RealFP}(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector, mk::Integer)
+function pacf_regress!(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector, mk::Integer) where T<:RealFP
     lx = size(X, 1)
     tmpX = ones(T, lx, mk + 1)
     for j = 1 : size(X,2)
@@ -498,7 +499,7 @@ function pacf_regress!{T<:RealFP}(r::RealMatrix, X::AbstractMatrix{T}, lags::Int
     r
 end
 
-function pacf_yulewalker!{T<:RealFP}(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector, mk::Integer)
+function pacf_yulewalker!(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector, mk::Integer) where T<:RealFP
     tmp = Vector{T}(mk)
     for j = 1 : size(X,2)
         acfs = autocor(X[:,j], 1:mk)
@@ -521,7 +522,7 @@ using the Yule-Walker equations.
 
 `r` must be a matrix of size `(length(lags), size(x, 2))`.
 """
-function pacf!{T<:RealFP}(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector; method::Symbol=:regression)
+function pacf!(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector; method::Symbol=:regression) where T<:RealFP
     lx = size(X, 1)
     m = length(lags)
     minlag, maxlag = extrema(lags)
@@ -552,11 +553,11 @@ If `x` is a vector, return a vector of the same length as `lags`.
 If `x` is a matrix, return a matrix of size `(length(lags), size(x, 2))`,
 where each column in the result corresponds to a column in `x`.
 """
-function pacf{T<:Real}(X::AbstractMatrix{T}, lags::IntegerVector; method::Symbol=:regression)
+function pacf(X::AbstractMatrix{T}, lags::IntegerVector; method::Symbol=:regression) where T<:Real
     pacf!(Matrix{fptype(T)}(length(lags), size(X,2)), float(X), lags; method=method)
 end
 
-function pacf{T<:Real}(x::AbstractVector{T}, lags::IntegerVector; method::Symbol=:regression)
+function pacf(x::AbstractVector{T}, lags::IntegerVector; method::Symbol=:regression) where T<:Real
     vec(pacf(reshape(x, length(x), 1), lags, method=method))
 end
 

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -1,6 +1,6 @@
 # Statistical Models
 
-@compat abstract type StatisticalModel end
+abstract type StatisticalModel end
 
 """
     coef(obj::StatisticalModel)
@@ -197,7 +197,7 @@ end
 
 const adjr² = adjr2
 
-@compat abstract type RegressionModel <: StatisticalModel end
+abstract type RegressionModel <: StatisticalModel end
 
 """
     fitted(obj::RegressionModel)
@@ -251,7 +251,7 @@ dof_residual(obj::RegressionModel) = error("dof_residual is not defined for $(ty
 """
     params(obj)
 
-Return all parameters of a model. 
+Return all parameters of a model.
 """
 params(obj) = error("params is not defined for $(typeof(obj))")
 function params! end
@@ -259,7 +259,7 @@ function params! end
 ## coefficient tables with specialized show method
 
 ## Nms are the coefficient names, corresponding to rows in the table
-type CoefTable
+mutable struct CoefTable
     cols::Vector
     colnms::Vector
     rownms::Vector
@@ -284,7 +284,7 @@ type CoefTable
     end
 end
 
-type PValue
+mutable struct PValue
     v::Number
     function PValue(v::Number)
         0. <= v <= 1. || isnan(v) || error("p-values must be in [0.,1.]")
@@ -336,11 +336,11 @@ function show(io::IO, ct::CoefTable)
 end
 
 """
-	ConvergenceException(iters::Int)
+    ConvergenceException(iters::Int)
 
 The fitting procedure failed to converge in `iters` number of iterations.
 """
-type ConvergenceException <: Exception
+struct ConvergenceException <: Exception
     iters::Int
 end
 

--- a/src/toeplitzsolvers.jl
+++ b/src/toeplitzsolvers.jl
@@ -1,5 +1,5 @@
 # Symmetric Toeplitz solver
-function durbin!{T<:BlasReal}(r::AbstractVector{T}, y::AbstractVector{T})
+function durbin!(r::AbstractVector{T}, y::AbstractVector{T}) where T<:BlasReal
     n = length(r)
     n <= length(y) || throw(DimensionMismatch("Auxiliary vector cannot be shorter than data vector"))
     y[1] = -r[1]
@@ -22,9 +22,9 @@ function durbin!{T<:BlasReal}(r::AbstractVector{T}, y::AbstractVector{T})
     end
     return y
 end
-durbin{T<:BlasReal}(r::AbstractVector{T}) = durbin!(r, zeros(T, length(r)))
+durbin(r::AbstractVector{T}) where {T<:BlasReal} = durbin!(r, zeros(T, length(r)))
 
-function levinson!{T<:BlasReal}(r::AbstractVector{T}, b::AbstractVector{T}, x::AbstractVector{T})
+function levinson!(r::AbstractVector{T}, b::AbstractVector{T}, x::AbstractVector{T}) where T<:BlasReal
     n = length(b)
     n == length(r) || throw(DimensionMismatch("Vectors must have same length"))
     n <= length(x) || throw(DimensionMismatch("Auxiliary vector cannot be shorter than data vector"))
@@ -63,4 +63,4 @@ function levinson!{T<:BlasReal}(r::AbstractVector{T}, b::AbstractVector{T}, x::A
     end
     return x
 end
-levinson{T<:BlasReal}(r::AbstractVector{T}, b::AbstractVector{T}) = levinson!(r, copy(b), zeros(T, length(b)))
+levinson(r::AbstractVector{T}, b::AbstractVector{T}) where {T<:BlasReal} = levinson!(r, copy(b), zeros(T, length(b)))

--- a/test/signalcorr.jl
+++ b/test/signalcorr.jl
@@ -6,8 +6,6 @@
 
 using StatsBase
 using Base.Test
-using Compat
-import Compat.view
 
 # random data for testing
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -1,7 +1,5 @@
 using StatsBase
 using Base.Test
-using Compat
-import Compat: view
 
 @testset "StatsBase.Weights" begin
 weight_funcs = (weights, aweights, fweights, pweights)


### PR DESCRIPTION
Ref https://github.com/JuliaLang/METADATA.jl/pull/10398. Decided to go the whole nine yards:

* Remove Compat dependency
* Migrate to `where`
* Remove now-irrelevant `VERSION` checks
* Bump the Julia lower bound to 0.6

The diff is pretty big (I ended up touching pretty much every file) but the changes are pretty straightforward.