### PR TITLE
Require Julia 0.7.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7.0-beta2
+julia 0.7.0
 DataStructures 0.5.0
 SortingAlgorithms
 Missings


### PR DESCRIPTION
To avoid getting capped automatically in registries.