### PR TITLE
Fix bug in addcounts_radixsort! when passing existing counts

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -324,9 +324,9 @@ radixsort_safe(::Type{T}) where {T<:BaseRadixSortSafeTypes} = true
 radixsort_safe(::Type) = false
 
 function _addcounts_radix_sort_loop!(cm::Dict{T}, sx::AbstractArray{T}) where T
-    tmpcount = 1
     last_sx = sx[1]
-
+    tmpcount = get(cm, last_sx, 0) + 1
+    
     # now the data is sorted: can just run through and accumulate values before
     # adding into the Dict
     @inbounds for i in 2:length(sx)
@@ -336,7 +336,7 @@ function _addcounts_radix_sort_loop!(cm::Dict{T}, sx::AbstractArray{T}) where T
         else
             cm[last_sx] = tmpcount
             last_sx = sxi
-            tmpcount = 1
+            tmpcount = get(cm, last_sx, 0) + 1
         end
     end
 

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -97,6 +97,9 @@ xx = repeat([6, 1, 3, 1], outer=100_000)
 cm = Dict{Int, Int}()
 StatsBase.addcounts_radixsort!(cm,xx)
 @test cm == Dict(1 => 200_000, 3 => 100_000, 6 => 100_000)
+xx2 = repeat([7, 1, 3, 1], outer=100_000)
+StatsBase.addcounts_radixsort!(cm,xx2)
+@test cm == Dict(1 => 400_000, 3 => 200_000, 6 => 100_000, 7 => 100_000)
 
 # testing the Dict-based addcounts
 cm = Dict{Int, Int}()


### PR DESCRIPTION
The addcounts_radixsort! wasn't adding the counts! It is now fixed with tests to prevent it from happening again. See #376 