### PR TITLE
Make weighted quantile tests stricter and documentation more precise

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -558,13 +558,14 @@ Weights must not be negative. The weights and data vectors must have the same le
 
 With [`FrequencyWeights`](@ref), the function returns the same result as
 `quantile` for a vector with repeated values.
+
 With non `FrequencyWeights`,  denote ``N`` the length of the vector, ``w`` the vector of weights,
-``h = p (\\sum_{i<= N}w_i - w_1) + w_1`` the cumulative weight corresponding to the
-probability ``p`` and ``S_k = \\sum_{i<=k}w_i`` the cumulative weight for each
+``h = p (\\sum_{i<= N} w_i - w_1) + w_1`` the cumulative weight corresponding to the
+probability ``p`` and ``S_k = \\sum_{i<=k} w_i`` the cumulative weight for each
 observation, define ``v_{k+1}`` the smallest element of `v` such that ``S_{k+1}``
-is strictly superior to ``h``. The weighted ``p`` quantile is given by ``v_k + \\gamma (v_{k+1} -v_k)``
-with  ``\\gamma = (h - S_k)/(S_{k+1}-S_k)``. In particular, when `w` is a vector
-of ones, the function returns the same result as `quantile`.
+is strictly superior to ``h``. The weighted ``p`` quantile is given by ``v_k + \\gamma (v_{k+1} - v_k)``
+with  ``\\gamma = (h - S_k)/(S_{k+1} - S_k)``. In particular, when all weights are equal,
+the function returns the same result as the unweighted `quantile`.
 """
 function quantile(v::RealVector{V}, w::AbstractWeights{W}, p::RealVector) where {V,W<:Real}
     # checks
@@ -599,11 +600,12 @@ function quantile(v::RealVector{V}, w::AbstractWeights{W}, p::RealVector) where 
     vk, vkold = zero(V), zero(V)
     k = 0
 
+    w1 = vw[1][2]
     for i in 1:length(p)
         if isa(w, FrequencyWeights)
             h = p[i] * (wsum - 1) + 1
         else
-            h = p[i] * (wsum - vw[1][2]) + vw[1][2]
+            h = p[i] * (wsum - w1) + w1
         end
         while Sk <= h
             k += 1

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -474,12 +474,15 @@ end
             @test quantile(data[i][reorder], f(wt[i][reorder]), p) ≈ quantile_answers[i] atol = 1e-5
         end
     end
-    # w = 1 corresponds to base quantile
-    for i = 1:length(data)
-        @test quantile(data[i], f(ones(Int64, length(data[i]))), p) ≈ quantile(data[i], p) atol = 1e-5
-        for j = 1:10
-            prandom = rand(4)
-            @test quantile(data[i], f(ones(Int64, length(data[i]))),  prandom) ≈ quantile(data[i], prandom) atol = 1e-5
+    # All equal weights corresponds to base quantile
+    for v in (1, 2, 345)
+        for i = 1:length(data)
+            w = f(fill(v, length(data[i])))
+            @test quantile(data[i], w, p) ≈ quantile(data[i], p) atol = 1e-5
+            for j = 1:10
+                prandom = rand(4)
+                @test quantile(data[i], w,  prandom) ≈ quantile(data[i], prandom) atol = 1e-5
+            end
         end
     end
     # test zeros are removed


### PR DESCRIPTION
For `ProbabilityWeights` and `AnalyticWeights`, the magnitude of weights does not matter when they are equal. Also clean a few things.

CC: @matthieugomez 