### PR TITLE
Qualify call to `mapreduce_impl` with `Base`

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -68,7 +68,7 @@ centralizedabs2fun(m) = x -> abs2.(x - m)
 centralize_sumabs2(A::AbstractArray, m) =
     mapreduce(centralizedabs2fun(m), +, A)
 centralize_sumabs2(A::AbstractArray, m, ifirst::Int, ilast::Int) =
-    mapreduce_impl(centralizedabs2fun(m), +, A, ifirst, ilast)
+    Base.mapreduce_impl(centralizedabs2fun(m), +, A, ifirst, ilast)
 
 function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::AbstractArray) where S
     # following the implementation of _mapreducedim! at base/reducedim.jl

--- a/test/base.jl
+++ b/test/base.jl
@@ -71,6 +71,9 @@ using Test, Random, LinearAlgebra, SparseArrays
     @test var([1 2 3 4 5; 6 7 8 9 10], dims=2) ≈ [2.5 2.5]'
     @test var([1 2 3 4 5; 6 7 8 9 10], dims=2; corrected=false) ≈ [2.0 2.0]'
 
+    @test var(collect(1:99), dims=1) ≈ [825]
+    @test var(Matrix(transpose(collect(1:99))), dims=2) ≈ [825]
+
     @test stdm([1,2,3], 2) ≈ 1.
     @test std([1,2,3]) ≈ 1.
     @test std([1,2,3]; corrected=false) ≈ sqrt(2.0/3)


### PR DESCRIPTION
Fixes #381. In the long term, avoiding a call to this internal function might be less fragile, but to get `var` working again quickly without performance impact, this is easiest.