### PR TITLE
generalize ranking

### DIFF
--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -16,7 +16,7 @@ end
 
 
 # Ordinal ranking ("1234 ranking") -- use the literal order resulted from sort
-function ordinalrank!(rks::RealArray, x::RealArray, p::IntegerArray)
+function ordinalrank!(rks::RealArray, x::AbstractArray, p::IntegerArray)
     n = _check_randparams(rks, x, p)
 
     if n > 0
@@ -32,18 +32,20 @@ end
 
 
 """
-    ordinalrank(x)
+    ordinalrank(x; lt = isless, rev::Bool = false)
 
 Return the [ordinal ranking](https://en.wikipedia.org/wiki/Ranking#Ordinal_ranking_.28.221234.22_ranking.29)
-("1234" ranking) of a real-valued array.
+("1234" ranking) of an array. The `lt` keyword allows providing a custom "less
+than" function; use `rev=true` to reverse the sorting order.
 All items in `x` are given distinct, successive ranks based on their
-position in `sort(x)`.
+position in `sort(x; lt = lt, rev = rev)`.
 """
-ordinalrank(x::RealArray) = ordinalrank!(Array{Int}(uninitialized, size(x)), x, sortperm(x))
+ordinalrank(x::AbstractArray; lt = isless, rev::Bool = false) =
+    ordinalrank!(Array{Int}(uninitialized, size(x)), x, sortperm(x; lt = lt, rev = rev))
 
 
 # Competition ranking ("1224" ranking) -- resolve tied ranks using min
-function competerank!(rks::RealArray, x::RealArray, p::IntegerArray)
+function competerank!(rks::RealArray, x::AbstractArray, p::IntegerArray)
     n = _check_randparams(rks, x, p)
 
     if n > 0
@@ -70,18 +72,20 @@ end
 
 
 """
-    competerank(x)
+    competerank(x; lt = isless, rev::Bool = false)
 
 Return the [standard competition ranking](http://en.wikipedia.org/wiki/Ranking#Standard_competition_ranking_.28.221224.22_ranking.29)
-("1224" ranking) of a real-valued
-array. Items that compare equal are given the same rank, then a gap is left
+("1224" ranking) of an array. The `lt` keyword allows providing a custom "less
+than" function; use `rev=true` to reverse the sorting order.
+Items that compare equal are given the same rank, then a gap is left
 in the rankings the size of the number of tied items - 1.
 """
-competerank(x::RealArray) = competerank!(Array{Int}(uninitialized, size(x)), x, sortperm(x))
+competerank(x::AbstractArray; lt = isless, rev::Bool = false) =
+    competerank!(Array{Int}(uninitialized, size(x)), x, sortperm(x; lt = lt, rev = rev))
 
 
 # Dense ranking ("1223" ranking) -- resolve tied ranks using min
-function denserank!(rks::RealArray, x::RealArray, p::IntegerArray)
+function denserank!(rks::RealArray, x::AbstractArray, p::IntegerArray)
     n = _check_randparams(rks, x, p)
 
     if n > 0
@@ -111,15 +115,17 @@ end
     denserank(x)
 
 Return the [dense ranking](http://en.wikipedia.org/wiki/Ranking#Dense_ranking_.28.221223.22_ranking.29)
-("1223" ranking) of a real-valued array. Items that
+("1223" ranking) of an array. The `lt` keyword allows providing a custom "less
+than" function; use `rev=true` to reverse the sorting order. Items that
 compare equal receive the same ranking, and the next subsequent rank is
 assigned with no gap.
 """
-denserank(x::RealArray) = denserank!(Array{Int}(uninitialized, size(x)), x, sortperm(x))
+denserank(x::AbstractArray; lt = isless, rev::Bool = false) =
+    denserank!(Array{Int}(uninitialized, size(x)), x, sortperm(x; lt = lt, rev = rev))
 
 
 # Tied ranking ("1 2.5 2.5 4" ranking) -- resolve tied ranks using average
-function tiedrank!(rks::RealArray, x::RealArray, p::IntegerArray)
+function tiedrank!(rks::RealArray, x::AbstractArray, p::IntegerArray)
     n = _check_randparams(rks, x, p)
 
     if n > 0
@@ -158,8 +164,11 @@ end
 
 Return the [tied ranking](http://en.wikipedia.org/wiki/Ranking#Fractional_ranking_.28.221_2.5_2.5_4.22_ranking.29),
 also called fractional or "1 2.5 2.5 4" ranking,
-of a real-valued array. Items that compare equal receive the mean of the
+of an array. The `lt` keyword allows providing a custom "less
+than" function; use `rev=true` to reverse the sorting order.
+Items that compare equal receive the mean of the
 rankings they would have been assigned under ordinal ranking.
 """
-tiedrank(x::RealArray) = tiedrank!(Array{Float64}(uninitialized, size(x)), x, sortperm(x))
+tiedrank(x::AbstractArray; lt = isless, rev::Bool = false) =
+    tiedrank!(Array{Float64}(uninitialized, size(x)), x, sortperm(x; lt = lt, rev = rev))
 

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -4,15 +4,28 @@ using Compat.Test
 
 a = [1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 4.0, 5.0]
 x = [3.0, 1.0, 2.0, 4.0, 4.0, 2.0, 5.0, 4.0]  # x is a permutated version of a
+s = ["c", "a", "b", "d", "d", "b", "e", "d"] # s is a vector of strings ordered like x
 
 @test ordinalrank(a) == [1, 2, 3, 4, 5, 6, 7, 8]
 @test ordinalrank(x) == [4, 1, 2, 5, 6, 3, 8, 7]
+@test ordinalrank(s) == ordinalrank(x)
+@test ordinalrank(x, rev = true) == ordinalrank(-x)
+@test ordinalrank(x, lt = (x, y) -> isless(y, x)) == ordinalrank(-x)
 
 @test competerank(a) == [1, 2, 2, 4, 5, 5, 5, 8]
 @test competerank(x) == [4, 1, 2, 5, 5, 2, 8, 5]
+@test competerank(s) == competerank(x)
+@test competerank(x, rev = true) == competerank(-x)
+@test competerank(x, lt = (x, y) -> isless(y, x)) == competerank(-x)
 
 @test denserank(a) == [1, 2, 2, 3, 4, 4, 4, 5]
 @test denserank(x) == [3, 1, 2, 4, 4, 2, 5, 4]
+@test denserank(s) == denserank(x)
+@test denserank(x, rev = true) == denserank(-x)
+@test denserank(x, lt = (x, y) -> isless(y, x)) == denserank(-x)
 
 @test tiedrank(a) == [1.0, 2.5, 2.5, 4.0, 6.0, 6.0, 6.0, 8.0]
 @test tiedrank(x) == [4.0, 1.0, 2.5, 6.0, 6.0, 2.5, 8.0, 6.0]
+@test tiedrank(s) == tiedrank(x)
+@test tiedrank(x, rev = true) == tiedrank(-x)
+@test tiedrank(x, lt = (x, y) -> isless(y, x)) == tiedrank(-x)


### PR DESCRIPTION
This PR allows to pass any `AbstractArray` to the ranking functions (they only need to be sortable, which is true much more generally than `Array{<:Real}` which is the current restriction). Also, one can now pass a custom "less than" function or reverse the order of sorting. `sortperm` also provides a `by` keyword (to give a function to be applied before sorting), but that wouldn't work here as it would screw up the equality comparison, the user will have to do `competerank(by.(x))`