### PR TITLE
Fix random test failure in cov.jl due to negative varcorrection

### DIFF
--- a/test/cov.jl
+++ b/test/cov.jl
@@ -13,6 +13,12 @@ weight_funcs = (weights, aweights, fweights, pweights)
     w1 = rand(3)
     w2 = rand(8)
 
+    # varcorrection is negative if sum of weights is smaller than 1
+    if f === fweights
+        w1[1] += 1
+        w2[1] += 1
+    end
+
     wv1 = f(w1)
     wv2 = f(w2)
 


### PR DESCRIPTION
See https://github.com/JuliaStats/StatsBase.jl/pull/362.