### PR TITLE
Use keyword argument for dims in scatter and weighted mean

### DIFF
--- a/src/cov.jl
+++ b/src/cov.jl
@@ -85,7 +85,7 @@ _scattermatm(x::DenseMatrix, mean, dims::Int=1) =
 scattermat(x::DenseMatrix, wv::AbstractWeights; mean=nothing, dims::Int=1) =
     _scattermatm(x, wv, mean, dims)
 _scattermatm(x::DenseMatrix, wv::AbstractWeights, ::Nothing, dims::Int) =
-    _unscaled_covzm(x .- mean(x, wv, dims), wv, dims)
+    _unscaled_covzm(x .- mean(x, wv, dims=dims), wv, dims)
 _scattermatm(x::DenseMatrix, wv::AbstractWeights, mean, dims::Int) =
     _unscaled_covzm(x .- mean, wv, dims)
 
@@ -103,8 +103,8 @@ covm(x::DenseMatrix, mean, w::AbstractWeights, dims::Int=1;
     rmul!(scattermat(x, w, mean=mean, dims=dims), varcorrection(w, depcheck(:covm, corrected)))
 
 
-cov(x::DenseMatrix, w::AbstractWeights, vardim::Int=1; corrected::DepBool=nothing) =
-    covm(x, mean(x, w, vardim), w, vardim; corrected=depcheck(:cov, corrected))
+cov(x::DenseMatrix, w::AbstractWeights, dims::Int=1; corrected::DepBool=nothing) =
+    covm(x, mean(x, w, dims=dims), w, dims; corrected=depcheck(:cov, corrected))
 
 function corm(x::DenseMatrix, mean, w::AbstractWeights, vardim::Int=1)
     c = covm(x, mean, w, vardim; corrected=false)
@@ -113,22 +113,22 @@ function corm(x::DenseMatrix, mean, w::AbstractWeights, vardim::Int=1)
 end
 
 """
-    cor(X, w::AbstractWeights, vardim=1)
+    cor(X, w::AbstractWeights, dims=1)
 
 Compute the Pearson correlation matrix of `X` along the dimension
-`vardim` with a weighting `w` .
+`dims` with a weighting `w` .
 """
-cor(x::DenseMatrix, w::AbstractWeights, vardim::Int=1) =
-    corm(x, mean(x, w, vardim), w, vardim)
+cor(x::DenseMatrix, w::AbstractWeights, dims::Int=1) =
+    corm(x, mean(x, w, dims=dims), w, dims)
 
-function mean_and_cov(x::DenseMatrix, vardim::Int=1; corrected::Bool=true)
-    m = mean(x, dims = vardim)
-    return m, covm(x, m, vardim, corrected=corrected)
+function mean_and_cov(x::DenseMatrix, dims::Int=1; corrected::Bool=true)
+    m = mean(x, dims=dims)
+    return m, covm(x, m, dims, corrected=corrected)
 end
-function mean_and_cov(x::DenseMatrix, wv::AbstractWeights, vardim::Int=1;
+function mean_and_cov(x::DenseMatrix, wv::AbstractWeights, dims::Int=1;
                       corrected::DepBool=nothing)
-    m = mean(x, wv, vardim)
-    return m, cov(x, wv, vardim; corrected=depcheck(:mean_and_cov, corrected))
+    m = mean(x, wv, dims=dims)
+    return m, cov(x, wv, dims; corrected=depcheck(:mean_and_cov, corrected))
 end
 
 """

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -89,14 +89,6 @@ _scattermatm(x::DenseMatrix, wv::AbstractWeights, ::Nothing, dims::Int) =
 _scattermatm(x::DenseMatrix, wv::AbstractWeights, mean, dims::Int) =
     _unscaled_covzm(x .- mean, wv, dims)
 
-### Deprecated January 2019
-@deprecate scattermatm(x::DenseMatrix, mean, dims::Int) scattermat(x, mean=mean, dims=dims)
-@deprecate scattermatm(x::DenseMatrix, mean, wv::AbstractWeights, dims::Int) scattermat(x, wv, mean=mean, dims=dims)
-@deprecate scattermat(x::DenseMatrix, dims::Int) scattermat(x, dims=dims)
-@deprecate scattermat(x::DenseMatrix, wv::AbstractWeights, dims::Int) scattermat(x, wv, dims=dims)
-@deprecate scattermat_zm(x::DenseMatrix, dims::Int) scattermat_zm(x, dims=dims)
-@deprecate scattermat_zm(x::DenseMatrix, wv::AbstractWeights, dims::Int) scattermat_zm(x::DenseMatrix, wv::AbstractWeights, dims=dims)
-
 ## weighted cov
 covm(x::DenseMatrix, mean, w::AbstractWeights, dims::Int=1;
      corrected::DepBool=nothing) =

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -16,3 +16,13 @@ end
 @deprecate(mad!(v::AbstractArray{<:Real}, center;
                 constant::Real = BigFloat("1.482602218505601860547076529360423431326703202590312896536266275245674447622701")),
            mad!(v, center=center, constant=constant))
+
+### Deprecated January 2019
+@deprecate scattermatm(x::DenseMatrix, mean, dims::Int) scattermat(x, mean=mean, dims=dims)
+@deprecate scattermatm(x::DenseMatrix, mean, wv::AbstractWeights, dims::Int) scattermat(x, wv, mean=mean, dims=dims)
+@deprecate scattermat(x::DenseMatrix, dims::Int) scattermat(x, dims=dims)
+@deprecate scattermat(x::DenseMatrix, wv::AbstractWeights, dims::Int) scattermat(x, wv, dims=dims)
+@deprecate scattermat_zm(x::DenseMatrix, dims::Int) scattermat_zm(x, dims=dims)
+@deprecate scattermat_zm(x::DenseMatrix, wv::AbstractWeights, dims::Int) scattermat_zm(x::DenseMatrix, wv::AbstractWeights, dims=dims)
+@deprecate mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Int) mean!(R, A, w, dims=dims)
+@deprecate mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T<:Number,W<:Real} mean(A, w, dims=dims)

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -58,27 +58,27 @@ function varm!(R::AbstractArray, A::RealArray, w::AbstractWeights, M::RealArray,
           varcorrection(w, corrected))
 end
 
-function var!(R::AbstractArray, A::RealArray, w::AbstractWeights, dim::Int;
+function var!(R::AbstractArray, A::RealArray, w::AbstractWeights, dims::Int;
               mean=nothing, corrected::DepBool=nothing)
     corrected = depcheck(:var!, corrected)
 
     if mean == 0
-        varm!(R, A, w, Base.reducedim_initarray(A, dim, 0, eltype(R)), dim;
+        varm!(R, A, w, Base.reducedim_initarray(A, dims, 0, eltype(R)), dims;
                    corrected=corrected)
     elseif mean == nothing
-        varm!(R, A, w, Statistics.mean(A, w, dim), dim; corrected=corrected)
+        varm!(R, A, w, Statistics.mean(A, w, dims=dims), dims; corrected=corrected)
     else
         # check size of mean
         for i = 1:ndims(A)
             dA = size(A,i)
             dM = size(mean,i)
-            if i == dim
+            if i == dims
                 dM == 1 || throw(DimensionMismatch("Incorrect size of mean."))
             else
                 dM == dA || throw(DimensionMismatch("Incorrect size of mean."))
             end
         end
-        varm!(R, A, w, mean, dim; corrected=corrected)
+        varm!(R, A, w, mean, dims; corrected=corrected)
     end
 end
 
@@ -203,16 +203,16 @@ function mean_and_std(A::RealArray, dim::Int; corrected::Bool=true)
 end
 
 
-function mean_and_var(A::RealArray, w::AbstractWeights, dim::Int;
+function mean_and_var(A::RealArray, w::AbstractWeights, dims::Int;
                       corrected::DepBool=nothing)
-    m = mean(A, w, dim)
-    v = varm(A, w, m, dim; corrected=depcheck(:mean_and_var, corrected))
+    m = mean(A, w, dims=dims)
+    v = varm(A, w, m, dims; corrected=depcheck(:mean_and_var, corrected))
     m, v
 end
-function mean_and_std(A::RealArray, w::AbstractWeights, dim::Int;
+function mean_and_std(A::RealArray, w::AbstractWeights, dims::Int;
                       corrected::DepBool=nothing)
-    m = mean(A, w, dim)
-    s = stdm(A, w, m, dim; corrected=depcheck(:mean_and_std, corrected))
+    m = mean(A, w, dims=dims)
+    s = stdm(A, w, m, dims; corrected=depcheck(:mean_and_std, corrected))
     m, s
 end
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -467,7 +467,7 @@ mean(x, weights(w))
 ```
 """
 mean(A::AbstractArray{T}, w::AbstractWeights{W};
-    dims::Union{Nothing,Int}=nothing) where {T<:Number,W<:Real} = _mean(A, w, dims)
+     dims::Union{Nothing,Int}=nothing) where {T<:Number,W<:Real} = _mean(A, w, dims)
 _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Nothing) where {T<:Number,W<:Real} =
     sum(A, w) / sum(w)
 _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T<:Number,W<:Real} =

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -439,13 +439,13 @@ function wmean(v::AbstractArray{<:Number}, w::AbstractVector)
 end
 
 """
-    mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights[; dims::Int=nothing])
+    mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights[; dims=nothing])
 
 Compute the weighted mean of array `A` with weight vector `w`
 (of type `AbstractWeights`) along dimension `dims`, and write results to `R`.
 """
-mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights; dims=nothing) =
-    _mean!(R, A, w, dims)
+mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights;
+      dims::Union{Nothing,Int}=nothing) = _mean!(R, A, w, dims)
 _mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Nothing) = throw(ArgumentError("dims argument must be provided"))
 _mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Int) =
     rmul!(Base.sum!(R, A, w, dims), inv(sum(w)))
@@ -466,11 +466,11 @@ w = rand(n)
 mean(x, weights(w))
 ```
 """
-mean(A::AbstractArray{T}, w::AbstractWeights{W}; dims=nothing) where {T<:Number,W<:Real} =
-    _mean(A, w, dims)
+mean(A::AbstractArray{T}, w::AbstractWeights{W};
+    dims::Union{Nothing,Int}=nothing) where {T<:Number,W<:Real} = _mean(A, w, dims)
 _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Nothing) where {T<:Number,W<:Real} =
     sum(A, w) / sum(w)
-_mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims) where {T<:Number,W<:Real} =
+_mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T<:Number,W<:Real} =
     _mean!(similar(A, wmeantype(T, W), Base.reduced_indices(axes(A), dims)), A, w, dims)
 
 ###### Weighted median #####

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -450,9 +450,6 @@ _mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Nothing) = 
 _mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Int) =
     rmul!(Base.sum!(R, A, w, dims), inv(sum(w)))
 
-### Deprecated January 2019
-@deprecate mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Int) mean!(R, A, w, dims=dims)
-
 wmeantype(::Type{T}, ::Type{W}) where {T,W} = typeof((zero(T)*zero(W) + zero(T)*zero(W)) / one(W))
 wmeantype(::Type{T}, ::Type{T}) where {T<:BlasReal} = T
 
@@ -475,9 +472,6 @@ _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Nothing) where {T<:Numbe
     sum(A, w) / sum(w)
 _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims) where {T<:Number,W<:Real} =
     _mean!(similar(A, wmeantype(T, W), Base.reduced_indices(axes(A), dims)), A, w, dims)
-
-### Deprecated January 2019
-@deprecate mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T<:Number,W<:Real} mean(A, w, dims=dims)
 
 ###### Weighted median #####
 function median(v::AbstractArray, w::AbstractWeights)

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -22,8 +22,8 @@ weight_funcs = (weights, aweights, fweights, pweights)
     wv1 = f(w1)
     wv2 = f(w2)
 
-    Z1w = X .- mean(X, wv1, 1)
-    Z2w = X .- mean(X, wv2, 2)
+    Z1w = X .- mean(X, wv1, dims=1)
+    Z2w = X .- mean(X, wv2, dims=2)
 
     ## reference results
 
@@ -46,8 +46,8 @@ weight_funcs = (weights, aweights, fweights, pweights)
         @test StatsBase.scattermat(X, mean=0)         ≈ Sz1
         @test StatsBase.scattermat(X, mean=0, dims=2) ≈ Sz2
 
-        @test StatsBase.scattermat(X, mean=mean(X, dims = 1))         ≈ S1
-        @test StatsBase.scattermat(X, mean=mean(X, dims = 2), dims=2) ≈ S2
+        @test StatsBase.scattermat(X, mean=mean(X, dims=1))         ≈ S1
+        @test StatsBase.scattermat(X, mean=mean(X, dims=2), dims=2) ≈ S2
 
         @test StatsBase.scattermat(X, mean=zeros(1,8))       ≈ Sz1
         @test StatsBase.scattermat(X, mean=zeros(3), dims=2) ≈ Sz2
@@ -59,8 +59,8 @@ weight_funcs = (weights, aweights, fweights, pweights)
             @test StatsBase.scattermat(X, wv1, mean=0)         ≈ Sz1w
             @test StatsBase.scattermat(X, wv2, mean=0, dims=2) ≈ Sz2w
 
-            @test StatsBase.scattermat(X, wv1, mean=mean(X, wv1, 1))         ≈ S1w
-            @test StatsBase.scattermat(X, wv2, mean=mean(X, wv2, 2), dims=2) ≈ S2w
+            @test StatsBase.scattermat(X, wv1, mean=mean(X, wv1, dims=1))         ≈ S1w
+            @test StatsBase.scattermat(X, wv2, mean=mean(X, wv2, dims=2), dims=2) ≈ S2w
 
             @test StatsBase.scattermat(X, wv1, mean=zeros(1,8))       ≈ Sz1w
             @test StatsBase.scattermat(X, wv2, mean=zeros(3), dims=2) ≈ Sz2w
@@ -75,8 +75,8 @@ weight_funcs = (weights, aweights, fweights, pweights)
             @test StatsBase.covm(X, 0, wv1, 1; corrected=false) ≈ Sz1w ./ sum(wv1)
             @test StatsBase.covm(X, 0, wv2, 2; corrected=false) ≈ Sz2w ./ sum(wv2)
 
-            @test StatsBase.covm(X, mean(X, wv1, 1), wv1, 1; corrected=false) ≈ S1w ./ sum(wv1)
-            @test StatsBase.covm(X, mean(X, wv2, 2), wv2, 2; corrected=false) ≈ S2w ./ sum(wv2)
+            @test StatsBase.covm(X, mean(X, wv1, dims=1), wv1, 1; corrected=false) ≈ S1w ./ sum(wv1)
+            @test StatsBase.covm(X, mean(X, wv2, dims=2), wv2, 2; corrected=false) ≈ S2w ./ sum(wv2)
 
             @test StatsBase.covm(X, zeros(1,8), wv1, 1; corrected=false) ≈ Sz1w ./ sum(wv1)
             @test StatsBase.covm(X, zeros(3), wv2, 2; corrected=false)   ≈ Sz2w ./ sum(wv2)
@@ -84,27 +84,27 @@ weight_funcs = (weights, aweights, fweights, pweights)
 
         @testset "Mean and covariance" begin
             (m, C) = mean_and_cov(X; corrected=false)
-            @test m == mean(X, dims = 1)
-            @test C == cov(X, dims = 1, corrected=false)
+            @test m == mean(X, dims=1)
+            @test C == cov(X, dims=1, corrected=false)
 
             (m, C) = mean_and_cov(X, 1; corrected=false)
-            @test m == mean(X, dims = 1)
-            @test C == cov(X, dims = 1, corrected = false)
+            @test m == mean(X, dims=1)
+            @test C == cov(X, dims=1, corrected = false)
 
             (m, C) = mean_and_cov(X, 2; corrected=false)
-            @test m == mean(X, dims = 2)
-            @test C == cov(X, dims = 2, corrected = false)
+            @test m == mean(X, dims=2)
+            @test C == cov(X, dims=2, corrected = false)
 
             (m, C) = mean_and_cov(X, wv1; corrected=false)
-            @test m == mean(X, wv1, 1)
+            @test m == mean(X, wv1, dims=1)
             @test C == cov(X, wv1, 1, corrected=false)
 
             (m, C) = mean_and_cov(X, wv1, 1; corrected=false)
-            @test m == mean(X, wv1, 1)
+            @test m == mean(X, wv1, dims=1)
             @test C == cov(X, wv1, 1, corrected=false)
 
             (m, C) = mean_and_cov(X, wv2, 2; corrected=false)
-            @test m == mean(X, wv2, 2)
+            @test m == mean(X, wv2, dims=2)
             @test C == cov(X, wv2, 2, corrected=false)
         end
         @testset "Conversions" begin
@@ -146,8 +146,8 @@ weight_funcs = (weights, aweights, fweights, pweights)
                 @test StatsBase.covm(X, 0, wv1, 1; corrected=true) ≈ Sz1w .* var_corr1
                 @test StatsBase.covm(X, 0, wv2, 2; corrected=true) ≈ Sz2w .* var_corr2
 
-                @test StatsBase.covm(X, mean(X, wv1, 1), wv1, 1; corrected=true) ≈ S1w .* var_corr1
-                @test StatsBase.covm(X, mean(X, wv2, 2), wv2, 2; corrected=true) ≈ S2w .* var_corr2
+                @test StatsBase.covm(X, mean(X, wv1, dims=1), wv1, 1; corrected=true) ≈ S1w .* var_corr1
+                @test StatsBase.covm(X, mean(X, wv2, dims=2), wv2, 2; corrected=true) ≈ S2w .* var_corr2
 
                 @test StatsBase.covm(X, zeros(1,8), wv1, 1; corrected=true) ≈ Sz1w .* var_corr1
                 @test StatsBase.covm(X, zeros(3), wv2, 2; corrected=true)   ≈ Sz2w .* var_corr2
@@ -155,30 +155,30 @@ weight_funcs = (weights, aweights, fweights, pweights)
         end
         @testset "Mean and covariance" begin
             (m, C) = mean_and_cov(X; corrected=true)
-            @test m == mean(X, dims =1)
-            @test C == cov(X, dims = 1, corrected = true)
+            @test m == mean(X, dims=1)
+            @test C == cov(X, dims=1, corrected = true)
 
             (m, C) = mean_and_cov(X, 1; corrected=true)
-            @test m == mean(X, dims = 1)
-            @test C == cov(X, dims = 1, corrected = true)
+            @test m == mean(X, dims=1)
+            @test C == cov(X, dims=1, corrected = true)
 
             (m, C) = mean_and_cov(X, 2; corrected=true)
-            @test m == mean(X, dims = 2)
-            @test C == cov(X, dims = 2, corrected = true)
+            @test m == mean(X, dims=2)
+            @test C == cov(X, dims=2, corrected = true)
 
             if isa(wv1, Weights)
                 @test_throws ArgumentError mean_and_cov(X, wv1; corrected=true)
             else
                 (m, C) = mean_and_cov(X, wv1; corrected=true)
-                @test m == mean(X, wv1, 1)
+                @test m == mean(X, wv1, dims=1)
                 @test C == cov(X, wv1, 1; corrected=true)
 
                 (m, C) = mean_and_cov(X, wv1, 1; corrected=true)
-                @test m == mean(X, wv1, 1)
+                @test m == mean(X, wv1, dims=1)
                 @test C == cov(X, wv1, 1; corrected=true)
 
                 (m, C) = mean_and_cov(X, wv2, 2; corrected=true)
-                @test m == mean(X, wv2, 2)
+                @test m == mean(X, wv2, dims=2)
                 @test C == cov(X, wv2, 2; corrected=true)
             end
         end

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -40,30 +40,30 @@ weight_funcs = (weights, aweights, fweights, pweights)
     Sz2w = X * Matrix(Diagonal(w2)) * X'
 
     @testset "Scattermat" begin
-        @test scattermat(X)    ≈ S1
-        @test scattermat(X, 2) ≈ S2
+        @test scattermat(X)         ≈ S1
+        @test scattermat(X, dims=2) ≈ S2
 
-        @test StatsBase.scattermatm(X, 0)    ≈ Sz1
-        @test StatsBase.scattermatm(X, 0, 2) ≈ Sz2
+        @test StatsBase.scattermat(X, mean=0)         ≈ Sz1
+        @test StatsBase.scattermat(X, mean=0, dims=2) ≈ Sz2
 
-        @test StatsBase.scattermatm(X, mean(X, dims = 1))    ≈ S1
-        @test StatsBase.scattermatm(X, mean(X, dims = 2), 2) ≈ S2
+        @test StatsBase.scattermat(X, mean=mean(X, dims = 1))         ≈ S1
+        @test StatsBase.scattermat(X, mean=mean(X, dims = 2), dims=2) ≈ S2
 
-        @test StatsBase.scattermatm(X, zeros(1,8))  ≈ Sz1
-        @test StatsBase.scattermatm(X, zeros(3), 2) ≈ Sz2
+        @test StatsBase.scattermat(X, mean=zeros(1,8))       ≈ Sz1
+        @test StatsBase.scattermat(X, mean=zeros(3), dims=2) ≈ Sz2
 
         @testset "Weighted" begin
-            @test scattermat(X, wv1)    ≈ S1w
-            @test scattermat(X, wv2, 2) ≈ S2w
+            @test scattermat(X, wv1)         ≈ S1w
+            @test scattermat(X, wv2, dims=2) ≈ S2w
 
-            @test StatsBase.scattermatm(X, 0, wv1)    ≈ Sz1w
-            @test StatsBase.scattermatm(X, 0, wv2, 2) ≈ Sz2w
+            @test StatsBase.scattermat(X, wv1, mean=0)         ≈ Sz1w
+            @test StatsBase.scattermat(X, wv2, mean=0, dims=2) ≈ Sz2w
 
-            @test StatsBase.scattermatm(X, mean(X, wv1, 1), wv1)    ≈ S1w
-            @test StatsBase.scattermatm(X, mean(X, wv2, 2), wv2, 2) ≈ S2w
+            @test StatsBase.scattermat(X, wv1, mean=mean(X, wv1, 1))         ≈ S1w
+            @test StatsBase.scattermat(X, wv2, mean=mean(X, wv2, 2), dims=2) ≈ S2w
 
-            @test StatsBase.scattermatm(X, zeros(1,8), wv1)  ≈ Sz1w
-            @test StatsBase.scattermatm(X, zeros(3), wv2, 2) ≈ Sz2w
+            @test StatsBase.scattermat(X, wv1, mean=zeros(1,8))       ≈ Sz1w
+            @test StatsBase.scattermat(X, wv2, mean=zeros(3), dims=2) ≈ Sz2w
         end
     end
 

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -110,8 +110,8 @@ w2 = rand(6)
 @testset "Uncorrected with $f" for f in weight_funcs
     wv1 = f(w1)
     wv2 = f(w2)
-    m1 = mean(x, wv1, 1)
-    m2 = mean(x, wv2, 2)
+    m1 = mean(x, wv1, dims=1)
+    m2 = mean(x, wv2, dims=2)
 
     expected_var1 = sum(abs2.(x .- m1) .* w1, dims = 1) ./ sum(wv1)
     expected_var2 = sum(abs2.(x .- m2) .* w2', dims = 2) ./ sum(wv2)
@@ -135,32 +135,32 @@ w2 = rand(6)
     @testset "Mean and Variance" begin
         for d in 1:2
             (m, v) = mean_and_var(x, d; corrected=false)
-            @test m == mean(x, dims = d)
-            @test v == var(x, dims = d, corrected=false)
+            @test m == mean(x, dims=d)
+            @test v == var(x, dims=d, corrected=false)
         end
 
         (m, v) = mean_and_var(x, wv1, 1; corrected=false)
-        @test m == mean(x, wv1, 1)
+        @test m == mean(x, wv1, dims=1)
         @test v == var(x, wv1, 1; corrected=false)
 
         (m, v) = mean_and_var(x, wv2, 2; corrected=false)
-        @test m == mean(x, wv2, 2)
+        @test m == mean(x, wv2, dims=2)
         @test v == var(x, wv2, 2; corrected=false)
     end
 
     @testset "Mean and Standard Deviation" begin
         for d in 1:2
             (m, s) = mean_and_std(x, d; corrected=false)
-            @test m == mean(x, dims = d)
-            @test s == std(x, dims = d; corrected=false)
+            @test m == mean(x, dims=d)
+            @test s == std(x, dims=d; corrected=false)
         end
 
         (m, s) = mean_and_std(x, wv1, 1; corrected=false)
-        @test m == mean(x, wv1, 1)
+        @test m == mean(x, wv1, dims=1)
         @test s == std(x, wv1, 1; corrected=false)
 
         (m, s) = mean_and_std(x, wv2, 2; corrected=false)
-        @test m == mean(x, wv2, 2)
+        @test m == mean(x, wv2, dims=2)
         @test s == std(x, wv2, 2; corrected=false)
     end
 end
@@ -168,8 +168,8 @@ end
 @testset "Corrected with $f" for f in weight_funcs
     wv1 = f(w1)
     wv2 = f(w2)
-    m1 = mean(x, wv1, 1)
-    m2 = mean(x, wv2, 2)
+    m1 = mean(x, wv1, dims=1)
+    m2 = mean(x, wv2, dims=2)
 
     if !isa(wv1, Weights)
         expected_var1 = sum(abs2.(x .- m1) .* w1, dims = 1) .* StatsBase.varcorrection(wv1, true)
@@ -203,19 +203,19 @@ end
     @testset "Mean and Variance" begin
         for d in 1:2
             (m, v) = mean_and_var(x, d; corrected=true)
-            @test m == mean(x, dims = d)
-            @test v == var(x, dims = d, corrected=true)
+            @test m == mean(x, dims=d)
+            @test v == var(x, dims=d, corrected=true)
         end
 
         if isa(wv1, Weights)
             @test_throws ArgumentError mean_and_var(x, wv1, 1; corrected=true)
         else
             (m, v) = mean_and_var(x, wv1, 1; corrected=true)
-            @test m == mean(x, wv1, 1)
+            @test m == mean(x, wv1, dims=1)
             @test v == var(x, wv1, 1; corrected=true)
 
             (m, v) = mean_and_var(x, wv2, 2; corrected=true)
-            @test m == mean(x, wv2, 2)
+            @test m == mean(x, wv2, dims=2)
             @test v == var(x, wv2, 2; corrected=true)
         end
     end
@@ -223,19 +223,19 @@ end
     @testset "Mean and Standard Deviation" begin
         for d in 1:2
             (m, s) = mean_and_std(x, d; corrected=true)
-            @test m == mean(x, dims = d)
-            @test s == std(x, dims = d, corrected=true)
+            @test m == mean(x, dims=d)
+            @test s == std(x, dims=d, corrected=true)
         end
 
         if isa(wv1, Weights)
             @test_throws ArgumentError mean_and_std(x, wv1, 1; corrected=true)
         else
             (m, s) = mean_and_std(x, wv1, 1; corrected=true)
-            @test m == mean(x, wv1, 1)
+            @test m == mean(x, wv1, dims=1)
             @test s == std(x, wv1, 1; corrected=true)
 
             (m, s) = mean_and_std(x, wv2, 2; corrected=true)
-            @test m == mean(x, wv2, 2)
+            @test m == mean(x, wv2, dims=2)
             @test s == std(x, wv2, 2; corrected=true)
         end
     end

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -226,10 +226,10 @@ end
     @test mean(1:3, f([1.0, 1.0, 0.5]))    ≈ 1.8
 
     for wt in ([1.0, 1.0, 1.0], [1.0, 0.2, 0.0], [0.2, 0.0, 1.0])
-        @test mean(a, f(wt), 1) ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims = 1)/sum(wt)
-        @test mean(a, f(wt), 2) ≈ sum(a.*reshape(wt, 1, length(wt), 1), dims = 2)/sum(wt)
-        @test mean(a, f(wt), 3) ≈ sum(a.*reshape(wt, 1, 1, length(wt)), dims = 3)/sum(wt)
-        @test_throws ErrorException mean(a, f(wt), 4)
+        @test mean(a, f(wt), dims=1) ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims=1)/sum(wt)
+        @test mean(a, f(wt), dims=2) ≈ sum(a.*reshape(wt, 1, length(wt), 1), dims=2)/sum(wt)
+        @test mean(a, f(wt), dims=3) ≈ sum(a.*reshape(wt, 1, 1, length(wt)), dims=3)/sum(wt)
+        @test_throws ErrorException mean(a, f(wt), dims=4)
     end
 end
 


### PR DESCRIPTION
Fixes #219 

We also need to make these changes to weighted `var`, `std`, `mean_and_var`, `mean_and_std`, `cov`, and `cor`. Annoyingly, we didn't manage to make things consistent in `Statistics` so `dims` is `dimvar` in unweighted `cor` and `cov` so we might want to make that change to `Statistics` before changing them here.