### PR TITLE
using SortingAlgorithms.jl's radix sort to speed up countmap

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -9,7 +9,7 @@ module StatsBase
 
     import SpecialFunctions: erfcinv
 
-    using Compat
+    using Compat, SortingAlgorithms
 
     ## tackle compatibility issues
 
@@ -127,7 +127,7 @@ module StatsBase
     hist,
     # histrange,
     midpoints,
-    
+
     ## robust
     trim,           # trimmed set
     trim!,          # trimmed set

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -6,9 +6,6 @@
 #
 #################################################
 
-# used to make Dict-based countmap faster
-import Base: ht_keyindex2, _setindex!
-
 const IntUnitRange{T<:Integer} = UnitRange{T}
 
 #### functions for counting a single list of integers (1D)
@@ -255,12 +252,11 @@ end
 
 function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
     for v in x
-        index = ht_keyindex2(cm, v)
+        index = Base.ht_keyindex2(cm, v)
         if index > 0
-          @inbounds cm.keys[index] = v
-          @inbounds cm.vals[index] += 1
+            @inbounds cm.vals[index] += 1
         else
-          @inbounds _setindex!(cm, 1, v, -index)
+            @inbounds Base._setindex!(cm, 1, v, -index)
         end
     end
     return cm

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -237,11 +237,11 @@ Add counts based on `x` to a count map. New entries will be added if new values 
 If a weighting vector `wv` is specified, the sum of the weights is used rather than the
 raw counts.
 """
-function addcounts!(cm::Dict{T}, x::AbstractArray{T}) where T
+function addcounts!(cm::Dict{T}, x::AbstractArray{T}; uselessmem = false) where T
     # if it's of bits type then can speed things up using radix sort
     # from heuristics it was found that 2^16 = 65536 is the point at which
     # radixsort is more performant
-    if radixsort_safe(T) & length(x) > 65536
+    if uselessmem && radixsort_safe(T) && length(x) > 65536
         addcounts_radixsort!(cm, x)
         return cm
     else
@@ -264,13 +264,8 @@ function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
 end
 
 "Can the type be sorted by radixsort"
-function radixsort_safe(T::Type)
-    if T <: Number
-        return isbits(T)
-    else
-        return false
-    end
-end
+radixsort_safe(::Type{T}) where {T<:Number} = isbits(T)
+radixsort_safe(::Type) = false
 
 function addcounts_radixsort!(cm::Dict{T}, x::AbstractArray{T}) where T
     # it's much faster to make a copy of x and then sort! vs sort

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -268,16 +268,16 @@ radixsort_safe(T::Type) = isbits(T)
 function addcounts_radixsort!(cm::Dict{T}, x::AbstractArray{T}) where T
     sx = sort(x, alg = RadixSort)
     tmpcount = 1
-    last_sx1 = sx[1]
+    last_sx = sx[1]
 
     # now the data is sorted: can just run through and accumulate values before
     # adding into the Dict
     for sx1 = sx[2:end]
-        if last_sx1 == sx1
+        if last_sx == sx1
             tmpcount += 1
         else
-            cm[last_sx1] = tmpcount
-            last_sx1 = sx1
+            cm[last_sx] = tmpcount
+            last_sx = sx1
             tmpcount = 1
         end
     end

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -237,20 +237,25 @@ Add counts based on `x` to a count map. New entries will be added if new values 
 If a weighting vector `wv` is specified, the sum of the weights is used rather than the
 raw counts.
 
-alg can be one of
-    :auto       -   default; uses :radixsort if safe to do so
-    :radixsort  -   if radixsort_safe(eltype(x)) == true then use radixsort to
-                    sort the input array in order to achieve faster performance
-                    by using more RAM. One should choose :dict if the
-                    amount of available RAM is a limitation.
-    :dict       -   Uses Dict-based method which is generally slower but uses
-                    less RAM and is safe for any data type.
+`alg` can be one of
+- `:auto`:      default; uses `:radixsort` if safe to do so
+
+- `:radixsort`: if `radixsort_safe(eltype(x)) == true` then use `:radixsort`
+                to sort the input array in order to achieve higher performance
+                by using more RAM. Choose `:dict` if the amount of available RAM
+                is a limitation.
+
+- `:dict`:      Uses Dict-based method which is generally slower but uses less
+                RAM and is safe for any data type.
 """
 function addcounts!(cm::Dict{T}, x::AbstractArray{T}; alg = :auto) where T
     # if it's safe to be sorted using radixsort then it should be faster
     # albeit using more RAM
-    if radixsort_safe(T) & (alg == :auto | alg == :radixsort)
+    if radixsort_safe(T) && (alg == :auto || alg == :radixsort)
         addcounts_radixsort!(cm, x)
+    else if alg == :radixsort
+        warn("`alg = :radixsort` is chosen but type `radixsort_safe($T)` did not return `true`; using `alg = :dict` instead")
+        addcounts_dict!(cm,x)
     else
         addcounts_dict!(cm,x)
     end

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -255,7 +255,7 @@ function addcounts!(cm::Dict{T}, x::AbstractArray{T}; alg = :auto) where T
     # albeit using more RAM
     if radixsort_safe(T) && (alg == :auto || alg == :radixsort)
         addcounts_radixsort!(cm, x)
-    else if alg == :radixsort
+    elseif alg == :radixsort
         throw(ArgumentError("`alg = :radixsort` is chosen but type `radixsort_safe($T)` did not return `true`; use `alg = :auto` or `alg = :dict` instead"))
     else
         addcounts_dict!(cm,x)

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -241,7 +241,7 @@ function addcounts!(cm::Dict{T}, x::AbstractArray{T}; uselessmem = false) where 
     # if it's of bits type then can speed things up using radix sort
     # from heuristics it was found that 2^16 = 65536 is the point at which
     # radixsort is more performant
-    if uselessmem && radixsort_safe(T) && length(x) > 65536
+    if uselessmem && radixsort_safe(T)
         addcounts_radixsort!(cm, x)
         return cm
     else

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -237,18 +237,19 @@ Add counts based on `x` to a count map. New entries will be added if new values 
 If a weighting vector `wv` is specified, the sum of the weights is used rather than the
 raw counts.
 
-`alg` can be one of
-- `:auto`:      default; if `radixsort_safe(eltype(x)) == true` then use
-                `:radixsort`, otherwise use `:dict`
+`alg` can be one of:
+- `:auto` (default): if `StatsBase.radixsort_safe(eltype(x)) == true` then use
+                     `:radixsort`, otherwise use `:dict`.
 
-- `:radixsort`: if `radixsort_safe(eltype(x)) == true` then use the [radix sort](https://en.wikipedia.org/wiki/Radix_sort)
-                algorithm to sort the input vector which will generally lead to
-                shorter running time. However the radix sort algorithm creates a
-                copy of the input vector and hence uses more RAM. Choose `:dict`
-                if the amount of available RAM is a limitation.
+- `:radixsort`:      if `radixsort_safe(eltype(x)) == true` then use the
+                     [radix sort](https://en.wikipedia.org/wiki/Radix_sort)
+                     algorithm to sort the input vector which will generally lead to
+                     shorter running time. However the radix sort algorithm creates a
+                     copy of the input vector and hence uses more RAM. Choose `:dict`
+                     if the amount of available RAM is a limitation.
 
-- `:dict`:      uses `Dict`-based method which is generally slower but uses less
-                RAM and is safe for any data type.
+- `:dict`:           use `Dict`-based method which is generally slower but uses less
+                     RAM and is safe for any data type.
 """
 function addcounts!(cm::Dict{T}, x::AbstractArray{T}; alg = :auto) where T
     # if it's safe to be sorted using radixsort then it should be faster
@@ -331,18 +332,18 @@ end
 Return a dictionary mapping each unique value in `x` to its number
 of occurrences.
 
-`alg` can be one of
-- `:auto`:      default; if `radixsort_safe(eltype(x)) == true` then use
-                `:radixsort`, otherwise use `:dict`
+- `:auto` (default): if `StatsBase.radixsort_safe(eltype(x)) == true` then use
+                     `:radixsort`, otherwise use `:dict`.
 
-- `:radixsort`: if `radixsort_safe(eltype(x)) == true` then use the [radix sort](https://en.wikipedia.org/wiki/Radix_sort)
-                algorithm to sort the input vector which will generally lead to
-                shorter running time. However the radix sort algorithm creates a
-                copy of the input vector and hence uses more RAM. Choose `:dict`
-                if the amount of available RAM is a limitation.
+- `:radixsort`:      if `radixsort_safe(eltype(x)) == true` then use the
+                     [radix sort](https://en.wikipedia.org/wiki/Radix_sort)
+                     algorithm to sort the input vector which will generally lead to
+                     shorter running time. However the radix sort algorithm creates a
+                     copy of the input vector and hence uses more RAM. Choose `:dict`
+                     if the amount of available RAM is a limitation.
 
-- `:dict`:      uses `Dict`-based method which is generally slower but uses less
-                RAM and is safe for any data type.
+- `:dict`:           use `Dict`-based method which is generally slower but uses less
+                     RAM and is safe for any data type.
 """
 countmap(x::AbstractArray{T}; alg = :auto) where {T} = addcounts!(Dict{T,Int}(), x; alg = alg)
 countmap(x::AbstractArray{T}, wv::AbstractWeights{W}) where {T,W} = addcounts!(Dict{T,W}(), x, wv)

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -263,7 +263,7 @@ function addcounts_radixsort!(cm::Dict{T}, x::AbstractArray{T}) where T
     tmpcount = 1
     last_sx1 = sx[1]
 
-    # now the data is sort can just run through and accumulate values before
+    # now the data is sorted: can just run through and accumulate values before
     # adding into the Dict
     for sx1 = sx[2:end]
         if last_sx1 == sx1

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -250,6 +250,7 @@ function addcounts!(cm::Dict{T}, x::AbstractArray{T}) where T
     end
 end
 
+"""Dict-based addcounts method"""
 function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
     for v in x
         index = Base.ht_keyindex2(cm, v)
@@ -263,10 +264,19 @@ function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
 end
 
 "Can the type be sorted by radixsort"
-radixsort_safe(T::Type) = isbits(T)
+function radixsort_safe(T::Type)
+    if T <: Number
+        return isbits(T)
+    else
+        return false
+    end
+end
 
 function addcounts_radixsort!(cm::Dict{T}, x::AbstractArray{T}) where T
-    sx = sort(x, alg = RadixSort)
+    # it's much faster to make a copy of x and then sort! vs sort
+    sx = copy(x)
+    sort!(sx; alg = RadixSort)
+
     tmpcount = 1
     last_sx = sx[1]
 
@@ -286,6 +296,7 @@ function addcounts_radixsort!(cm::Dict{T}, x::AbstractArray{T}) where T
 
     return cm
 end
+
 
 function addcounts!(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractWeights{W}) where {T,W}
     n = length(x)

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -85,9 +85,12 @@ pm = proportionmap(x)
 @test pm["b"] ≈ (1/3)
 @test pm["c"] ≈ (1/6)
 
-xx = vcat(repeat([1];inner = 100), rand(2:1000, 1_000_000))[sample(1:1_000_100, 1_000_100, replace=false)]
+# testing the radixsort branch of countmap
+xx = repeat([1, 1, 3, 6], outer=100_000)
 cxx = countmap(xx)
-@test cxx[1] == 100
+@test cxx[1] == 200000
+@test cxx[3] == 100000
+@test cxx[6] == 100000
 
 cm = countmap(x, weights(w))
 @test cm["a"] == 5.5

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -87,25 +87,20 @@ pm = proportionmap(x)
 
 
 # testing the radixsort branch of countmap
-xx = repeat([1, 1, 3, 6], outer=100_000);
+xx = repeat([6, 1, 3, 1], outer=100_000)
 cm = countmap(xx)
-@test cm[1] == 200000
-@test cm[3] == 100_000
-@test cm[6] == 100_000
+@test cm == Dict(1 => 200_000, 3 => 100_000, 6 => 100_000)
 
-xx = repeat([1, 1, 3, 6], outer=100_000);
+# testing the radixsort-based addcounts
+xx = repeat([6, 1, 3, 1], outer=100_000)
 cm = Dict{Int, Int}()
 StatsBase.addcounts_radixsort!(cm,xx)
-@test cm[1] == 200000
-@test cm[3] == 100_000
-@test cm[6] == 100_000
+@test cm == Dict(1 => 200_000, 3 => 100_000, 6 => 100_000)
 
 # testing the Dict-based addcounts
 cm = Dict{Int, Int}()
 StatsBase.addcounts_dict!(cm,xx)
-@test cm[1] == 200000
-@test cm[3] == 100_000
-@test cm[6] == 100_000
+@test cm == Dict(1 => 200_000, 3 => 100_000, 6 => 100_000)
 
 cm = countmap(x, weights(w))
 @test cm["a"] == 5.5

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -85,12 +85,27 @@ pm = proportionmap(x)
 @test pm["b"] ≈ (1/3)
 @test pm["c"] ≈ (1/6)
 
+
 # testing the radixsort branch of countmap
-xx = repeat([1, 1, 3, 6], outer=100_000)
-cxx = countmap(xx)
-@test cxx[1] == 200000
-@test cxx[3] == 100000
-@test cxx[6] == 100000
+xx = repeat([1, 1, 3, 6], outer=100_000);
+cm = countmap(xx)
+@test cm[1] == 200000
+@test cm[3] == 100_000
+@test cm[6] == 100_000
+
+xx = repeat([1, 1, 3, 6], outer=100_000);
+cm = Dict{Int, Int}()
+StatsBase.addcounts_radixsort!(cm,xx)
+@test cm[1] == 200000
+@test cm[3] == 100_000
+@test cm[6] == 100_000
+
+# testing the Dict-based addcounts
+cm = Dict{Int, Int}()
+StatsBase.addcounts_dict!(cm,xx)
+@test cm[1] == 200000
+@test cm[3] == 100_000
+@test cm[6] == 100_000
 
 cm = countmap(x, weights(w))
 @test cm["a"] == 5.5

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -85,6 +85,10 @@ pm = proportionmap(x)
 @test pm["b"] ≈ (1/3)
 @test pm["c"] ≈ (1/6)
 
+xx = vcat(repeat([1];inner = 100), rand(2:1000, 1_000_000))[sample(1:1_000_100, 1_000_100, replace=false)]
+cxx = countmap(xx)
+@test cxx[1] == 100
+
 cm = countmap(x, weights(w))
 @test cm["a"] == 5.5
 @test cm["b"] == 4.5


### PR DESCRIPTION
One performance benchmark included
```julia
using Compat, BenchmarkTools, SortingAlgorithms
@belapsed addcounts_radixsort!(Dict{Int,Int}(), rand(1:2_500_000,100_000_000)) #17 seconds
@belapsed addcounts_dict!(Dict{Int,Int}(), rand(1:2_500_000,100_000_000)) #26 seconds
```