### PR TITLE
Faster countmap for small bits type

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -283,6 +283,40 @@ function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
     return cm
 end
 
+"""Specialist addcounts methods for small bits types"""
+function addcounts!(cm::Dict{Bool}, x::AbstractArray{Bool})
+    sumx = sum(x)
+    cm[true] = sumx
+    cm[false] =length(x) = sumx
+    cm
+end
+
+"""toindex functions to convert an integer to an array index between 1 to typemax{T}"""
+function toindex(x::Int16)
+  Int(x) + 32769
+end
+
+function toindex(x::Int8)
+  Int(x) + 129
+end
+
+function toindex(x::T) where T <: Union{UInt8, UInt16}
+  Int(x) + 1
+end
+
+function addcounts!(cm::Dict{T}, x::Vector{T}) where T <: Union{UInt8, UInt16, Int8, Int16}
+  arr = zeros(Int, 2^(sizeof(T)*8))
+
+  for xi in x
+    @inbounds arr[toindex(xi)] += 1
+  end
+
+  for (i,arr1) in zip(typemin(T):typemax(T),arr)
+    arr1 == 0 || @inbounds cm[i] = arr1
+  end
+  cm
+end
+
 const BaseRadixSortSafeTypes = Union{Int8, Int16, Int32, Int64, Int128,
                                      UInt8, UInt16, UInt32, UInt64, UInt128,
                                      Float32, Float64}
@@ -351,6 +385,9 @@ of occurrences.
                      RAM and is safe for any data type.
 """
 countmap(x::AbstractArray{T}; alg = :auto) where {T} = addcounts!(Dict{T,Int}(), x; alg = alg)
+# specialist function for Bool
+countmap(x::AbstractArray{T}) where T<:Union{Bool, UInt8, UInt16, Int8, Int16} = addcounts!(Dict{T,Int}(), x) 
+    
 countmap(x::AbstractArray{T}, wv::AbstractVector{W}) where {T,W<:Real} = addcounts!(Dict{T,W}(), x, wv)
 
 

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -284,7 +284,7 @@ function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
 end
 
 """Specialist addcounts methods for small bits types"""
-function addcounts!(cm::Dict{Bool,Int}, x::AbstractArray{Bool})
+function addcounts!(cm::Dict{Bool}, x::AbstractArray{Bool})
     sumx = sum(x)
     cm[true] = sumx
     cm[false] = length(x) - sumx

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -264,7 +264,7 @@ function addcounts!(cm::Dict{T}, x::AbstractArray{T}; alg = :auto) where T
 
     # if it's safe to be sorted using radixsort then it should be faster
     # albeit using more RAM
-   if radixsort_safe(T) && (alg == :auto || alg == :radixsort)
+    if radixsort_safe(T) && (alg == :auto || alg == :radixsort)
         addcounts_radixsort!(cm, x)
     elseif alg == :radixsort
         throw(ArgumentError("`alg = :radixsort` is chosen but type `radixsort_safe($T)` did not return `true`; use `alg = :auto` or `alg = :dict` instead"))

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -286,7 +286,7 @@ end
 # If the bits type is of small size i.e. it can have up to 65536 distinct values
 # then it is always better to apply a counting-sort like reduce algorithm for 
 # faster results and less memory usage. However we still wish to enable others
-# to write generic algorithms, therefore the two methods below still accept the 
+# to write generic algorithms, therefore the methods below still accept the 
 # `alg` argument but it is ignored.
 function addcounts!(cm::Dict{Bool}, x::AbstractArray{Bool}; alg = :ignored)
     sumx = sum(x)
@@ -295,15 +295,22 @@ function addcounts!(cm::Dict{Bool}, x::AbstractArray{Bool}; alg = :ignored)
     cm
 end
 
-function addcounts!(cm::Dict{T}, x::Vector{T}; alg = :ignored) where T <: Union{UInt8, UInt16, Int8, Int16}
+function addcounts!(cm::Dict{T}, x::AbstractArray{T}; alg = :ignored) where T <: Union{UInt8, UInt16, Int8, Int16}
     counts = zeros(Int, 2^(8sizeof(T)))
 
-    for xi in x
-        @inbounds counts[Int(xi) - typemin(T) + 1] += 1
+    @inbounds for xi in x
+        counts[Int(xi) - typemin(T) + 1] += 1
     end
 
     for (i, c) in zip(typemin(T):typemax(T), counts)
-        c == 0 || @inbounds cm[i] = get(cm, i, 0) + c
+        if c != 0
+            index = ht_keyindex2!(cm, i)
+            if index > 0
+                @inbounds cm.vals[index] += c
+            else
+                @inbounds Base._setindex!(cm, c, i, -index)
+            end
+        end
     end
     cm
 end

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -284,10 +284,10 @@ function addcounts_dict!(cm::Dict{T}, x::AbstractArray{T}) where T
 end
 
 """Specialist addcounts methods for small bits types"""
-function addcounts!(cm::Dict{Bool}, x::AbstractArray{Bool})
+function addcounts!(cm::Dict{Bool,Int}, x::AbstractArray{Bool})
     sumx = sum(x)
     cm[true] = sumx
-    cm[false] =length(x) = sumx
+    cm[false] = length(x) - sumx
     cm
 end
 

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -119,14 +119,7 @@ pm = proportionmap(x, weights(w))
 bx = [true, false, true, true, false]
 @test countmap(bx) == Dict(true => 3, false => 2)
 
-tx = UInt8[0, 10, 255, 34, 10]
-@test countmap(tx) == Dict(0 => 1, 10 => 2, 255 => 1, 34 => 1)
-
-tx = UInt16[0, 8, 64000, 27, 8]
-@test countmap(tx) == Dict(0 => 1, 8 => 2, 64000 => 1, 27 => 1)
-
-tx = Int8[0, 10, -127, 34, 10]
-@test countmap(tx) == Dict(0 => 1, 10 => 2, -127 => 1, 34 => 1)
-
-tx = Int16[0, 9, -32000, 35, 9]
-@test countmap(tx) == Dict(0 => 1, 9 => 2, -32000 => 1, 35 => 1)
+for T in [UInt8, UInt16, Int8, Int16]
+    tx = T[typemin(T), 8, typemax(T), 19, 8]
+    @test countmap(tx) == Dict(typemin(T) => 1, typemax(T) => 1, 8 => 2, 19 => 1)
+end

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -119,14 +119,14 @@ pm = proportionmap(x, weights(w))
 bx = [true, false, true, true, false]
 @test countmap(bx) == Dict(true => 3, false => 2)
 
-uint8x = UInt8[0, 10, 255, 34, 10]
-@test countmap(uint8x) == Dict(0 => 1, 10 => 2, 255 => 1, 34 => 1)
+tx = UInt8[0, 10, 255, 34, 10]
+@test countmap(tx) == Dict(0 => 1, 10 => 2, 255 => 1, 34 => 1)
 
-uint16x = UInt16[0, 10, 255, 34, 10]
-@test countmap(uint16x) == Dict(0 => 1, 10 => 2, 255 => 1, 34 => 1)
+tx = UInt16[0, 8, 64000, 27, 8]
+@test countmap(tx) == Dict(0 => 1, 8 => 2, 64000 => 1, 27 => 1)
 
-int8x = Int8[0, 10, -127, 34, 10]
-@test countmap(int8x) == Dict(0 => 1, 10 => 2, -127 => 1, 34 => 1)
+tx = Int8[0, 10, -127, 34, 10]
+@test countmap(tx) == Dict(0 => 1, 10 => 2, -127 => 1, 34 => 1)
 
-int16x = Int16[0, 10, -127, 34, 10]
-@test countmap(int16x) == Dict(0 => 1, 10 => 2, -127 => 1, 34 => 1)
+tx = Int16[0, 9, -32000, 35, 9]
+@test countmap(tx) == Dict(0 => 1, 9 => 2, -32000 => 1, 35 => 1)

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -114,3 +114,19 @@ pm = proportionmap(x, weights(w))
 @test pm["a"] ≈ (5.5 / 13.5)
 @test pm["b"] ≈ (4.5 / 13.5)
 @test pm["c"] ≈ (3.5 / 13.5)
+
+# testing small bits type
+bx = [true, false, true, true, false]
+@test countmap(bx) == Dict(true => 3, false => 2)
+
+uint8x = UInt8[0, 10, 255, 34, 10]
+@test countmap(uint8x) == Dict(0 => 1, 10 => 2, 255 => 1, 34 => 1)
+
+uint16x = UInt16[0, 10, 255, 34, 10]
+@test countmap(uint16x) == Dict(0 => 1, 10 => 2, 255 => 1, 34 => 1)
+
+int8x = Int8[0, 10, -127, 34, 10]
+@test countmap(int8x) == Dict(0 => 1, 10 => 2, -127 => 1, 34 => 1)
+
+int16x = Int16[0, 10, -127, 34, 10]
+@test countmap(int16x) == Dict(0 => 1, 10 => 2, -127 => 1, 34 => 1)


### PR DESCRIPTION
See below benchmarking code which shows that the new algorithms for small bits types significantly outperforms the existing algorithms, e.g. for `Int16` the timing goes from 56.4s to 2.3s

![timings vs new algorithm for small bits types vs old](https://user-images.githubusercontent.com/4497189/34906099-6691cd02-f8ba-11e7-808f-de25f8b5ec0d.png)

```julia
import StatsBase: addcounts!, addcounts_dict!, addcounts_radixsort!

using Plots
bool = rand(Bool, 1_000_000_000);
bool_new = @elapsed addcounts!(Dict{Bool,Int}(), bool); # 0.7 
bool_old = @elapsed addcounts_dict!(Dict{Bool,Int}(), bool); # 13

uint8 = rand(UInt8, 1_000_000_000);
uint8_new = @elapsed addcounts!(Dict{UInt8,Int}(), uint8); # 1.1
uint8_old = @elapsed addcounts_radixsort!(Dict{UInt8,Int}(), uint8); # 8.78

int8 = rand(Int8, 1_000_000_000);
int8_new = @elapsed addcounts!(Dict{Int8,Int}(), int8); # 1.1
int8_old = @elapsed addcounts_radixsort!(Dict{Int8,Int}(), int8); # 8.5


uint16 = rand(UInt16, 1_000_000_000);
uint16_new = @elapsed addcounts!(Dict{UInt16,Int}(), uint16); # 2.3
uint16_old = @elapsed addcounts_radixsort!(Dict{UInt16,Int}(), uint16); # 59.73

int16 = rand(Int16, 1_000_000_000);
int16_new = @elapsed addcounts!(Dict{Int16,Int}(), int16) # 2.3
int16_old = @elapsed addcounts_radixsort!(Dict{Int16,Int}(), int16) # 56.4


using DataFrames

resdf = DataFrame(
    datatype = repeat(["Bool","UInt8","Int8","UInt16","Int16"], inner=2),
    new_old = repeat(["new","old"], outer=5),
    timings = [bool_new, bool_old, uint8_new, uint8_old, int8_new, int8_old, uint16_new, uint16_old, int16_new, int16_old])

resdf[:xlabel] = resdf[:datatype].*resdf[:new_old]
using Plots, StatPlots
groupedbar(resdf[:datatype], resdf[:timings], group=resdf[:new_old], bar_position = :dodge, ylabel="time (s)")
savefig("Timings vs new algorithm for small bits types vs old")
```

