### PR TITLE
remove export of unused `hist`

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -139,7 +139,6 @@ module StatsBase
 
     AbstractHistogram,
     Histogram,
-    hist,
     midpoints,
     # histrange,
 


### PR DESCRIPTION
As far as I can tell this identifier no longer exists anywhere.