### PR TITLE
Allow mismatched element types for weighted means

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -466,11 +466,11 @@ w = rand(n)
 mean(x, weights(w))
 ```
 """
-mean(A::AbstractArray{T}, w::AbstractWeights{W};
-     dims::Union{Nothing,Int}=nothing) where {T<:Number,W<:Real} = _mean(A, w, dims)
-_mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Nothing) where {T<:Number,W<:Real} =
+mean(A::AbstractArray, w::AbstractWeights; dims::Union{Nothing,Int}=nothing) =
+    _mean(A, w, dims)
+_mean(A::AbstractArray, w::AbstractWeights, dims::Nothing) =
     sum(A, w) / sum(w)
-_mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T<:Number,W<:Real} =
+_mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T,W} =
     _mean!(similar(A, wmeantype(T, W), Base.reduced_indices(axes(A), dims)), A, w, dims)
 
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -443,4 +443,8 @@ end
     @test median(data, f(wt)) ≈ quantile(data, f(wt), 0.5) atol = 1e-5
 end
 
+@testset "Mismatched eltypes" begin
+    @test round(mean(Union{Int,Missing}[1,2], weights([1,2])), digits=3) ≈ 1.667
+end
+
 end # @testset StatsBase.Weights


### PR DESCRIPTION
We've recently inadvertently disallowed a mismatch between the array's element type and the element type of the weights when computing a weighted mean. This leads to bizarre behavior, as it dispatches to a nonsensical method where the array is treated as a function.

Fixes #475 