### PR TITLE
Fix docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,3 @@ jobs:
                                     Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
       after_success: skip
-      

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, StatsBase, Statistics, Random
+using Documenter, StatsBase, Statistics, Random, LinearAlgebra
 
 # Workaround for JuliaLang/julia/pull/28625
 if Base.HOME_PROJECT[] !== nothing

--- a/docs/src/means.md
+++ b/docs/src/means.md
@@ -12,6 +12,6 @@ The `mean` and `mean!` functions are also extended to accept a weight vector of 
 `AbstractWeights` to compute weighted mean.
 
 ```@docs
-Statistics.mean(A::AbstractArray, w::AbstractWeights)
-Statistics.mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dim::Int)
+mean
+mean!
 ```


### PR DESCRIPTION
Many of the methods related to histograms were not found because `LinearAlgebra` wasn't loaded. The signature for the weighted means function had also changed slightly so they were also missed.