### PR TITLE
Fix scalarstats docs

### DIFF
--- a/docs/src/scalarstats.md
+++ b/docs/src/scalarstats.md
@@ -46,7 +46,7 @@ percentile
 iqr
 nquantile
 quantile
-Base.median{W<:Real}(v::StatsBase.RealVector, w::AbstractWeights{W})
+Base.median(v::StatsBase.RealVector, w::AbstractWeights{<:Real})
 ```
 
 ## Mode and Modes

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -60,3 +60,15 @@ isempty
 values
 sum
 ```
+
+The following constructors are provided:
+```@docs
+AnalyticWeights
+FrequencyWeights
+ProbabilityWeights
+Weights
+aweights
+fweights
+pweights
+weights
+```


### PR DESCRIPTION
The invalid docstring signature for median triggered a Documenter error and the block was left as-is in the manual. Fixing this uncovered another error due to the missing docstrings for weight vectors constructors.