### PR TITLE
Add midpoints, which was deprecated in Base.

### DIFF
--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -6,5 +6,5 @@ inverse_rle
 levelsmap
 indexmap
 indicatormat
-StatsBase.midpoints
+midpoints
 ```

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -6,4 +6,5 @@ inverse_rle
 levelsmap
 indexmap
 indicatormat
+StatsBase.midpoints
 ```

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -15,7 +15,7 @@ module StatsBase
         using Printf
     end
 
-    if VERSION < v"0.7-"
+    if VERSION < v"0.7.0-DEV.3335"
         import Base: midpoints
     end
 

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -130,7 +130,7 @@ module StatsBase
     Histogram,
     hist,
     # histrange,
-    midpoints,
+    # midpoints,    # TODO export when depending on Julia v0.7
 
     ## robust
     trim,           # trimmed set

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -15,6 +15,10 @@ module StatsBase
         using Printf
     end
 
+    if VERSION < v"0.7-"
+        import Base: midpoints
+    end
+
     ## tackle compatibility issues
 
     export
@@ -130,7 +134,7 @@ module StatsBase
     Histogram,
     hist,
     # histrange,
-    # midpoints,    # TODO export when depending on Julia v0.7
+    midpoints,
 
     ## robust
     trim,           # trimmed set

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -532,4 +532,4 @@ Calculate the midpoints (pairwise mean of consecutive elements).
 """
 midpoints(v::AbstractVector) = [middle(v[i - 1], v[i]) for i in 2:length(v)]
 
-midpoints(r::Range) = r[1:(end - 1)] + 0.5 * step(r)
+midpoints(r::Range) = r[1:(end - 1)] + step(r) / 2

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -524,3 +524,12 @@ have the same binning, shape of weights and properties (`closed` and
 weights of the resulting histogram will have the same type as those of `h`.
 """
 Base.merge(h::Histogram, others::Histogram...) = merge!(zero(h), h, others...)
+
+"""
+    midpoints(v)
+
+Calculate the midpoints (pairwise mean of consecutive elements).
+"""
+StatsBase.midpoints(v::AbstractVector) = [middle(v[i - 1], v[i]) for i in 2:length(v)]
+
+StatsBase.midpoints(r::Range) = r[1:(end - 1)] + 0.5 * step(r)

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -525,16 +525,11 @@ weights of the resulting histogram will have the same type as those of `h`.
 """
 Base.merge(h::Histogram, others::Histogram...) = merge!(zero(h), h, others...)
 
-if VERSION ≥ v"0.7-"
-    # HACK, along with qualified function names, remove when v0.6 is phased out
-    function midpoints end
-end
-
 """
     midpoints(v)
 
 Calculate the midpoints (pairwise mean of consecutive elements).
 """
-StatsBase.midpoints(v::AbstractVector) = [middle(v[i - 1], v[i]) for i in 2:length(v)]
+midpoints(v::AbstractVector) = [middle(v[i - 1], v[i]) for i in 2:length(v)]
 
-StatsBase.midpoints(r::Range) = r[1:(end - 1)] + 0.5 * step(r)
+midpoints(r::Range) = r[1:(end - 1)] + 0.5 * step(r)

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -525,6 +525,11 @@ weights of the resulting histogram will have the same type as those of `h`.
 """
 Base.merge(h::Histogram, others::Histogram...) = merge!(zero(h), h, others...)
 
+if VERSION ≥ v"0.7-"
+    # HACK, along with qualified function names, remove when v0.6 is phased out
+    function midpoints end
+end
+
 """
     midpoints(v)
 

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -227,8 +227,8 @@ end
 end
 
 @testset "midpoints" begin
-    @test StatsBase.midpoints([1, 2, 4]) == [1.5, 3.0]
-    @test StatsBase.midpoints(linspace(0, 1, 5)) == 0.125:0.25:0.875
+    @test midpoints([1, 2, 4]) == [1.5, 3.0]
+    @test midpoints(linspace(0, 1, 5)) == 0.125:0.25:0.875
 end
 
 end # @testset "StatsBase.Histogram"

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -226,5 +226,9 @@ end
     @test (@inferred merge(histograms...)) == h
 end
 
+@testset "midpoints" begin
+    @test StatsBase.midpoints([1, 2, 4]) == [1.5, 3.0]
+    @test StatsBase.midpoints(linspace(0, 1, 5)) == 0.125:0.25:0.875
+end
 
 end # @testset "StatsBase.Histogram"


### PR DESCRIPTION
Currently not exported, to avoid symbol conflict.