### PR TITLE
Fix #433 : support view in histogram

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -5,7 +5,7 @@ import LinearAlgebra: norm, normalize, normalize!
 
 
 ## Fast getindex function for multiple arrays, returns a tuple of array elements
-@inline Base.@propagate_inbounds @generated function _multi_getindex(i::Integer, c::AbstractArray...)
+@inline Base.@propagate_inbounds @generated function _multi_getindex(i::Union{Integer, CartesianIndex}, c::AbstractArray...)
     N = length(c)
     result_expr = Expr(:tuple)
     for j in 1:N

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -58,6 +58,10 @@ end
     @test fit(Histogram,0:99,weights(2*ones(100)),nbins=5).weights == [40,40,40,40,40]
     @test fit(Histogram{Int32},0:99,weights(2*ones(100)),nbins=5).weights == [40,40,40,40,40]
     @test fit(Histogram{Float32},0:99,weights(2*ones(100)),nbins=5).weights == [40,40,40,40,40]
+
+    d = collect(0:99)
+    v = view(d, fill(true, 100))
+    @test fit(Histogram{Float32},v,weights(2*ones(100)),nbins=5).weights == [40,40,40,40,40]
 end
 
 


### PR DESCRIPTION
This fixes #433 (error when fitting histogram on `view(v, bool_array)`)  by allowing use of `CartesianIndex` in `_multi_getindex`.