### PR TITLE
WIP: expand data by FrequencyWeights

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -137,6 +137,18 @@ See the documentation for [`FrequencyWeights`](@ref) for more details.
 fweights(vs::RealVector) = FrequencyWeights(vs)
 fweights(vs::RealArray) = FrequencyWeights(vec(vs))
 
+function Base.repeat(v::RealVector, w::FrequencyWeights{<:Integer, <:Integer})
+    result = Vector{eltype(v)}(sum(w))
+    i = 0
+    for (vi, wi) in zip(v, w)
+        for _ in 1:wi
+            i += 1
+            result[i] = vi
+        end
+    end
+    result 
+end
+
 """
     varcorrection(w::FrequencyWeights, corrected=false)
 


### PR DESCRIPTION
This PR adds a `repeat(x::RealVector, w::FrequencyWeight{<:Integer})` method to create a new vector where each element in `x` gets repeated by its associated weight in `w`.  Would this be useful, if only for better testing?  It would help catch cases like https://github.com/JuliaStats/StatsBase.jl/issues/313

```julia
x = randn(10)
w = rand(1:5, 10)
p = [0, .25, .5, .75, 1]
@test quantile(x, w, p) == quantile(repeat(x, w), p)
```