### PR TITLE
 Handle missing values and empty inputs in SummaryStats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/build
 docs/site
 perf/*.csv
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,19 @@
+name = "StatsBase"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SortingAlgorithms = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[extras]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["DelimitedFiles", "LinearAlgebra", "Random", "SparseArrays", "Test"]

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -40,14 +40,31 @@ io = IOBuffer()
 describe(io, collect(1:10))
 @test String(take!(io)) == """
                            Summary Stats:
+                           Length:         10
+                           Missing Count:  0
                            Mean:           5.500000
                            Minimum:        1.000000
                            1st Quartile:   3.250000
                            Median:         5.500000
                            3rd Quartile:   7.750000
                            Maximum:        10.000000
-                           Length:         10
                            Type:           $Int
+                           """
+
+describe(io, Union{Float32,Missing}[1.0, 4.5, missing, missing, 33.1])
+@test String(take!(io)) == """
+                           Summary Stats:
+                           Length:         5
+                           Missing Count:  2
+                           (All summary stats are missing)
+                           Type:           $(Union{Float32,Missing})
+                           """
+
+describe(io, Float64[])
+@test String(take!(io)) == """
+                           Summary Stats:
+                           Length:         0
+                           Type:           Float64
                            """
 
 describe(io, fill("s", 3))


### PR DESCRIPTION
Currently, `SummaryStats` will error when computing quantiles if the input is empty or contains any missing values. Instead, we can simply inform the user that the input is empty or that there were missing
values that caused the statistics to be missing.

I've also added a Project.toml file as a separate commit, since they're indispensable for local development and no longer confuse METADATA CI.