### PR TITLE
Loosened `countmap` and `addcount` signatures.

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -317,7 +317,7 @@ function addcounts_radixsort!(cm::Dict{T}, x::AbstractArray{T}) where T
     return cm
 end
 
-function addcounts!(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractWeights{W}) where {T,W}
+function addcounts!(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractVector{W}) where {T,W<:Real}
     n = length(x)
     length(wv) == n || throw(DimensionMismatch())
     w = values(wv)
@@ -352,7 +352,7 @@ of occurrences.
                      RAM and is safe for any data type.
 """
 countmap(x::AbstractArray{T}; alg = :auto) where {T} = addcounts!(Dict{T,Int}(), x; alg = alg)
-countmap(x::AbstractArray{T}, wv::AbstractWeights{W}) where {T,W} = addcounts!(Dict{T,W}(), x, wv)
+countmap(x::AbstractArray{T}, wv::AbstractVector{W}) where {T,W<:Real} = addcounts!(Dict{T,W}(), x, wv)
 
 
 """

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -107,6 +107,9 @@ cm = countmap(x, weights(w))
 @test cm["a"] == 5.5
 @test cm["b"] == 4.5
 @test cm["c"] == 3.5
+
+@test cm == countmap(x, w)
+
 pm = proportionmap(x, weights(w))
 @test pm["a"] ≈ (5.5 / 13.5)
 @test pm["b"] ≈ (4.5 / 13.5)


### PR DESCRIPTION
They can now accept any `AbstractVector{<:Real}` as weights w/o introducing
method ambiguities. Also, `AbstractWeights` is a subtype of `AbstractVector`, so the existing behaviour is preserved.

Closes #335 