### PR TITLE
Add proportion normalization to histograms

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -442,8 +442,8 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
             for A in aux_weights
                 A ./= s
             end
-        else mode != :pdf && mode != :density
-            throw(ArgumentError("Normalization mode must be :pdf, :density, :proportion or :none"))
+        else 
+            throw(ArgumentError("Normalization mode must be :pdf, :density, :fraction or :none"))
         end
         h
     end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -425,7 +425,6 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                 end
             end
             h.isdensity = true
-        elseif mode == :proportion
             if h.isdensity #if it already is a density, reverse that operation
                 SumT = norm_type(h)
                 vs_0 = one(SumT)
@@ -437,6 +436,7 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                 end
                 h.isdensity = false
             end
+        elseif mode == :fraction
             s = sum(weights)
             weights ./= s
             for A in aux_weights

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -425,8 +425,25 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                 end
             end
             h.isdensity = true
+        elseif mode == :proportion
+            if h.isdensity #if it already is a density, reverse that operation
+                SumT = norm_type(h)
+                vs_0 = one(SumT)
+                @inbounds @nloops $N i weights d->(vs_{$N-d+1} = vs_{$N-d} * _edge_binvolume(SumT, edges[d], i_d)) begin
+                    (@nref $N weights i) *= $(Symbol("vs_$N"))
+                    for A in aux_weights
+                        (@nref $N A i) *= $(Symbol("vs_$N"))
+                    end
+                end
+                h.isdensity = false
+            end
+            s = sum(weights)
+            weights ./= s
+            for A in aux_weights
+                A ./= s
+            end
         else mode != :pdf && mode != :density
-            throw(ArgumentError("Normalization mode must be :pdf, :density or :none"))
+            throw(ArgumentError("Normalization mode must be :pdf, :density, :proportion or :none"))
         end
         h
     end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -399,6 +399,10 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
             (size(A) != size(weights)) && throw(DimensionMismatch("aux_weights must have same size as histogram weights"))
         end
 
+        if mode == :fraction && h.isdensity
+            mode = :pdf
+        end
+
         if mode == :none
             # nothing to do
         elseif mode == :pdf || mode == :density
@@ -425,17 +429,6 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                 end
             end
             h.isdensity = true
-            if h.isdensity #if it already is a density, reverse that operation
-                SumT = norm_type(h)
-                vs_0 = one(SumT)
-                @inbounds @nloops $N i weights d->(vs_{$N-d+1} = vs_{$N-d} * _edge_binvolume(SumT, edges[d], i_d)) begin
-                    (@nref $N weights i) *= $(Symbol("vs_$N"))
-                    for A in aux_weights
-                        (@nref $N A i) *= $(Symbol("vs_$N"))
-                    end
-                end
-                h.isdensity = false
-            end
         elseif mode == :fraction
             s = sum(weights)
             weights ./= s

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -401,9 +401,9 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
 
         if mode == :none
             # nothing to do
-        elseif mode == :pdf || mode == :density || mode == :fraction
+        elseif mode == :pdf || mode == :density || mode == :probability
             if h.isdensity
-                if mode == :pdf || mode == :fraction
+                if mode == :pdf || mode == :probability
                     # histogram already represents a density, just divide weights by norm
                     s = 1/norm(h)
                     weights .*= s
@@ -426,7 +426,7 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                     end
                     h.isdensity = true
                 else
-                    # :fraction - divide weights by sum of weights
+                    # :probability - divide weights by sum of weights
                     nf = inv(sum(weights))
                     weights .*= nf
                     for A in aux_weights
@@ -435,7 +435,7 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                 end
             end
         else
-            throw(ArgumentError("Normalization mode must be :pdf, :density, :fraction or :none"))
+            throw(ArgumentError("Normalization mode must be :pdf, :density, :probability or :none"))
         end
         h
     end
@@ -454,13 +454,13 @@ Valid values for `mode` are:
 * `:density`: Normalize by bin sizes only. Resulting histogram represents
    count density of input and does not have norm 1. Will not modify the
    histogram if it already represents a density (`h.isdensity == 1`).
-* `:fraction`: Normalize by sum of weights only. Resulting histogram
+* `:probability`: Normalize by sum of weights only. Resulting histogram
    represents the fraction of probability mass for each bin and does not have
    norm 1.
 *  `:none`: Leaves histogram unchanged. Useful to simplify code that has to
    conditionally apply different modes of normalization.
 
-Successive application of both `:fraction` and `:density` normalization (in
+Successive application of both `:probability` and `:density` normalization (in
 any order) is equivalent to `:pdf` normalization.
 """
 normalize(h::Histogram{T,N}; mode::Symbol=:pdf) where {T,N} =

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -173,6 +173,10 @@ end
     h_copy = deepcopy(float(h))
     @test @inferred(normalize!(h_copy, mode = :density)) == h_copy
 
+    h_proportion = normalize(h, mode = :pdf)
+    @test sum(h_pdf.weights) ≈ 1.
+    @test h_proportion = normalize(h_pdf, mode = :proportion)
+
     h2 = deepcopy(float(h))
     mod_h2 = normalize!(h2, mode = :density)
     @test mod_h2 === h2 && mod_h2.weights === h2.weights

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -175,7 +175,10 @@ end
 
     h_proportion = normalize(h, mode = :fraction)
     @test sum(h_proportion.weights) ≈ 1.
-    @test h_proportion.weights ≈ normalize(h_pdf, mode = :proportion).weights
+    h_newpdf = normalize(h_proportion, mode = :density)
+    @test h_newpdf.weights ≈ h_pdf.weights
+    h_newpdf2 = normalize(h_density, mode = :fraction)
+    @test h_newpdf2.weights ≈ h_pdf.weights
 
     h2 = deepcopy(float(h))
     mod_h2 = normalize!(h2, mode = :density)

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -173,9 +173,9 @@ end
     h_copy = deepcopy(float(h))
     @test @inferred(normalize!(h_copy, mode = :density)) == h_copy
 
-    h_proportion = normalize(h, mode = :pdf)
-    @test sum(h_pdf.weights) ≈ 1.
-    @test h_proportion = normalize(h_pdf, mode = :proportion)
+    h_proportion = normalize(h, mode = :proportion)
+    @test sum(h_proportion.weights) ≈ 1.
+    @test h_proportion.weights ≈ normalize(h_pdf, mode = :proportion).weights
 
     h2 = deepcopy(float(h))
     mod_h2 = normalize!(h2, mode = :density)

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -173,7 +173,7 @@ end
     h_copy = deepcopy(float(h))
     @test @inferred(normalize!(h_copy, mode = :density)) == h_copy
 
-    h_proportion = normalize(h, mode = :proportion)
+    h_proportion = normalize(h, mode = :fraction)
     @test sum(h_proportion.weights) ≈ 1.
     @test h_proportion.weights ≈ normalize(h_pdf, mode = :proportion).weights
 

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -160,7 +160,7 @@ end
     @test @inferred(norm(h_pdf)) ≈ 1
     @test @inferred(normalize(h_pdf, mode = :pdf)) == h_pdf
     @test @inferred(normalize(h_pdf, mode = :density)) == h_pdf
-    @test @inferred(normalize(h_pdf, mode = :fraction)) == h_pdf
+    @test @inferred(normalize(h_pdf, mode = :probability)) == h_pdf
 
     h_density = normalize(h, mode = :density)
     @test h_density.weights ≈ h.weights ./ bin_vols
@@ -170,14 +170,14 @@ end
         Histogram(h_density.edges, h_density.weights .* (1/norm(h_density)), h_density.closed, true)
     @test normalize(h_density, mode = :pdf).weights ≈ h_pdf.weights
     @test normalize(h_density, mode = :density) == h_density
-    @test normalize(h_density, mode = :fraction).weights ≈ h_pdf.weights
+    @test normalize(h_density, mode = :probability).weights ≈ h_pdf.weights
 
-    h_fraction = normalize(h, mode = :fraction)
+    h_fraction = normalize(h, mode = :probability)
     @test sum(h_fraction.weights) ≈ 1
     @test h_fraction.isdensity == false
     @test normalize(h_fraction, mode = :pdf).weights ≈ h_pdf.weights
     @test normalize(h_fraction, mode = :density).weights ≈ h_pdf.weights
-    @test normalize(h_fraction, mode = :fraction).weights ≈ h_fraction.weights
+    @test normalize(h_fraction, mode = :probability).weights ≈ h_fraction.weights
 
     h_copy = deepcopy(float(h))
     @test @inferred(normalize!(h_copy, mode = :density)) == h_copy


### PR DESCRIPTION
This adds the option of a `:proportion` normalization to histograms. This was suggested here: https://discourse.julialang.org/t/plots-how-to-create-a-histogram-such-that-sum-of-bar-heights-1/5392/16

The proportion normalization is the normalization where the sum of all weights (the height of the histogram bars in a plot) is = 1. It is not a density-controlled normalization. It can be more intuitive to read from a diagram than a pdf normalization.