### PR TITLE
Correct R² formulas and add Efron's R²

### DIFF
--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -198,6 +198,10 @@ For a linear model, the R² is defined as ``ESS/TSS``, with ``ESS`` the explaine
 and ``TSS`` the total sum of squares.
 """
 function r2(obj::StatisticalModel)
+
+    Base.depwarn("The default r² method for linear models is deprecated. " *
+                 "Packages should define their own methods.", :r2)
+
     μ = meanresponse(obj)
     mss(obj) / sum(x -> abs2(x - μ), response(obj))
 end

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -228,7 +228,7 @@ function r2(obj::StatisticalModel, variant::Symbol)
         y = response(obj)
         ŷ = fitted(obj)
         μ = meanresponse(obj)
-        1 - sum(abs2, y .- ŷ) / sum(x -> abs2(x - μ), response(obj))
+        1 - sum(x -> abs2(x[1] - x[2]), zip(y, ŷ)) / sum(x -> abs2(x - μ), response(obj))
     else
         ll = loglikelihood(obj)
         ll0 = nullloglikelihood(obj)

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -201,8 +201,7 @@ function r2(obj::StatisticalModel)
     Base.depwarn("The default r² method for linear models is deprecated. " *
                  "Packages should define their own methods.", :r2)
 
-    μ = meanresponse(obj)
-    mss(obj) / sum(x -> abs2(x - μ), response(obj))
+    mss(obj) / deviance(obj)
 end
 
 """

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -198,7 +198,6 @@ For a linear model, the R² is defined as ``ESS/TSS``, with ``ESS`` the explaine
 and ``TSS`` the total sum of squares.
 """
 function r2(obj::StatisticalModel)
-
     Base.depwarn("The default r² method for linear models is deprecated. " *
                  "Packages should define their own methods.", :r2)
 


### PR DESCRIPTION
This PR fixed the R² formulas, which were previously based on the deviance instead of the likelihood function. It also adds Efron's R².
The following variants were benchmarked against Stata's fitstat: McFadden, Cox and Snell, Nagelkerke and Efron.
Cox and Snell's and Efron's R² should match the classical R² for linear models.

Closes #396.