### PR TITLE
Add convergenceexception information

### DIFF
--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -459,8 +459,15 @@ ConvergenceException(iters, lastchange::T=NaN, tol::T=NaN) where {T<:Real} =
     ConvergenceException{T}(iters, lastchange, tol)
 
 function Base.showerror(io::IO, ce::ConvergenceException)
-    print(io, "failure to converge after $(ce.iters) iterations.")
+    print(io, "failure to converge after ", ce.iters, " iterations.")
     if !isnan(ce.lastchange)
-        print(io, " Last change ($(ce.lastchange)) was greater than tolerance ($(ce.tol)).")
+        print(
+            io,
+            " Last change (",
+            ce.lastchange,
+            ") was greater than tolerance (",
+            ce.tol,
+            ")."
+        )
     end
 end

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -447,9 +447,7 @@ struct ConvergenceException{T<:Real} <: Exception
     lastchange::T
     tol::T
     msg::String
-    function ConvergenceException{T}(
-        iters, lastchange::T, tol::T, msg::String
-    ) where T<:Real
+    function ConvergenceException{T}(iters, lastchange::T, tol::T, msg::String) where T<:Real
         if tol > lastchange
             throw(ArgumentError("Change must be greater than tol."))
         else

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -462,16 +462,9 @@ ConvergenceException(
     ConvergenceException{T}(iters, lastchange, tol, string(msg))
 
 function Base.showerror(io::IO, ce::ConvergenceException)
-    print(io, "failure to converge after ", ce.iters, " iterations.")
+    print(io, "failure to converge after $(ce.iters) iterations.")
     if !isnan(ce.lastchange)
-        print(
-            io,
-            " Last change (",
-            ce.lastchange,
-            ") was greater than tolerance (",
-            ce.tol,
-            ")."
-        )
+        print(io, " Last change ($(ce.lastchange)) was greater than tolerance ($(ce.tol)).")
     end
     if !isempty(ce.msg)
         print(io, ' ', ce.msg)

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -446,17 +446,22 @@ struct ConvergenceException{T<:Real} <: Exception
     iters::Int
     lastchange::T
     tol::T
-    function ConvergenceException{T}(iters, lastchange::T, tol::T) where T<:Real
+    info::String
+    function ConvergenceException{T}(
+        iters, lastchange::T, tol::T, info::String
+    ) where T<:Real
         if tol > lastchange
             throw(ArgumentError("Change must be greater than tol."))
         else
-            new(iters, lastchange, tol)
+            new(iters, lastchange, tol, info)
         end
     end
 end
 
-ConvergenceException(iters, lastchange::T=NaN, tol::T=NaN) where {T<:Real} =
-    ConvergenceException{T}(iters, lastchange, tol)
+ConvergenceException(
+    iters, lastchange::T=NaN, tol::T=NaN, info::AbstractString = ""
+) where {T<:Real} =
+    ConvergenceException{T}(iters, lastchange, tol, string(info))
 
 function Base.showerror(io::IO, ce::ConvergenceException)
     print(io, "failure to converge after ", ce.iters, " iterations.")
@@ -469,5 +474,8 @@ function Base.showerror(io::IO, ce::ConvergenceException)
             ce.tol,
             ")."
         )
+    end
+    if !isempty(ce.info)
+        print(io, ' ', ce.info)
     end
 end

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -456,10 +456,9 @@ struct ConvergenceException{T<:Real} <: Exception
     end
 end
 
-ConvergenceException(
-    iters, lastchange::T=NaN, tol::T=NaN, msg::AbstractString = ""
-) where {T<:Real} =
-    ConvergenceException{T}(iters, lastchange, tol, string(msg))
+ConvergenceException(iters, lastchange::T=NaN, tol::T=NaN,
+                     msg::AbstractString="") where {T<:Real} =
+    ConvergenceException{T}(iters, lastchange, tol, String(msg))
 
 function Base.showerror(io::IO, ce::ConvergenceException)
     print(io, "failure to converge after $(ce.iters) iterations.")

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -446,22 +446,22 @@ struct ConvergenceException{T<:Real} <: Exception
     iters::Int
     lastchange::T
     tol::T
-    info::String
+    msg::String
     function ConvergenceException{T}(
-        iters, lastchange::T, tol::T, info::String
+        iters, lastchange::T, tol::T, msg::String
     ) where T<:Real
         if tol > lastchange
             throw(ArgumentError("Change must be greater than tol."))
         else
-            new(iters, lastchange, tol, info)
+            new(iters, lastchange, tol, msg)
         end
     end
 end
 
 ConvergenceException(
-    iters, lastchange::T=NaN, tol::T=NaN, info::AbstractString = ""
+    iters, lastchange::T=NaN, tol::T=NaN, msg::AbstractString = ""
 ) where {T<:Real} =
-    ConvergenceException{T}(iters, lastchange, tol, string(info))
+    ConvergenceException{T}(iters, lastchange, tol, string(msg))
 
 function Base.showerror(io::IO, ce::ConvergenceException)
     print(io, "failure to converge after ", ce.iters, " iterations.")
@@ -475,7 +475,7 @@ function Base.showerror(io::IO, ce::ConvergenceException)
             ")."
         )
     end
-    if !isempty(ce.info)
-        print(io, ' ', ce.info)
+    if !isempty(ce.msg)
+        print(io, ' ', ce.msg)
     end
 end

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -39,6 +39,5 @@ x3   0.453058  0.72525 0.999172 0.5567
 @test sprint(showerror, ConvergenceException(10, 0.2, 0.1, "Try changing maxIter.")) ==
     "failure to converge after 10 iterations. Last change (0.2) was greater than tolerance (0.1). Try changing maxIter."
 
-
 err = @test_throws ArgumentError ConvergenceException(10,.1,.2)
 @test err.value.msg == "Change must be greater than tol."

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -36,5 +36,9 @@ x3   0.453058  0.72525 0.999172 0.5567
 @test sprint(showerror, ConvergenceException(10, 0.2, 0.1)) ==
     "failure to converge after 10 iterations. Last change (0.2) was greater than tolerance (0.1)."
 
+@test sprint(showerror, ConvergenceException(10, 0.2, 0.1, "Try changing maxIter.")) ==
+    "failure to converge after 10 iterations. Last change (0.2) was greater than tolerance (0.1). Try changing maxIter."
+
+
 err = @test_throws ArgumentError ConvergenceException(10,.1,.2)
 @test err.value.msg == "Change must be greater than tol."


### PR DESCRIPTION
In order to add informative hints to `ConvergenceException`s, I have added a `info` field to `ConvergenceException` structs. If the `info` field is not empty, it will also be printed with the error message for `ConvergenceExceptions`. This is useful to inform the user of why he or she may be experiencing problems with convergence, and to suggest ways to avoid these errors. For an example of this, see JuliaStats/GLM.jl#303.