### PR TITLE
don't import/export midpoints on 0.6

### DIFF
--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -6,5 +6,5 @@ inverse_rle
 levelsmap
 indexmap
 indicatormat
-midpoints
+StatsBase.midpoints
 ```

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -15,10 +15,6 @@ module StatsBase
         using Printf
     end
 
-    if VERSION < v"0.7.0-DEV.3335"
-        import Base: midpoints
-    end
-
     ## tackle compatibility issues
 
     export
@@ -134,7 +130,6 @@ module StatsBase
     Histogram,
     hist,
     # histrange,
-    midpoints,
 
     ## robust
     trim,           # trimmed set
@@ -186,6 +181,10 @@ module StatsBase
     model_response,
 
     ConvergenceException
+
+@static if !isdefined(Base, :midpoints)
+    export midpoints
+end
 
     # source files
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -526,7 +526,7 @@ weights of the resulting histogram will have the same type as those of `h`.
 Base.merge(h::Histogram, others::Histogram...) = merge!(zero(h), h, others...)
 
 """
-    midpoints(v)
+    StatsBase.midpoints(v)
 
 Calculate the midpoints (pairwise mean of consecutive elements).
 """

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -227,8 +227,8 @@ end
 end
 
 @testset "midpoints" begin
-    @test midpoints([1, 2, 4]) == [1.5, 3.0]
-    @test midpoints(linspace(0, 1, 5)) == 0.125:0.25:0.875
+    @test StatsBase.midpoints([1, 2, 4]) == [1.5, 3.0]
+    @test StatsBase.midpoints(linspace(0, 1, 5)) == 0.125:0.25:0.875
 end
 
 end # @testset "StatsBase.Histogram"


### PR DESCRIPTION
fix https://github.com/JuliaStats/StatsBase.jl/pull/345#issuecomment-366185186