### PR TITLE
Avoid overwriting auto-generated *Weights constructors 

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -13,6 +13,11 @@ macro weights(name)
             values::V
             sum::S
         end
+        if VERSION < v"0.7.0-DEV.5260"
+            $(esc(name))(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} = $(esc(name)){S, eltype(vs), V}(vs, s)
+        else
+            $(esc(name))(vs) = $(esc(name))(vs, sum(vs))
+        end
     end
 end
 
@@ -55,12 +60,6 @@ all operations possible for [`FrequencyWeights`](@ref), [`AnalyticWeights`](@ref
 and [`ProbabilityWeights`](@ref).
 """ Weights
 
-if VERSION < v"0.7.0-DEV.5260"
-    Weights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} = Weights{S, eltype(vs), V}(vs, s)
-else
-    Weights(vs) = Weights(vs, sum(vs))
-end
-
 """
     weights(vs)
 
@@ -95,13 +94,6 @@ for each observation. These weights may also be referred to as reliability weigh
 precision weights or inverse variance weights. These are typically used when the observations
 being weighted are aggregate values (e.g., averages) with differing variances.
 """ AnalyticWeights
-
-if VERSION < v"0.7.0-DEV.5260"
-    AnalyticWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
-        AnalyticWeights{S, eltype(vs), V}(vs, s)
-else
-    AnalyticWeights(vs::RealVector) = AnalyticWeights(vs, sum(vs))
-end
 
 """
     aweights(vs)
@@ -141,13 +133,6 @@ Frequency weights describe the number of times (or frequency) each observation
 was observed. These weights may also be referred to as case weights or repeat weights.
 """ FrequencyWeights
 
-if VERSION < v"0.7.0-DEV.5260"
-    FrequencyWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
-        FrequencyWeights{S, eltype(vs), V}(vs, s)
-else
-    FrequencyWeights(vs::RealVector) = FrequencyWeights(vs, sum(vs))
-end
-
 """
     fweights(vs)
 
@@ -185,13 +170,6 @@ Probability weights represent the inverse of the sampling probability for each o
 providing a correction mechanism for under- or over-sampling certain population groups.
 These weights may also be referred to as sampling weights.
 """ ProbabilityWeights
-
-if VERSION < v"0.7.0-DEV.5260"
-    ProbabilityWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
-        ProbabilityWeights{S, eltype(vs), V}(vs, s)
-else
-    ProbabilityWeights(vs::RealVector) = ProbabilityWeights(vs, sum(vs))
-end
 
 """
     pweights(vs)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -44,7 +44,7 @@ otherwise returns ``\\frac{1}{n}`` (i.e. no correction).
 
 @weights Weights
 
-"""
+@doc """
     Weights(vs, wsum=sum(vs))
 
 Construct a `Weights` vector with weight values `vs`.
@@ -53,8 +53,13 @@ A precomputed sum may be provided as `wsum`.
 The `Weights` type describes a generic weights vector which does not support
 all operations possible for [`FrequencyWeights`](@ref), [`AnalyticWeights`](@ref)
 and [`ProbabilityWeights`](@ref).
-"""
-Weights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} = Weights{S, eltype(vs), V}(vs, s)
+""" Weights
+
+if VERSION < v"0.7.0-DEV.5260"
+    Weights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} = Weights{S, eltype(vs), V}(vs, s)
+else
+    Weights(vs) = Weights(vs, sum(vs))
+end
 
 """
     weights(vs)
@@ -79,7 +84,7 @@ end
 
 @weights AnalyticWeights
 
-"""
+@doc """
     AnalyticWeights(vs, wsum=sum(vs))
 
 Construct an `AnalyticWeights` vector with weight values `vs`.
@@ -89,9 +94,14 @@ Analytic weights describe a non-random relative importance (usually between 0 an
 for each observation. These weights may also be referred to as reliability weights,
 precision weights or inverse variance weights. These are typically used when the observations
 being weighted are aggregate values (e.g., averages) with differing variances.
-"""
-AnalyticWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
-    AnalyticWeights{S, eltype(vs), V}(vs, s)
+""" AnalyticWeights
+
+if VERSION < v"0.7.0-DEV.5260"
+    AnalyticWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
+        AnalyticWeights{S, eltype(vs), V}(vs, s)
+else
+    AnalyticWeights(vs::RealVector) = AnalyticWeights(vs, sum(vs))
+end
 
 """
     aweights(vs)
@@ -121,7 +131,7 @@ end
 
 @weights FrequencyWeights
 
-"""
+@doc """
     FrequencyWeights(vs, wsum=sum(vs))
 
 Construct a `FrequencyWeights` vector with weight values `vs`.
@@ -129,9 +139,14 @@ A precomputed sum may be provided as `wsum`.
 
 Frequency weights describe the number of times (or frequency) each observation
 was observed. These weights may also be referred to as case weights or repeat weights.
-"""
-FrequencyWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
-    FrequencyWeights{S, eltype(vs), V}(vs, s)
+""" FrequencyWeights
+
+if VERSION < v"0.7.0-DEV.5260"
+    FrequencyWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
+        FrequencyWeights{S, eltype(vs), V}(vs, s)
+else
+    FrequencyWeights(vs::RealVector) = FrequencyWeights(vs, sum(vs))
+end
 
 """
     fweights(vs)
@@ -160,7 +175,7 @@ end
 
 @weights ProbabilityWeights
 
-"""
+@doc """
     ProbabilityWeights(vs, wsum=sum(vs))
 
 Construct a `ProbabilityWeights` vector with weight values `vs`.
@@ -169,9 +184,14 @@ A precomputed sum may be provided as `wsum`.
 Probability weights represent the inverse of the sampling probability for each observation,
 providing a correction mechanism for under- or over-sampling certain population groups.
 These weights may also be referred to as sampling weights.
-"""
-ProbabilityWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
-    ProbabilityWeights{S, eltype(vs), V}(vs, s)
+""" ProbabilityWeights
+
+if VERSION < v"0.7.0-DEV.5260"
+    ProbabilityWeights(vs::V, s::S=sum(vs)) where {S<:Real, V<:RealVector} =
+        ProbabilityWeights{S, eltype(vs), V}(vs, s)
+else
+    ProbabilityWeights(vs::RealVector) = ProbabilityWeights(vs, sum(vs))
+end
 
 """
     pweights(vs)


### PR DESCRIPTION
Fixes #386 (well, not the "make a release" part, obviously).