### PR TITLE
actually Bool,Big* are not radixsort_safe

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -285,8 +285,7 @@ end
 
 const BaseRadixSortSafeTypes = Union{Int8, Int16, Int32, Int64, Int128,
                                      UInt8, UInt16, UInt32, UInt64, UInt128,
-                                     Float16, Float32, Float64, Bool,
-                                     BigInt, BigFloat}
+                                     Float32, Float64}
 
 "Can the type be safely sorted by radixsort"
 radixsort_safe(::Type{T}) where {T<:BaseRadixSortSafeTypes} = true


### PR DESCRIPTION
This is due to implementation in sortingAlgorithms.jl. Sorry my bad, really should have had test cases to test all of these.

My bad. Won't happen again.