### PR TITLE
Bump to next non-breaking version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.30.0"
+version = "0.30.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Please may we release a version with the new `eweights` functionality added in https://github.com/JuliaStats/StatsBase.jl/pull/401

https://github.com/JuliaStats/StatsBase.jl/compare/v0.30.0...master

We're pre-1.0, and this is backwards compatible with `v0.30`, so just incremented to `0.30.1`
:)
