### PR TITLE
Return a callable type from ecdf instead of a closure.

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -1,7 +1,7 @@
 __precompile__()
 
 module StatsBase
-    import Base: length, isempty, eltype, values, sum, show
+    import Base: length, isempty, eltype, values, sum, show, maximum, minimum, extrema
     import Base.Cartesian: @nloops, @nref, @nextract
     using Base: @irrational, @propagate_inbounds
     import DataStructures: heapify!, heappop!, percolate_down!
@@ -129,6 +129,7 @@ module StatsBase
 
     ## empirical
     ecdf,           # empirical cumulative distribution function
+    ECDF,           # type for empirical cumulative distribution function
 
     AbstractHistogram,
     Histogram,

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -2,46 +2,55 @@
 
 
 ## Empirical CDF
+
+struct ECDF{T <: AbstractVector{<:Real}}
+    sorted_values::T
+end
+
+function (ecdf::ECDF)(x::Real)
+    searchsortedlast(ecdf.sorted_values, x) / length(ecdf.sorted_values)
+end
+
+function (ecdf::ECDF)(v::RealVector)
+    ord = sortperm(v)
+    m = length(v)
+    r = similar(ecdf.sorted_values, m)
+    r0 = 0
+    i = 1
+    n = length(ecdf.sorted_values)
+    for x in ecdf.sorted_values
+        while i <= m && x > v[ord[i]]
+            r[ord[i]] = r0
+            i += 1
+        end
+        r0 += 1
+        if i > m
+            break
+        end
+    end
+    while i <= m
+        r[ord[i]] = n
+        i += 1
+    end
+    return r / n
+end
+
 """
     ecdf(X)
 
 Return an empirical cumulative distribution function (ECDF) based on a vector of samples
 given in `X`.
 
-Note: this is a higher-level function that returns a function, which can then be applied
-to evaluate CDF values on other samples.
+Note: this function that returns a callable composite type, which can then be applied to
+evaluate CDF values on other samples.
+
+`extrema`, `minimum`, and `maximum` are supported to for obtaining the range over which
+function is inside the interval ``(0,1)``; the function is defined for the whole real line.
 """
-function ecdf(X::RealVector{T}) where T<:Real
-    Xs = sort(X)
-    n = length(X)
+ecdf(X::RealVector{T}) where T<:Real = ECDF(sort(X))
 
-    ef(x::Real) = searchsortedlast(Xs, x) / n
+minimum(ecdf::ECDF) = first(ecdf.sorted_values)
 
-    function ef(v::RealVector)
-        ord = sortperm(v)
-        m = length(v)
-        r = Vector{T}(undef, m)
-        r0 = 0
+maximum(ecdf::ECDF) = last(ecdf.sorted_values)
 
-        i = 1
-        for x in Xs
-            while i <= m && x > v[ord[i]]
-                r[ord[i]] = r0
-                i += 1
-            end
-            r0 += 1
-            if i > m
-                break
-            end
-        end
-        while i <= m
-            r[ord[i]] = n
-            i += 1
-        end
-        return r / n
-    end
-
-    return ef
-end
-
-
+extrema(ecdf::ECDF) = (minimum(ecdf), maximum(ecdf))

--- a/test/empirical.jl
+++ b/test/empirical.jl
@@ -1,12 +1,15 @@
 using StatsBase
 using Test
 
-fnecdf = ecdf(randn(10000000))
-@test isapprox(fnecdf([-1.96, -1.644854, -1.281552, -0.6744898, 0, 0.6744898, 1.281552, 1.644854, 1.96]),
-    [0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.975], atol=1e-3)
-@test isapprox(fnecdf(1.96), 0.975, atol=1e-3)
-@test fnecdf([-1.96, -1.644854, -1.281552, -0.6744898, 0, 0.6744898, 1.281552, 1.644854, 1.96]) ≈
-    map(fnecdf, [-1.96, -1.644854, -1.281552, -0.6744898, 0, 0.6744898, 1.281552, 1.644854, 1.96])
-
-fnecdf = ecdf([0.5])
-@test fnecdf([zeros(5000); ones(5000)]) == [zeros(5000); ones(5000)]
+@testset "ECDF" begin
+    x = randn(10000000)
+    fnecdf = ecdf(x)
+    y = [-1.96, -1.644854, -1.281552, -0.6744898, 0, 0.6744898, 1.281552, 1.644854, 1.96]
+    @test isapprox(fnecdf(y), [0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.975], atol=1e-3)
+    @test isapprox(fnecdf(1.96), 0.975, atol=1e-3)
+    @test fnecdf(y) ≈ map(fnecdf, y)
+    @test extrema(fnecdf) == (minimum(fnecdf), maximum(fnecdf)) == extrema(x)
+    fnecdf = ecdf([0.5])
+    @test fnecdf([zeros(5000); ones(5000)]) == [zeros(5000); ones(5000)]
+    @test extrema(fnecdf) == (minimum(fnecdf), maximum(fnecdf)) == (0.5, 0.5)
+end


### PR DESCRIPTION
Also define minimum, maximum, and extrema.

**Rationale:** this should allow other packages to dispatch on the results of `ecdf`, eg for plotting. Accessor functions are defined for this purpose.

**Implementation:** code was moved mostly unchanged. Tests added for new functionality.