### PR TITLE
Improve entropy

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -450,22 +450,11 @@ zscore(X::AbstractArray{<:Real}, dim::Int) = ((μ, σ) = mean_and_std(X, dim); z
 """
     entropy(p, [b])
 
-Compute the entropy of an array `p`, optionally specifying a real number
+Compute the entropy of a collection of probabilities `p`, optionally specifying a real number
 `b` such that the entropy is scaled by `1/log(b)`.
 """
-function entropy(p::AbstractArray{T}) where T<:Real
-    s = zero(T)
-    z = zero(T)
-    for i = 1:length(p)
-        @inbounds pi = p[i]
-        if pi > z
-            s += pi * log(pi)
-        end
-    end
-    return -s
-end
-
-entropy(p::AbstractArray{<:Real}, b::Real) = entropy(p) / log(b)
+entropy(p) = -sum(pi -> pi * log(pi), p)
+entropy(p, b::Real) = entropy(p) / log(b)
 
 """
     renyientropy(p, α)


### PR DESCRIPTION
There is no reason to only allow entropy to be calculated on arrays
so this generalizes it to be for any iterable.

It also drops the requirement that the elements all be `Real`.
If somone wants to make a nonreal type, that has addition, multiplication and log,
and then wants to use `entropy` on that, then good for them.
(Realistic causes of this is something like symbolic math types).


Finally, It removes the thing where negative probabilities were just dropped from the calculation of entropy.
Because that is insane AFAIK.

If anything, we should be throwing an error in that case (which this will do, since `log` will throw).

