### PR TITLE
faster sampling without replacement using  shrinking array algorithm

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -221,7 +221,7 @@ function shrinking_array_sample!(rng::AbstractRNG, a::AbstractArray, x::Abstract
     for (i, m) in zip(1:k, n:-1:n-k+1)
         rgen = RangeGenerator(1:m)
         idx = rand(rng, rgen)
-        x[i], a[idx] = a[idx], a[m]
+        @inbounds x[i], a[idx] = a[idx], a[m]
     end
 
     return x

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -216,13 +216,12 @@ counter by 1 each time - hence shrinking-array.
 function shrinking_array_sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray)
     n = length(a)
     k = length(x)
-    k <= n || error("length(x) should not exceed length(a)")
+    k <= n || error(DimensionMismatch("length(x) should not exceed length(a)"))
 
-    ca = copy(a)
     for (i, m) in zip(1:k, n:-1:n-k+1)
         rgen = RangeGenerator(1:m)
         idx = rand(rng, rgen)
-        x[i], ca[idx] = ca[idx], ca[m]
+        x[i], a[idx] = a[idx], a[m]
     end
 
     return x
@@ -370,7 +369,7 @@ function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
             elseif n < k * 24
                 fisher_yates_sample!(rng, a, x)
             else
-                shrinking_array_sample!(rng, a, x)
+                shrinking_array_sample!(rng, copy(a), x)
             end
         end
     end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -218,10 +218,13 @@ function shrinking_array_sample!(rng::AbstractRNG, a::AbstractArray, x::Abstract
     k = length(x)
     k <= n || throw(DimensionMismatch("length(x) should not exceed length(a)"))
 
+    # need to use an index instead as in the case where a = 1:j then a[jj] = val
+    # is not defined
+    aindex = collect(1:n)
     for (i, m) in zip(1:k, n:-1:n-k+1)
         rgen = RangeGenerator(1:m)
         idx = rand(rng, rgen)
-        @inbounds x[i], a[idx] = a[idx], a[m]
+        @inbounds x[i], aindex[idx] = a[aindex[idx]], aindex[m]
     end
 
     return x
@@ -369,7 +372,7 @@ function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
             elseif n < k * 24
                 fisher_yates_sample!(rng, a, x)
             else
-                shrinking_array_sample!(rng, copy(a), x)
+                shrinking_array_sample!(rng, a, x)
             end
         end
     end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -216,7 +216,7 @@ counter by 1 each time - hence shrinking-array.
 function shrinking_array_sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray)
     n = length(a)
     k = length(x)
-    k <= n || error(DimensionMismatch("length(x) should not exceed length(a)"))
+    k <= n || throw(DimensionMismatch("length(x) should not exceed length(a)"))
 
     for (i, m) in zip(1:k, n:-1:n-k+1)
         rgen = RangeGenerator(1:m)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -130,7 +130,7 @@ function check_sample_norep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=fa
 end
 
 import StatsBase: knuths_sample!, fisher_yates_sample!, self_avoid_sample!
-import StatsBase: seqsample_a!, seqsample_c!
+import StatsBase: seqsample_a!, seqsample_c!, shrinking_array_sample!
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)
@@ -155,6 +155,14 @@ end
 check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
 
 test_rng_use(self_avoid_sample!, 1:10, zeros(Int, 6))
+
+a = zeros(Int, 5, n)
+for j = 1:size(a,2)
+    shrinking_array_sample!(3:12, view(a,:,j))
+end
+check_sample_norep(a, (3, 12), 5.0e-3; ordered=false)
+
+test_rng_use(shrinking_array_sample!, 1:10, zeros(Int, 6))
 
 a = zeros(Int, 5, n)
 for j = 1:size(a,2)


### PR DESCRIPTION
See benchmark

```julia
using StatsBase
x = rand(1:1_000_000, 1_000_000)

@time StatsBase.self_avoid_sample!(x, similar(x)) # 5 seconds
@time StatsBase.shrinking_array_sample!(x, similar(x)) # 0.6 second
```