### PR TITLE
Provide standardize API for 1D array

### DIFF
--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -9,7 +9,7 @@ abstract type AbstractDataTransform end
 Apply transformation `t` to vector or matrix `x` in place.
 """
 transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = transform!(x, t, x)
-transform!(t::AbstractDataTransform, x::AbstractVector{<:Real}) = transform!(t, reshape(x, :, 1))
+transform!(t::AbstractDataTransform, x::AbstractVector{<:Real}) = (transform!(t, reshape(x, :, 1)); x)
 
 """
     transform(t::AbstractDataTransform, x)
@@ -30,7 +30,7 @@ Perform an in-place reconstruction into an original data scale from a transforme
 vector or matrix `y` using `t` transformation.
 """
 reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = reconstruct!(y, t, y)
-reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real}) = reconstruct!(t, reshape(y, :, 1))
+reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real}) = (reconstruct!(t, reshape(y, :, 1)); y)
 
 """
     reconstruct(t::AbstractDataTransform, y)
@@ -306,9 +306,7 @@ end
 
 function fit(::Type{UnitRangeTransform}, X::AbstractVector{<:Real};
              dims::Union{Integer,Nothing}=nothing, unit::Bool=true)
-    if dims == nothing
-        Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
-    elseif dims != 1
+    if dims != 1
         throw(DomainError(dims, "fit only accept dims=1 over a vector. Try fit(t, x, dims=1)."))
     end
 

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -8,19 +8,20 @@ abstract type AbstractDataTransform end
 
 Apply transformation `t` to vector or matrix `x` in place.
 """
-transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = transform!(x, t, x)
-transform!(t::AbstractDataTransform, x::AbstractVector{<:Real}) = (transform!(t, reshape(x, :, 1)); x)
+transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) =
+    transform!(x, t, x)
+transform!(t::AbstractDataTransform, x::AbstractVector{<:Real}) =
+    (transform!(t, reshape(x, :, 1)); x)
 
 """
     transform(t::AbstractDataTransform, x)
 
 Return a standardized vector or matrix `x` using `t` transformation.
 """
-transform(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = transform!(similar(x), t, x)
-
-function transform(t::AbstractDataTransform, x::AbstractVector{<:Real})
-    return vec(transform(t, reshape(x, :, 1)))
-end
+transform(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) =
+    transform!(similar(x), t, x)
+transform(t::AbstractDataTransform, x::AbstractVector{<:Real}) =
+    vec(transform(t, reshape(x, :, 1)))
 
 # reconstruct the original data from transformed values
 """
@@ -29,8 +30,10 @@ end
 Perform an in-place reconstruction into an original data scale from a transformed
 vector or matrix `y` using `t` transformation.
 """
-reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = reconstruct!(y, t, y)
-reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real}) = (reconstruct!(t, reshape(y, :, 1)); y)
+reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) =
+    reconstruct!(y, t, y)
+reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real}) =
+    (reconstruct!(t, reshape(y, :, 1)); y)
 
 """
     reconstruct(t::AbstractDataTransform, y)
@@ -38,11 +41,10 @@ reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real}) = (reconstruct
 Return a reconstruction of an originally scaled data from a transformed vector
 or matrix `y` using `t` transformation.
 """
-reconstruct(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = reconstruct!(similar(y), t, y)
-
-function reconstruct(t::AbstractDataTransform, y::AbstractVector{<:Real})
-    return vec(reconstruct(t, reshape(y, :, 1)))
-end
+reconstruct(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) =
+    reconstruct!(similar(y), t, y)
+reconstruct(t::AbstractDataTransform, y::AbstractVector{<:Real}) =
+    vec(reconstruct(t, reshape(y, :, 1)))
 
 """
     Standardization (Z-score transformation)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -280,7 +280,8 @@ end
 """
     standardize(DT, X; kwargs...)
 
-Standardize data using `DT` transformation which is a subtype of `AbstractDataTransform`:
+ Return a row-standardized copy of vector or matrix `X` using transformation `DT`
+ which is a subtype of `AbstractDataTransform`:
 
 - `ZScoreTransform`
 - `UnitRangeTransform`

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -8,11 +8,16 @@ abstract type AbstractDataTransform end
 
 Apply transformation `t` to vector or matrix `x` in place.
 """
-transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = _transform!(x, t, x)
+function transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real})
+    if t.dims == 1
+        return transform!(x, t, x)
+    elseif t.dims == 2
+        return transform!(x', t, x')'
+    end
+end
 
 function transform!(t::AbstractDataTransform, x::AbstractVector{<:Real})
-    x = reshape(x, :, 1)
-    _transform!(x, t, x)
+    transform!(t, reshape(x, :, 1))
     return vec(x)
 end
 
@@ -21,20 +26,17 @@ end
 
 Return a standardized vector or matrix `x` using `t` transformation.
 """
-transform(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = _transform!(similar(x), t, x)
-
-function transform(t::AbstractDataTransform, x::AbstractVector{<:Real})
-    x = reshape(x, :, 1)
-    x_ = _transform!(similar(x), t, x)
-    return vec(x_)
+function transform(t::AbstractDataTransform, x::AbstractMatrix{<:Real})
+    if t.dims == 1
+        return transform!(similar(x), t, x)
+    elseif t.dims == 2
+        return transform!(similar(x)', t, x')'
+    end
 end
 
-function _transform!(y::AbstractMatrix{<:Real}, t::AbstractDataTransform, x::AbstractMatrix{<:Real})
-    if t.dims == 1
-        return transform!(y, t, x)
-    elseif t.dims == 2
-        return transform!(y', t, x')'
-    end
+function transform(t::AbstractDataTransform, x::AbstractVector{<:Real})
+    xmat = transform(t, reshape(x, :, 1))
+    return vec(xmat)
 end
 
 # reconstruct the original data from transformed values
@@ -44,11 +46,16 @@ end
 Perform an in-place reconstruction into an original data scale from a transformed
 vector or matrix `y` using `t` transformation.
 """
-reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = _reconstruct!(y, t, y)
+function reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real})
+    if t.dims == 1
+        return reconstruct!(y, t, y)
+    elseif t.dims == 2
+        return reconstruct!(y', t, y')'
+    end
+end
 
 function reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real})
-    y = reshape(y, :, 1)
-    _reconstruct!(y, t, y)
+    reconstruct!(t, reshape(y, :, 1))
     return vec(y)
 end
 
@@ -58,20 +65,17 @@ end
 Return a reconstruction of an originally scaled data from a transformed vector
 or matrix `y` using `t` transformation.
 """
-reconstruct(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = _reconstruct!(similar(y), t, y)
-
-function reconstruct(t::AbstractDataTransform, y::AbstractVector{<:Real})
-    y = reshape(y, :, 1)
-    y_ = _reconstruct!(similar(y), t, y)
-    return vec(y_)
+function reconstruct(t::AbstractDataTransform, y::AbstractMatrix{<:Real})
+    if t.dims == 1
+        return reconstruct!(similar(y), t, y)
+    elseif t.dims == 2
+        return reconstruct!(similar(y)', t, y')'
+    end
 end
 
-function _reconstruct!(y::AbstractMatrix{<:Real}, t::AbstractDataTransform, x::AbstractMatrix{<:Real})
-    if t.dims == 1
-        return reconstruct!(y, t, x)
-    elseif t.dims == 2
-        return reconstruct!(y', t, x')'
-    end
+function reconstruct(t::AbstractDataTransform, y::AbstractVector{<:Real})
+    ymat = reconstruct(t, reshape(y, :, 1))
+    return vec(ymat)
 end
 
 """

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -10,10 +10,11 @@ Apply transformation `t` to vector or matrix `x` in place.
 """
 function transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real})
     if t.dims == 1
-        return transform!(x, t, x)
+        transform!(x, t, x)
     elseif t.dims == 2
-        return transform!(x', t, x')'
+        transform!(x', t, x')
     end
+    return x
 end
 
 function transform!(t::AbstractDataTransform, x::AbstractVector{<:Real})
@@ -48,10 +49,11 @@ vector or matrix `y` using `t` transformation.
 """
 function reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real})
     if t.dims == 1
-        return reconstruct!(y, t, y)
+        reconstruct!(y, t, y)
     elseif t.dims == 2
-        return reconstruct!(y', t, y')'
+        reconstruct!(y', t, y')
     end
+    return y
 end
 
 function reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real})

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -133,6 +133,8 @@ function fit(::Type{ZScoreTransform}, X::AbstractMatrix{<:Real};
         m, s = mean_and_std(X, 2)
     elseif dims === nothing
         Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
+    else
+        throw(DomainError(dims, "fit only accept dims to be 1 or 2."))
     end
     T = eltype(X)
     return ZScoreTransform(l, dims, (center ? vec(m) : zeros(T, 0)),
@@ -330,6 +332,8 @@ function fit(::Type{UnitRangeTransform}, X::AbstractMatrix{<:Real};
         l, tmin, tmax = _extract_info(X')
     elseif dims == nothing
         Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
+    else
+        throw(DomainError(dims, "fit only accept dims to be 1 or 2."))
     end
 
     for i = 1:l

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -19,7 +19,7 @@ end
 
 function transform!(t::AbstractDataTransform, x::AbstractVector{<:Real})
     transform!(t, reshape(x, :, 1))
-    return vec(x)
+    return x
 end
 
 """
@@ -36,8 +36,7 @@ function transform(t::AbstractDataTransform, x::AbstractMatrix{<:Real})
 end
 
 function transform(t::AbstractDataTransform, x::AbstractVector{<:Real})
-    xmat = transform(t, reshape(x, :, 1))
-    return vec(xmat)
+    return vec(transform(t, reshape(x, :, 1)))
 end
 
 # reconstruct the original data from transformed values
@@ -58,7 +57,7 @@ end
 
 function reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real})
     reconstruct!(t, reshape(y, :, 1))
-    return vec(y)
+    return y
 end
 
 """
@@ -76,8 +75,7 @@ function reconstruct(t::AbstractDataTransform, y::AbstractMatrix{<:Real})
 end
 
 function reconstruct(t::AbstractDataTransform, y::AbstractVector{<:Real})
-    ymat = reconstruct(t, reshape(y, :, 1))
-    return vec(ymat)
+    return vec(reconstruct(t, reshape(y, :, 1)))
 end
 
 """

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -280,10 +280,13 @@ end
 """
     standardize(DT, X; kwargs...)
 
-Return a row-standardized matrix `X` using `DT` transformation which is a subtype of `AbstractDataTransform`:
+Standardize data using `DT` transformation which is a subtype of `AbstractDataTransform`:
 
 - `ZScoreTransform`
 - `UnitRangeTransform`
+
+Return a row-standardized matrix while the input of `X` is a `AbstractMatrix`.
+Return a standardized vector while the input of `X` is a `AbstractVector`.
 
 # Example
 
@@ -302,7 +305,7 @@ julia> standardize(UnitRangeTransform, [0.0 -0.5 0.5; 0.0 1.0 2.0])
 ```
 """
 function standardize(::Type{DT}, X::AbstractArray{<:Real,1}; kwargs...) where {DT <: AbstractDataTransform}
-    return transform(fit(DT, X; kwargs...), X)
+    return transform(fit(DT, X'; kwargs...), X')'
 end
 function standardize(::Type{DT}, X::AbstractArray{<:Real,2}; kwargs...) where {DT <: AbstractDataTransform}
     return transform(fit(DT, X; kwargs...), X)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -133,7 +133,7 @@ function fit(::Type{ZScoreTransform}, X::AbstractVector{<:Real};
     if dims == nothing
         Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
     elseif dims != 1
-        throw(DomainError(dims, "fit only accept dims=1 over a vector. Try fit(t, x, dims=1)."))
+        throw(DomainError(dims, "fit only accepts dims=1 over a vector. Try fit(t, x, dims=1)."))
     end
 
     T = eltype(X)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -96,7 +96,7 @@ Fit standardization parameters to `X` and return a `ZScoreTransform` transformat
 # Keyword arguments
 
 * `dims`: if `1` fit standardization parameters in column-wise fashion;
-  if `2` fit in row-wise fashion. The default is `nothing`.
+  if `2` fit in row-wise fashion. The default is `nothing`, which is equivalent to `dims=2` with a deprecation warning.
 
 * `center`: if `true` (the default) center data so that its mean is zero.
 

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -8,12 +8,12 @@ abstract type AbstractDataTransform end
 
 Apply transformation `t` to vector or matrix `x` in place.
 """
-function transform!(t::AbstractDataTransform, x::AbstractVecOrMat{<:Real})
-    if t.dims == 1
-        return transform!(x, t, x)
-    elseif t.dims == 2
-        return transform!(x', t, x')'
-    end
+transform!(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = _transform!(x, t, x)
+
+function transform!(t::AbstractDataTransform, x::AbstractVector{<:Real})
+    x = reshape(x, :, 1)
+    _transform!(x, t, x)
+    return vec(x)
 end
 
 """
@@ -21,11 +21,19 @@ end
 
 Return a standardized vector or matrix `x` using `t` transformation.
 """
-function transform(t::AbstractDataTransform, x::AbstractVecOrMat{<:Real})
+transform(t::AbstractDataTransform, x::AbstractMatrix{<:Real}) = _transform!(similar(x), t, x)
+
+function transform(t::AbstractDataTransform, x::AbstractVector{<:Real})
+    x = reshape(x, :, 1)
+    x_ = _transform!(similar(x), t, x)
+    return vec(x_)
+end
+
+function _transform!(y::AbstractMatrix{<:Real}, t::AbstractDataTransform, x::AbstractMatrix{<:Real})
     if t.dims == 1
-        return transform!(similar(x), t, x)
+        return transform!(y, t, x)
     elseif t.dims == 2
-        return transform!(similar(x)', t, x')'
+        return transform!(y', t, x')'
     end
 end
 
@@ -36,12 +44,12 @@ end
 Perform an in-place reconstruction into an original data scale from a transformed
 vector or matrix `y` using `t` transformation.
 """
-function reconstruct!(t::AbstractDataTransform, y::AbstractVecOrMat{<:Real})
-    if t.dims == 1
-        return reconstruct!(y, t, y)
-    elseif t.dims == 2
-        return reconstruct!(y', t, y')'
-    end
+reconstruct!(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = _reconstruct!(y, t, y)
+
+function reconstruct!(t::AbstractDataTransform, y::AbstractVector{<:Real})
+    y = reshape(y, :, 1)
+    _reconstruct!(y, t, y)
+    return vec(y)
 end
 
 """
@@ -50,11 +58,19 @@ end
 Return a reconstruction of an originally scaled data from a transformed vector
 or matrix `y` using `t` transformation.
 """
-function reconstruct(t::AbstractDataTransform, y::AbstractVecOrMat{<:Real})
+reconstruct(t::AbstractDataTransform, y::AbstractMatrix{<:Real}) = _reconstruct!(similar(y), t, y)
+
+function reconstruct(t::AbstractDataTransform, y::AbstractVector{<:Real})
+    y = reshape(y, :, 1)
+    y_ = _reconstruct!(similar(y), t, y)
+    return vec(y_)
+end
+
+function _reconstruct!(y::AbstractMatrix{<:Real}, t::AbstractDataTransform, x::AbstractMatrix{<:Real})
     if t.dims == 1
-        return reconstruct!(similar(y), t, y)
+        return reconstruct!(y, t, x)
     elseif t.dims == 2
-        return reconstruct!(similar(y)', t, y')'
+        return reconstruct!(y', t, x')'
     end
 end
 

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -33,7 +33,7 @@ end
 """
     reconstruct!(t::AbstractDataTransform, y)
 
-Perform an in-place reconstruction into an original data scale from a row-transformed
+Perform an in-place reconstruction into an original data scale from a transformed
 vector or matrix `y` using `t` transformation.
 """
 function reconstruct!(t::AbstractDataTransform, y::AbstractVecOrMat{<:Real})
@@ -47,7 +47,7 @@ end
 """
     reconstruct(t::AbstractDataTransform, y)
 
-Return a reconstruction of an originally scaled data from a row-transformed vector
+Return a reconstruction of an originally scaled data from a transformed vector
 or matrix `y` using `t` transformation.
 """
 function reconstruct(t::AbstractDataTransform, y::AbstractVecOrMat{<:Real})
@@ -95,8 +95,8 @@ Fit standardization parameters to `X` and return a `ZScoreTransform` transformat
 
 # Keyword arguments
 
-* `dims`: if `1` (the default) fit standardization parameters in column-wise fashion;
-  if `2` fit in row-wise fashion.
+* `dims`: if `1` fit standardization parameters in column-wise fashion;
+  if `2` fit in row-wise fashion. The default is `nothing`.
 
 * `center`: if `true` (the default) center data so that its mean is zero.
 
@@ -112,7 +112,7 @@ julia> X = [0.0 -0.5 0.5; 0.0 1.0 2.0]
  0.0  -0.5  0.5
  0.0   1.0  2.0
 
-julia> dt = fit(ZScoreTransform, X)
+julia> dt = fit(ZScoreTransform, X, dims=2)
 ZScoreTransform{Float64}(2, [0.0, 1.0], [0.5, 1.0])
 
 julia> StatsBase.transform(dt, X)
@@ -298,7 +298,8 @@ Fit a scaling parameters to `X` and return transformation description.
 
 # Keyword arguments
 
-* `dims`: if `1` (the default) fit standardization parameters in column-wise fashion; if `2` fit in row-wise fashion.
+* `dims`: if `1` fit standardization parameters in column-wise fashion;
+ if `2` fit in row-wise fashion. The default is `nothing`.
 
 * `unit`: if `true` (the default) shift the minimum data to zero.
 
@@ -312,7 +313,7 @@ julia> X = [0.0 -0.5 0.5; 0.0 1.0 2.0]
  0.0  -0.5  0.5
  0.0   1.0  2.0
 
-julia> dt = fit(UnitRangeTransform, X)
+julia> dt = fit(UnitRangeTransform, X, dims=2)
 UnitRangeTransform{Float64}(2, true, [-0.5, 0.0], [1.0, 0.5])
 
 julia> StatsBase.transform(dt, X)
@@ -444,13 +445,13 @@ end
 """
     standardize(DT, X; dims=nothing, kwargs...)
 
- Return a column-standardized copy of vector or matrix `X` along dimensions `dims`
+ Return a standardized copy of vector or matrix `X` along dimensions `dims`
  using transformation `DT` which is a subtype of `AbstractDataTransform`:
 
 - `ZScoreTransform`
 - `UnitRangeTransform`
 
-Return a column-standardized matrix while the input of `X` is a `AbstractMatrix`.
+Return a standardized matrix while the input of `X` is a `AbstractMatrix`.
 Return a standardized vector while the input of `X` is a `AbstractVector`.
 
 # Example
@@ -458,12 +459,12 @@ Return a standardized vector while the input of `X` is a `AbstractVector`.
 ```jldoctest
 julia> using StatsBase
 
-julia> standardize(ZScoreTransform, [0.0 -0.5 0.5; 0.0 1.0 2.0])
+julia> standardize(ZScoreTransform, [0.0 -0.5 0.5; 0.0 1.0 2.0], dims=2)
 2×3 Array{Float64,2}:
   0.0  -1.0  1.0
  -1.0   0.0  1.0
 
-julia> standardize(UnitRangeTransform, [0.0 -0.5 0.5; 0.0 1.0 2.0])
+julia> standardize(UnitRangeTransform, [0.0 -0.5 0.5; 0.0 1.0 2.0], dims=2)
 2×3 Array{Float64,2}:
  0.5  0.0  1.0
  0.0  0.5  1.0

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -41,7 +41,7 @@ reconstruct(t::AbstractDataTransform, y::AbstractArray{<:Real,2})  = reconstruct
 """
     Standardization (Z-score transformation)
 """
-struct ZScoreTransform{T<:Real} <: AbstractDataTransform
+struct ZScoreTransform{T <: Real} <: AbstractDataTransform
     dim::Int
     mean::Vector{T}
     scale::Vector{T}
@@ -97,7 +97,7 @@ julia> StatsBase.transform(dt, X)
  -1.0   0.0  1.0
 ```
 """
-function fit(::Type{ZScoreTransform}, X::AbstractArray{<:Real,2}; center::Bool=true, scale::Bool=true)
+function fit(::Type{ZScoreTransform}, X::AbstractArray{<:Real,2}; center::Bool = true, scale::Bool = true)
     d, n = size(X)
     n >= 2 || error("X must contain at least two columns.")
 
@@ -110,9 +110,9 @@ end
 
 function transform!(y::AbstractVecOrMat{<:Real}, t::ZScoreTransform, x::AbstractVecOrMat{<:Real})
     d = t.dim
-    size(x,1) == size(y,1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
-    n = size(y,2)
-    size(x,2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
+    size(x, 1) == size(y, 1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
+    n = size(y, 2)
+    size(x, 2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
 
     m = t.mean
     s = t.scale
@@ -129,7 +129,7 @@ function transform!(y::AbstractVecOrMat{<:Real}, t::ZScoreTransform, x::Abstract
         if isempty(s)
             broadcast!(-, y, x, m)
         else
-            broadcast!((x,m,s)->(x-m)/s, y, x, m, s)
+            broadcast!((x, m, s)->(x - m) / s, y, x, m, s)
         end
     end
     return y
@@ -137,9 +137,9 @@ end
 
 function reconstruct!(x::AbstractVecOrMat{<:Real}, t::ZScoreTransform, y::AbstractVecOrMat{<:Real})
     d = t.dim
-    size(x,1) == size(y,1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
-    n = size(y,2)
-    size(x,2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
+    size(x, 1) == size(y, 1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
+    n = size(y, 2)
+    size(x, 2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
 
     m = t.mean
     s = t.scale
@@ -156,7 +156,7 @@ function reconstruct!(x::AbstractVecOrMat{<:Real}, t::ZScoreTransform, y::Abstra
         if isempty(s)
             broadcast!(+, x, y, m)
         else
-            broadcast!((y,m,s)->y*s+m, x, y, m, s)
+            broadcast!((y, m, s)->y * s + m, x, y, m, s)
         end
     end
     return x
@@ -165,7 +165,7 @@ end
 """
     Unit range normalization
 """
-struct UnitRangeTransform{T<:Real}  <: AbstractDataTransform
+struct UnitRangeTransform{T <: Real}  <: AbstractDataTransform
     dim::Int
     unit::Bool
     min::Vector{T}
@@ -223,7 +223,7 @@ julia> StatsBase.transform(dt, X)
  0.0  0.5  1.0
 ```
 """
-function fit(::Type{UnitRangeTransform}, X::AbstractArray{<:Real,2}; unit::Bool=true)
+function fit(::Type{UnitRangeTransform}, X::AbstractArray{<:Real,2}; unit::Bool = true)
     d, n = size(X)
 
     tmin = X[:, 1]
@@ -245,15 +245,15 @@ end
 
 function transform!(y::AbstractVecOrMat{<:Real}, t::UnitRangeTransform, x::AbstractVecOrMat{<:Real})
     d = t.dim
-    size(x,1) == size(y,1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
-    n = size(x,2)
-    size(y,2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
+    size(x, 1) == size(y, 1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
+    n = size(x, 2)
+    size(y, 2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
 
     tmin = t.min
     tscale = t.scale
 
     if t.unit
-        broadcast!((x,s,m) -> (x-m)*s, y, x, tscale, tmin)
+        broadcast!((x, s, m)->(x - m) * s, y, x, tscale, tmin)
     else
         broadcast!(*, y, x, tscale)
     end
@@ -262,15 +262,15 @@ end
 
 function reconstruct!(x::AbstractVecOrMat{<:Real}, t::UnitRangeTransform, y::AbstractVecOrMat{<:Real})
     d = t.dim
-    size(x,1) == size(y,1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
-    n = size(y,2)
-    size(x,2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
+    size(x, 1) == size(y, 1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
+    n = size(y, 2)
+    size(x, 2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
 
     tmin = t.min
     tscale = t.scale
 
     if t.unit
-        broadcast!((y,s,m) -> y/s + m, x, y, tscale, tmin)
+        broadcast!((y, s, m)->y / s + m, x, y, tscale, tmin)
     else
         broadcast!(/, x, y, tscale)
     end
@@ -301,6 +301,9 @@ julia> standardize(UnitRangeTransform, [0.0 -0.5 0.5; 0.0 1.0 2.0])
  0.0  0.5  1.0
 ```
 """
-function standardize(::Type{DT}, X::AbstractArray{<:Real,2}; kwargs...) where {DT<:AbstractDataTransform}
+function standardize(::Type{DT}, X::AbstractArray{<:Real,1}; kwargs...) where {DT <: AbstractDataTransform}
+    return transform(fit(DT, X; kwargs...), X)
+end
+function standardize(::Type{DT}, X::AbstractArray{<:Real,2}; kwargs...) where {DT <: AbstractDataTransform}
     return transform(fit(DT, X; kwargs...), X)
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -6,7 +6,7 @@ using Test
 @testset "Transformations" begin
     X = rand(5, 8)
 
-    t = fit(ZScoreTransform, X; center=false, scale=false)
+    t = fit(ZScoreTransform, X; center = false, scale = false)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
     @test isempty(t.mean)
@@ -16,20 +16,20 @@ using Test
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X; center=false)
+    t = fit(ZScoreTransform, X; center = false)
     Y = transform(t, X)
     @test isempty(t.mean)
     @test length(t.scale) == 5
-    @test Y ≈ X ./ std(X, dims=2)
+    @test Y ≈ X ./ std(X, dims = 2)
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X; scale=false)
+    t = fit(ZScoreTransform, X; scale = false)
     Y = transform(t, X)
     @test length(t.mean) == 5
     @test isempty(t.scale)
-    @test Y ≈ X .- mean(X, dims=2)
+    @test Y ≈ X .- mean(X, dims = 2)
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
@@ -38,29 +38,34 @@ using Test
     Y = transform(t, X)
     @test length(t.mean) == 5
     @test length(t.scale) == 5
-    @test Y ≈ (X .- mean(X, dims=2)) ./ std(X, dims=2)
+    @test Y ≈ (X .- mean(X, dims = 2)) ./ std(X, dims = 2)
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
+    
+    @test Y == standardize(ZScoreTransform, X)
+    @test Y[1,:] == standardize(ZScoreTransform, X[1,:])
 
     t = fit(UnitRangeTransform, X)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
     @test length(t.min) == 5
     @test length(t.scale) == 5
-    @test Y ≈ (X .- minimum(X, dims=2)) ./ (maximum(X, dims=2) .- minimum(X, dims=2))
+    @test Y ≈ (X .- minimum(X, dims = 2)) ./ (maximum(X, dims = 2) .- minimum(X, dims = 2))
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(UnitRangeTransform, X; unit=false)
+    t = fit(UnitRangeTransform, X; unit = false)
     Y = transform(t, X)
     @test length(t.min) == 5
     @test length(t.scale) == 5
-    @test Y ≈ X ./ (maximum(X, dims=2) .- minimum(X, dims=2))
+    @test Y ≈ X ./ (maximum(X, dims = 2) .- minimum(X, dims = 2))
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    @test Y == standardize(UnitRangeTransform, X; unit=false)
+    @test Y == standardize(UnitRangeTransform, X; unit = false)
+    @test Y[1,:] == standardize(UnitRangeTransform, X[1,:]; unit = false)
+    
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -15,9 +15,9 @@ using Test
     @test isempty(t.scale)
     @test isequal(X, Y)
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -27,9 +27,9 @@ using Test
     @test length(t.scale) == 8
     @test Y ≈ X ./ std(X, dims=1)
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -39,9 +39,9 @@ using Test
     @test isempty(t.scale)
     @test Y ≈ X .- mean(X, dims=1)
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -52,9 +52,9 @@ using Test
     @test Y ≈ (X .- mean(X, dims=1)) ./ std(X, dims=1)
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(ZScoreTransform, X, dims=1)
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -65,9 +65,9 @@ using Test
     @test Y ≈ (X .- mean(X, dims=2)) ./ std(X, dims=2)
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(ZScoreTransform, X, dims=2)
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -77,9 +77,9 @@ using Test
     @test length(t.scale) == 8
     @test Y ≈ X ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -91,9 +91,9 @@ using Test
     @test Y ≈ (X .- minimum(X, dims=1)) ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(UnitRangeTransform, X, dims=1)
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -104,9 +104,9 @@ using Test
     @test length(t.scale) == 5
     @test Y ≈ (X .- minimum(X, dims=2)) ./ (maximum(X, dims=2) .- minimum(X, dims=2))
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     # vector
@@ -117,9 +117,9 @@ using Test
     Y = transform(t, X)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -128,9 +128,9 @@ using Test
     @test Y ≈ X ./ std(X, dims=1)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -139,9 +139,9 @@ using Test
     @test Y ≈ X .- mean(X, dims=1)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -151,9 +151,9 @@ using Test
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(ZScoreTransform, X, dims=1)
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -162,9 +162,9 @@ using Test
     @test Y ≈ (X .- minimum(X, dims=1)) ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
     X = copy(X_)
@@ -174,9 +174,9 @@ using Test
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(UnitRangeTransform, X, dims=1, unit=false)
-    transform!(t, X)
+    @test transform!(t, X) === X
     @test isequal(X, Y)
-    reconstruct!(t, Y)
+    @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -4,68 +4,109 @@ using Statistics
 using Test
 
 @testset "Transformations" begin
+    # matrix
     X = rand(5, 8)
 
-    t = fit(ZScoreTransform, X; center=false, scale=false)
+    t = fit(ZScoreTransform, X, dims=1, center=false, scale=false)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
     @test isempty(t.mean)
     @test isempty(t.scale)
     @test isequal(X, Y)
-    @test transform(t, X[:,1]) ≈ Y[:,1]
-    @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X; center=false)
+    t = fit(ZScoreTransform, X, dims=1, center=false)
     Y = transform(t, X)
     @test isempty(t.mean)
-    @test length(t.scale) == 5
-    @test Y ≈ X ./ std(X, dims=2)
-    @test transform(t, X[:,1]) ≈ Y[:,1]
-    @test reconstruct(t, Y[:,1]) ≈ X[:,1]
+    @test length(t.scale) == 8
+    @test Y ≈ X ./ std(X, dims=1)
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X; scale=false)
+    t = fit(ZScoreTransform, X, dims=1, scale=false)
     Y = transform(t, X)
-    @test length(t.mean) == 5
+    @test length(t.mean) == 8
     @test isempty(t.scale)
-    @test Y ≈ X .- mean(X, dims=2)
-    @test transform(t, X[:,1]) ≈ Y[:,1]
-    @test reconstruct(t, Y[:,1]) ≈ X[:,1]
+    @test Y ≈ X .- mean(X, dims=1)
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X)
+    t = fit(ZScoreTransform, X, dims=1)
+    Y = transform(t, X)
+    @test length(t.mean) == 8
+    @test length(t.scale) == 8
+    @test Y ≈ (X .- mean(X, dims=1)) ./ std(X, dims=1)
+    @test reconstruct(t, Y) ≈ X
+    @test Y ≈ standardize(ZScoreTransform, X, dims=1)
+
+    t = fit(ZScoreTransform, X, dims=2)
     Y = transform(t, X)
     @test length(t.mean) == 5
     @test length(t.scale) == 5
     @test Y ≈ (X .- mean(X, dims=2)) ./ std(X, dims=2)
-    @test transform(t, X[:,1]) ≈ Y[:,1]
-    @test reconstruct(t, Y[:,1]) ≈ X[:,1]
+    @test reconstruct(t, Y) ≈ X
+    @test Y ≈ standardize(ZScoreTransform, X, dims=2)
+
+    t = fit(UnitRangeTransform, X, dims=1, unit=false)
+    Y = transform(t, X)
+    @test length(t.min) == 8
+    @test length(t.scale) == 8
+    @test Y ≈ X ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test reconstruct(t, Y) ≈ X
 
-    @test Y == standardize(ZScoreTransform, X)
-    @test Y[1,:] == standardize(ZScoreTransform, X[1,:])
+    t = fit(UnitRangeTransform, X, dims=1)
+    Y = transform(t, X)
+    @test isa(t, AbstractDataTransform)
+    @test length(t.min) == 8
+    @test length(t.scale) == 8
+    @test Y ≈ (X .- minimum(X, dims=1)) ./ (maximum(X, dims=1) .- minimum(X, dims=1))
+    @test reconstruct(t, Y) ≈ X
+    @test Y ≈ standardize(UnitRangeTransform, X, dims=1)
 
-    t = fit(UnitRangeTransform, X)
+    t = fit(UnitRangeTransform, X, dims=2)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
     @test length(t.min) == 5
     @test length(t.scale) == 5
     @test Y ≈ (X .- minimum(X, dims=2)) ./ (maximum(X, dims=2) .- minimum(X, dims=2))
-    @test transform(t, X[:,1]) ≈ Y[:,1]
-    @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(UnitRangeTransform, X; unit=false)
+    # vector
+    X = rand(10)
+
+    t = fit(ZScoreTransform, X, dims=1, center=false, scale=false)
     Y = transform(t, X)
-    @test length(t.min) == 5
-    @test length(t.scale) == 5
-    @test Y ≈ X ./ (maximum(X, dims=2) .- minimum(X, dims=2))
-    @test transform(t, X[:,1]) ≈ Y[:,1]
-    @test reconstruct(t, Y[:,1]) ≈ X[:,1]
+    @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
 
-    @test Y == standardize(UnitRangeTransform, X; unit=false)
-    @test Y[1,:] == standardize(UnitRangeTransform, X[1,:]; unit=false)
+    t = fit(ZScoreTransform, X, dims=1, center=false)
+    Y = transform(t, X)
+    @test Y ≈ X ./ std(X, dims=1)
+    @test transform(t, X) ≈ Y
+    @test reconstruct(t, Y) ≈ X
+
+    t = fit(ZScoreTransform, X, dims=1, scale=false)
+    Y = transform(t, X)
+    @test Y ≈ X .- mean(X, dims=1)
+    @test transform(t, X) ≈ Y
+    @test reconstruct(t, Y) ≈ X
+
+    t = fit(ZScoreTransform, X, dims=1)
+    Y = transform(t, X)
+    @test Y ≈ (X .- mean(X, dims=1)) ./ std(X, dims=1)
+    @test transform(t, X) ≈ Y
+    @test reconstruct(t, Y) ≈ X
+    @test Y ≈ standardize(ZScoreTransform, X, dims=1)
+
+    t = fit(UnitRangeTransform, X, dims=1)
+    Y = transform(t, X)
+    @test Y ≈ (X .- minimum(X, dims=1)) ./ (maximum(X, dims=1) .- minimum(X, dims=1))
+    @test transform(t, X) ≈ Y
+    @test reconstruct(t, Y) ≈ X
+
+    t = fit(UnitRangeTransform, X, dims=1, unit=false)
+    Y = transform(t, X)
+    @test Y ≈ X ./ (maximum(X, dims=1) .- minimum(X, dims=1))
+    @test transform(t, X) ≈ Y
+    @test reconstruct(t, Y) ≈ X
+    @test Y ≈ standardize(UnitRangeTransform, X, dims=1, unit=false)
 
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -6,7 +6,7 @@ using Test
 @testset "Transformations" begin
     X = rand(5, 8)
 
-    t = fit(ZScoreTransform, X; center = false, scale = false)
+    t = fit(ZScoreTransform, X; center=false, scale=false)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
     @test isempty(t.mean)
@@ -16,20 +16,20 @@ using Test
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X; center = false)
+    t = fit(ZScoreTransform, X; center=false)
     Y = transform(t, X)
     @test isempty(t.mean)
     @test length(t.scale) == 5
-    @test Y ≈ X ./ std(X, dims = 2)
+    @test Y ≈ X ./ std(X, dims=2)
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(ZScoreTransform, X; scale = false)
+    t = fit(ZScoreTransform, X; scale=false)
     Y = transform(t, X)
     @test length(t.mean) == 5
     @test isempty(t.scale)
-    @test Y ≈ X .- mean(X, dims = 2)
+    @test Y ≈ X .- mean(X, dims=2)
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
@@ -38,11 +38,11 @@ using Test
     Y = transform(t, X)
     @test length(t.mean) == 5
     @test length(t.scale) == 5
-    @test Y ≈ (X .- mean(X, dims = 2)) ./ std(X, dims = 2)
+    @test Y ≈ (X .- mean(X, dims=2)) ./ std(X, dims=2)
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
-    
+
     @test Y == standardize(ZScoreTransform, X)
     @test Y[1,:] == standardize(ZScoreTransform, X[1,:])
 
@@ -51,7 +51,7 @@ using Test
     @test isa(t, AbstractDataTransform)
     @test length(t.min) == 5
     @test length(t.scale) == 5
-    @test Y ≈ (X .- minimum(X, dims = 2)) ./ (maximum(X, dims = 2) .- minimum(X, dims = 2))
+    @test Y ≈ (X .- minimum(X, dims=2)) ./ (maximum(X, dims=2) .- minimum(X, dims=2))
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
@@ -60,12 +60,12 @@ using Test
     Y = transform(t, X)
     @test length(t.min) == 5
     @test length(t.scale) == 5
-    @test Y ≈ X ./ (maximum(X, dims = 2) .- minimum(X, dims = 2))
+    @test Y ≈ X ./ (maximum(X, dims=2) .- minimum(X, dims=2))
     @test transform(t, X[:,1]) ≈ Y[:,1]
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    @test Y == standardize(UnitRangeTransform, X; unit = false)
-    @test Y[1,:] == standardize(UnitRangeTransform, X[1,:]; unit = false)
-    
+    @test Y == standardize(UnitRangeTransform, X; unit=false)
+    @test Y[1,:] == standardize(UnitRangeTransform, X[1,:]; unit=false)
+
 end

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -56,7 +56,7 @@ using Test
     @test reconstruct(t, Y[:,1]) ≈ X[:,1]
     @test reconstruct(t, Y) ≈ X
 
-    t = fit(UnitRangeTransform, X; unit = false)
+    t = fit(UnitRangeTransform, X; unit=false)
     Y = transform(t, X)
     @test length(t.min) == 5
     @test length(t.scale) == 5

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -1,11 +1,12 @@
 using StatsBase
-import StatsBase: transform, reconstruct
+import StatsBase: transform, reconstruct, transform!, reconstruct!
 using Statistics
 using Test
 
 @testset "Transformations" begin
     # matrix
     X = rand(5, 8)
+    X_ = copy(X)
 
     t = fit(ZScoreTransform, X, dims=1, center=false, scale=false)
     Y = transform(t, X)
@@ -14,21 +15,36 @@ using Test
     @test isempty(t.scale)
     @test isequal(X, Y)
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=1, center=false)
     Y = transform(t, X)
     @test isempty(t.mean)
     @test length(t.scale) == 8
     @test Y ≈ X ./ std(X, dims=1)
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=1, scale=false)
     Y = transform(t, X)
     @test length(t.mean) == 8
     @test isempty(t.scale)
     @test Y ≈ X .- mean(X, dims=1)
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=1)
     Y = transform(t, X)
     @test length(t.mean) == 8
@@ -36,7 +52,12 @@ using Test
     @test Y ≈ (X .- mean(X, dims=1)) ./ std(X, dims=1)
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(ZScoreTransform, X, dims=1)
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=2)
     Y = transform(t, X)
     @test length(t.mean) == 5
@@ -44,14 +65,24 @@ using Test
     @test Y ≈ (X .- mean(X, dims=2)) ./ std(X, dims=2)
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(ZScoreTransform, X, dims=2)
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(UnitRangeTransform, X, dims=1, unit=false)
     Y = transform(t, X)
     @test length(t.min) == 8
     @test length(t.scale) == 8
     @test Y ≈ X ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(UnitRangeTransform, X, dims=1)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
@@ -60,7 +91,12 @@ using Test
     @test Y ≈ (X .- minimum(X, dims=1)) ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(UnitRangeTransform, X, dims=1)
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(UnitRangeTransform, X, dims=2)
     Y = transform(t, X)
     @test isa(t, AbstractDataTransform)
@@ -68,45 +104,79 @@ using Test
     @test length(t.scale) == 5
     @test Y ≈ (X .- minimum(X, dims=2)) ./ (maximum(X, dims=2) .- minimum(X, dims=2))
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
     # vector
     X = rand(10)
+    X_ = copy(X)
 
     t = fit(ZScoreTransform, X, dims=1, center=false, scale=false)
     Y = transform(t, X)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=1, center=false)
     Y = transform(t, X)
     @test Y ≈ X ./ std(X, dims=1)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=1, scale=false)
     Y = transform(t, X)
     @test Y ≈ X .- mean(X, dims=1)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(ZScoreTransform, X, dims=1)
     Y = transform(t, X)
     @test Y ≈ (X .- mean(X, dims=1)) ./ std(X, dims=1)
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(ZScoreTransform, X, dims=1)
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(UnitRangeTransform, X, dims=1)
     Y = transform(t, X)
     @test Y ≈ (X .- minimum(X, dims=1)) ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
+    X = copy(X_)
     t = fit(UnitRangeTransform, X, dims=1, unit=false)
     Y = transform(t, X)
     @test Y ≈ X ./ (maximum(X, dims=1) .- minimum(X, dims=1))
     @test transform(t, X) ≈ Y
     @test reconstruct(t, Y) ≈ X
     @test Y ≈ standardize(UnitRangeTransform, X, dims=1, unit=false)
+    transform!(t, X)
+    @test isequal(X, Y)
+    reconstruct!(t, Y)
+    @test Y ≈ X_
 
 end


### PR DESCRIPTION
I found that `standardize` API is just available for 2D array, and not for 1D array.

I just add supporting for 1D array.