### PR TITLE
Ensure that pacf at lag 0 is 1.0

### DIFF
--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -513,7 +513,7 @@ function pacf_regress!(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVector,
         for i = 1 : length(lags)
             l = lags[i]
             sX = view(tmpX, 1+l:lx, 1:l+1)
-            r[i,j] = (cholfact!(sX'sX)\(sX'view(X, 1+l:lx, j)))[end]
+            r[i,j] = l == 0 ? 1 : (cholfact!(sX'sX)\(sX'view(X, 1+l:lx, j)))[end]
         end
     end
     r
@@ -580,4 +580,3 @@ end
 function pacf(x::AbstractVector{T}, lags::IntegerVector; method::Symbol=:regression) where T<:Real
     vec(pacf(reshape(x, length(x), 1), lags, method=method))
 end
-

--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -525,7 +525,7 @@ function pacf_yulewalker!(r::RealMatrix, X::AbstractMatrix{T}, lags::IntegerVect
         acfs = autocor(X[:,j], 1:mk)
         for i = 1 : length(lags)
             l = lags[i]
-            r[i,j] = l == 0 ? one(T) : l == 1 ? acfs[i] : -durbin!(view(acfs, 1:l), tmp)[l]
+            r[i,j] = l == 0 ? 1 : l == 1 ? acfs[i] : -durbin!(view(acfs, 1:l), tmp)[l]
         end
     end
 end


### PR DESCRIPTION
This change makes sure that the partial acf at lag zero is always one, which hasn't been the case so far (see issue #102).

There are two open issues:

1. We could just throw an error if lag zero is requested but this would be inconsistent with the `autocor` function where lag zero is a valid input. Therefore I would like to allow it for `pacf` as well.

2. My fix ensures that the pacf at lag zero is one but it is inefficient in the sense that the pacf at that lag is still looped through. This could potentially be relevant if someone wants to compute pacfs for a large number of dataseries. So if you like, I could also make a larger change so that the pacf at lag zero is taken out of the loop.