### PR TITLE
mad() and mad!() improvements

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -82,3 +82,6 @@ rand(s::RandIntSampler) = rand(Base.GLOBAL_RNG, s)
 @deprecate randi(rng::AbstractRNG, a::Int, b::Int) rand(rng, a:b)
 @deprecate randi(a::Int, b::Int) rand(a:b)
 
+@deprecate(mad!(v::AbstractArray{T}, center;
+                constant::Real = 1 / (-sqrt(2 * one(T)) * erfcinv(3 * one(T) / 2))) where T<:Real,
+           mad!(v, center=center, constant=constant))

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -238,45 +238,62 @@ sem(a::AbstractArray{<:Real}) = sqrt(var(a) / length(a))
 
 # Median absolute deviation
 """
-    mad(v; center=median(v), constant=1/quantile(Normal(), 3/4))
+    mad(v; center=median(v), normalize=true)
 
 Compute the median absolute deviation (MAD) of `v` around `center`
 (by default, around the median).
 
-Using the MAD as a consistent estimator of the standard deviation requires
-a scaling factor that depends on the underlying distribution.
-By default, `constant` is set to `1 / quantile(Normal(), 3/4) ≈ 1.4826`,
-which is appropriate for normally distributed data.
+If `normalize` is set to `true`, the MAD is multiplied by
+`1 / quantile(Normal(), 3/4) ≈ 1.4826`, in order to obtain a consistent estimator
+of the standard deviation under the assumption that the data is normally distributed.
 """
 function mad(v::AbstractArray{T};
-             center=median(v),
-             constant::Real = 1 / (-sqrt(2 * one(T)) * erfcinv(3 * one(T) / 2))) where T<:Real
+             center::Union{Real,Nothing}=nothing,
+             normalize::Union{Bool, Nothing}=nothing) where T<:Real
     isempty(v) && throw(ArgumentError("mad is not defined for empty arrays"))
 
     S = promote_type(T, typeof(middle(first(v))))
+    v2 = LinAlg.copy_oftype(v, S)
 
-    mad!(LinAlg.copy_oftype(v, S), center=center, constant=constant)
+    if normalize === nothing
+        Base.depwarn("the `normalize` keyword argument will be false by default in future releases: set it explicitly to silence this deprecation", :mad)
+        normalize = true
+    end
+
+    mad!(v2, center=center === nothing ? median!(v2) : center, normalize=normalize)
 end
 
 
 """
-    StatsBase.mad!(v; center=median!(v), constant=1/quantile(Normal(), 3/4))
+    StatsBase.mad!(v; center=median!(v), normalize=true)
 
 Compute the median absolute deviation (MAD) of `v` around `center`
 (by default, around the median), overwriting `v` in the process.
 
-Using the MAD as a consistent estimator of the standard deviation requires
-a scaling factor that depends on the underlying distribution.
-By default, `constant` is set to `1 / quantile(Normal(), 3/4) ≈ 1.4826`,
-which is appropriate for normally distributed data.
+If `normalize` is set to `true`, the MAD is multiplied by
+`1 / quantile(Normal(), 3/4) ≈ 1.4826`, in order to obtain a consistent estimator
+of the standard deviation under the assumption that the data is normally distributed.
 """
 function mad!(v::AbstractArray{T};
               center::Real=median!(v),
-              constant::Real = 1 / (-sqrt(2 * one(T)) * erfcinv(3 * one(T) / 2))) where T<:Real
+              normalize::Union{Bool,Nothing}=true,
+              constant=nothing) where T<:Real
     for i in 1:length(v)
         @inbounds v[i] = abs(v[i]-center)
     end
-    constant * median!(v)
+    k = 1 / (-sqrt(2 * one(T)) * erfcinv(3 * one(T) / 2))
+    if normalize === nothing
+        Base.depwarn("the `normalize` keyword argument will be false by default in future releases: set it explicitly to silence this deprecation", :mad)
+        normalize = true
+    end
+    if constant !== nothing
+        Base.depwarn("keyword argument `constant` is deprecated, use `normalize` instead or apply the multiplication directly", :mad)
+        constant * median!(v)
+    elseif normalize
+        k * median!(v)
+    else
+        one(k) * median!(v)
+    end
 end
 
 # Interquartile range

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -81,10 +81,13 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 
 @test sem([1:5;]) ≈ 0.707106781186548
 
-@test StatsBase.mad!([1:5;], 3) ≈ 1.4826022185056018
+@test StatsBase.mad(1:5; center=3) ≈ 1.4826022185056018
+@test StatsBase.mad!([1:5;]; center=3) ≈ 1.4826022185056018
 @test mad(1:5) ≈ 1.4826022185056018
+@test StatsBase.mad(1:5, constant=1.0) ≈ 1.0
 @test StatsBase.mad!([1:5;], constant=1.0) ≈ 1.0
-@test StatsBase.mad!([1:5;], 3, constant=1.0) ≈ 1.0
+@test StatsBase.mad(1:5, center=3, constant=1.0) ≈ 1.0
+@test StatsBase.mad!([1:5;], center=3, constant=1.0) ≈ 1.0
 @test_throws ArgumentError mad(Int[])
 
 # Issue 197

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -81,17 +81,17 @@ z2 = [8. 2. 3. 1.; 24. 10. -1. -1.; 20. 12. 1. -2.]
 
 @test sem([1:5;]) ≈ 0.707106781186548
 
-@test StatsBase.mad(1:5; center=3) ≈ 1.4826022185056018
-@test StatsBase.mad!([1:5;]; center=3) ≈ 1.4826022185056018
-@test mad(1:5) ≈ 1.4826022185056018
-@test StatsBase.mad(1:5, constant=1.0) ≈ 1.0
-@test StatsBase.mad!([1:5;], constant=1.0) ≈ 1.0
-@test StatsBase.mad(1:5, center=3, constant=1.0) ≈ 1.0
-@test StatsBase.mad!([1:5;], center=3, constant=1.0) ≈ 1.0
+@test StatsBase.mad(1:5; center=3, normalize=true) ≈ 1.4826022185056018
+@test StatsBase.mad!([1:5;]; center=3, normalize=true) ≈ 1.4826022185056018
+@test mad(1:5, normalize=true) ≈ 1.4826022185056018
+@test StatsBase.mad(1:5, normalize=false) ≈ 1.0
+@test StatsBase.mad!([1:5;], normalize=false) ≈ 1.0
+@test StatsBase.mad(1:5, center=3, normalize=false) ≈ 1.0
+@test StatsBase.mad!([1:5;], center=3, normalize=false) ≈ 1.0
 @test_throws ArgumentError mad(Int[])
 
 # Issue 197
-@test mad(1:2) ≈ 0.7413011092528009
+@test mad(1:2, normalize=true) ≈ 0.7413011092528009
 
 @test iqr(1:5) ≈ 2.0
 


### PR DESCRIPTION
Add `center` and `constant` arguments to `mad`, as for `mad!`. Make `center` a keyword argument for `mad!`. Improve docstrings.

Fixes https://github.com/JuliaStats/StatsBase.jl/issues/347.