### PR TITLE
Simplify weights

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -38,5 +38,5 @@ end
 
 ### Deprecated September 2019
 @deprecate sum(A::AbstractArray, w::AbstractWeights, dims::Int) sum(A, w, dims=dims)
-@deprecate values(wv::AbstractWeights{S, T, V}) where {S, T, V} convert(V, wv)
+@deprecate values(wv::AbstractWeights) convert(Vector, wv)
 @deprecate values(wv::UnitWeights) convert(Vector, wv)

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -35,3 +35,6 @@ end
 @deprecate wmedian(v::RealVector, w::RealVector) median(v, weights(w))
 
 @deprecate quantile(v::AbstractArray{<:Real}) quantile(v, [.0, .25, .5, .75, 1.0])
+
+### Deprecated September 2019
+@deprecate values(wv::AbstractWeights) convert(Vector, wv)

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -39,4 +39,3 @@ end
 ### Deprecated September 2019
 @deprecate sum(A::AbstractArray, w::AbstractWeights, dims::Int) sum(A, w, dims=dims)
 @deprecate values(wv::AbstractWeights) convert(Vector, wv)
-@deprecate values(wv::UnitWeights) convert(Vector, wv)

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -37,4 +37,6 @@ end
 @deprecate quantile(v::AbstractArray{<:Real}) quantile(v, [.0, .25, .5, .75, 1.0])
 
 ### Deprecated September 2019
-@deprecate values(wv::AbstractWeights) convert(Vector, wv)
+@deprecate sum(A::AbstractArray, w::AbstractWeights, dims::Int) sum(A, w, dims=dims)
+@deprecate values(wv::AbstractWeights{S, T, V}) where {S, T, V} convert(V, wv)
+@deprecate values(wv::UnitWeights) convert(Vector, wv)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -564,7 +564,7 @@ Base.sum(A::AbstractArray, w::AbstractWeights{<:Real}; dims::Union{Colon,Int}=:)
     wsum(A, w, dims)
 
 function Base.sum(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=:)
-    a = dims === : ? length(A) : size(A, dims)
+    a = (dims === :) ? length(A) : size(A, dims)
     a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
     return sum(A, dims=dims)
 end
@@ -618,7 +618,7 @@ _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T,W} =
     _mean!(similar(A, wmeantype(T, W), Base.reduced_indices(axes(A), dims)), A, w, dims)
 
 function mean(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=:)
-    a = dims === : ? length(A) : size(A, dims)
+    a = (dims === :) ? length(A) : size(A, dims)
     a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
     return mean(A, dims=dims)
 end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -617,7 +617,7 @@ _mean(A::AbstractArray, w::AbstractWeights, dims::Colon) =
 _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T,W} =
     _mean!(similar(A, wmeantype(T, W), Base.reduced_indices(axes(A), dims)), A, w, dims)
 
-function mean(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=Colon())
+function mean(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=:)
     a = dims === : ? length(A) : size(A, dims)
     a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
     return mean(A, dims=dims)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -277,7 +277,6 @@ isempty(wv::UnitWeights) = iszero(wv.len)
 length(wv::UnitWeights) = wv.len
 size(wv::UnitWeights) = Tuple(length(wv))
 
-Base.convert(::Type{AbstractVector}, wv::UnitWeights{T}) where T = ones(T, length(wv))
 Base.convert(::Type{Vector}, wv::UnitWeights{T}) where {T} = ones(T, length(wv))
 
 @propagate_inbounds function Base.getindex(wv::UnitWeights{T}, i::Integer) where T

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -30,7 +30,7 @@ Base.convert(::Type{Vector}, wv::AbstractWeights) = convert(Vector, wv.values)
     wv.values[i]
 end
 
-@propagate_inbounds function Base.getindex(wv::W, i::AbstractArray{<:Int}) where W <: AbstractWeights
+@propagate_inbounds function Base.getindex(wv::W, i::AbstractArray) where W <: AbstractWeights
     @boundscheck checkbounds(wv, i)
     v = wv.values[i]
     W(v, sum(v))

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -564,7 +564,7 @@ Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::I
 function Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}; dims::Union{Nothing,Int}=nothing)
     if dims === nothing
         length(A) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
-        return wsum(A, w.values)
+        return wsum(A, w)
     else
         size(A, dims) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
         return wsum(A, w.values, dims)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -35,7 +35,7 @@ end
     W(v, sum(v))
 end
 
-Base.getindex(wv::AbstractWeights, ::Colon) = wv
+Base.getindex(wv::W, ::Colon) where {W <: AbstractWeights} = W(copy(wv.values), sum(wv))
 
 @propagate_inbounds function Base.setindex!(wv::AbstractWeights, v::Real, i::Int)
     s = v - wv[i]

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -563,7 +563,7 @@ Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::I
 Base.sum(A::AbstractArray, w::AbstractWeights{<:Real}; dims::Union{Colon,Int}=:) =
     wsum(A, w, dims)
 
-function Base.sum(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=Colon())
+function Base.sum(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=:)
     a = dims === Colon() ? length(A) : size(A, dims)
     a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
     return sum(A, dims=dims)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -562,14 +562,15 @@ end
 
 ## extended sum! and wsum
 
-Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::Int; init::Bool=true) =
-    wsum!(R, A, w.values, dim; init=init)
+Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real};
+          dims::Union{Nothing,Int}=nothing, init::Bool=true) = wsum!(R, A, w.values, dims; init=init)
 
-Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}, dim::Int) = wsum(A, w.values, dim)
+Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}; dims::Union{Nothing,Int}=nothing) =
+    wsum(A, w.values, dims)
 
-function Base.sum(A::AbstractArray{<:Number}, w::UnitWeights, dim::Int)
-    size(A, dim) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
-    return sum(A, dims=dim)
+function Base.sum(A::AbstractArray{<:Number}, w::UnitWeights; dims::Union{Nothing,Int}=nothing)
+    size(A, dims) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
+    return sum(A, dims=dims)
 end
 
 ##### Weighted means #####

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -567,7 +567,7 @@ function Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}; dims::
         return wsum(A, w)
     else
         size(A, dims) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
-        return wsum(A, w.values, dims)
+        return wsum(A, w, dims)
     end
 end
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -1,4 +1,5 @@
-###### Weight vector #####
+##### Weight vector #####
+
 abstract type AbstractWeights{S<:Real, T<:Real, V<:AbstractVector{T}} <: AbstractVector{T} end
 
 """
@@ -247,7 +248,7 @@ eweights(n::Integer, λ::Real) = eweights(1:n, λ)
 eweights(t::AbstractVector, r::AbstractRange, λ::Real) =
     eweights(something.(indexin(t, r)), λ)
 
-# NOTE: No variance correction is implemented for exponential weights
+# NOTE: no variance correction is implemented for exponential weights
 
 struct UnitWeights{T<:Real} <: AbstractWeights{Int, T, V where V<:Vector{T}}
     len::Int
@@ -392,7 +393,6 @@ end
 #     (d) A is a general dense array with eltype <: BlasReal:
 #         dim <= 2: delegate to (a) and (b)
 #         otherwise, decompose A into multiple pages
-#
 
 function _wsum1!(R::AbstractArray, A::AbstractVector, w::AbstractVector, init::Bool)
     r = wsum(A, w)
@@ -455,7 +455,8 @@ function _wsumN!(R::StridedArray{T}, A::DenseArray{T,N}, w::StridedVector{T}, di
     return R
 end
 
-# General Cartesian-based weighted sum across dimensions
+## general Cartesian-based weighted sum across dimensions
+
 @generated function _wsum_general!(R::AbstractArray{RT}, f::supertype(typeof(abs)),
                                    A::AbstractArray{T,N}, w::AbstractVector{WT}, dim::Int, init::Bool) where {T,RT,WT,N}
     quote
@@ -512,7 +513,6 @@ end
     end
 end
 
-
 # N = 1
 _wsum!(R::StridedArray{T}, A::DenseArray{T,1}, w::StridedVector{T}, dim::Int, init::Bool) where {T<:BlasReal} =
     _wsum1!(R, A, w, init)
@@ -532,7 +532,6 @@ _wsum!(R::AbstractArray, A::AbstractArray, w::AbstractVector, dim::Int, init::Bo
 
 wsumtype(::Type{T}, ::Type{W}) where {T,W} = typeof(zero(T) * zero(W) + zero(T) * zero(W))
 wsumtype(::Type{T}, ::Type{T}) where {T<:BlasReal} = T
-
 
 """
     wsum!(R, A, w, dim; init=true)
@@ -559,7 +558,7 @@ function wsum(A::AbstractArray{<:Number}, w::UnitWeights, dim::Int)
     return sum(A, dims=dim)
 end
 
-# extended sum! and wsum
+## extended sum! and wsum
 
 Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::Int; init::Bool=true) =
     wsum!(R, A, values(w), dim; init=init)
@@ -571,7 +570,7 @@ function Base.sum(A::AbstractArray{<:Number}, w::UnitWeights, dim::Int)
     return sum(A, dims=dim)
 end
 
-###### Weighted means #####
+##### Weighted means #####
 
 """
     wmean(v, w::AbstractVector)
@@ -628,7 +627,8 @@ function _mean(A::AbstractArray, w::UnitWeights, dims::Int)
     return mean(A, dims=dims)
 end
 
-###### Weighted quantile #####
+##### Weighted quantile #####
+
 """
     quantile(v, w::AbstractWeights, p)
 
@@ -723,9 +723,8 @@ end
 
 quantile(v::RealVector, w::AbstractWeights{<:Real}, p::Number) = quantile(v, w, [p])[1]
 
+##### Weighted median #####
 
-
-###### Weighted median #####
 """
     median(v::RealVector, w::AbstractWeights)
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -559,7 +559,7 @@ end
 ## extended sum! and wsum
 
 Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::Int; init::Bool=true) =
-    wsum!(R, A, w.values, dim; init=init)
+    wsum!(R, A, w, dim; init=init)
 
 function Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}; dims::Union{Nothing,Int}=nothing)
     if dims === nothing

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -618,7 +618,7 @@ _mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T,W} =
     _mean!(similar(A, wmeantype(T, W), Base.reduced_indices(axes(A), dims)), A, w, dims)
 
 function mean(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=Colon())
-    a = dims === Colon() ? length(A) : size(A, dims)
+    a = dims === : ? length(A) : size(A, dims)
     a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
     return mean(A, dims=dims)
 end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -564,7 +564,7 @@ Base.sum(A::AbstractArray, w::AbstractWeights{<:Real}; dims::Union{Colon,Int}=:)
     wsum(A, w, dims)
 
 function Base.sum(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=:)
-    a = dims === Colon() ? length(A) : size(A, dims)
+    a = dims === : ? length(A) : size(A, dims)
     a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
     return sum(A, dims=dims)
 end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -25,7 +25,7 @@ size(wv::AbstractWeights) = size(wv.values)
 Base.convert(::Type{AbstractVector}, wv::AbstractWeights) = wv.values
 Base.convert(::Type{Vector}, wv::AbstractWeights) = convert(Vector, wv.values)
 
-@propagate_inbounds function Base.getindex(wv::W, i::Integer) where W <: AbstractWeights
+@propagate_inbounds function Base.getindex(wv::AbstractWeights, i::Integer)
     @boundscheck checkbounds(wv, i)
     wv.values[i]
 end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -1,6 +1,6 @@
 ##### Weight vector #####
 
-abstract type AbstractWeights{S<:Real, T<:Real, V<:AbstractVector{T}} <: AbstractVector{T} end
+abstract type AbstractWeights{S<:Real, T<:Real} <: AbstractVector{T} end
 
 """
     @weights name
@@ -10,8 +10,8 @@ and stores the `values` (`V<:RealVector`) and `sum` (`S<:Real`).
 """
 macro weights(name)
     return quote
-        mutable struct $name{S<:Real, T<:Real, V<:AbstractVector{T}} <: AbstractWeights{S, T, V}
-            values::V
+        mutable struct $name{S<:Real, T<:Real} <: AbstractWeights{S, T}
+            values::AbstractVector{T}
             sum::S
         end
         $(esc(name))(vs) = $(esc(name))(vs, sum(vs))
@@ -250,7 +250,7 @@ eweights(t::AbstractVector, r::AbstractRange, λ::Real) =
 
 # NOTE: no variance correction is implemented for exponential weights
 
-struct UnitWeights{T<:Real} <: AbstractWeights{Int, T, V where V<:Vector{T}}
+struct UnitWeights{T<:Real} <: AbstractWeights{Int, T}
     len::Int
 end
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -279,7 +279,7 @@ length(wv::UnitWeights) = wv.len
 size(wv::UnitWeights) = Tuple(length(wv))
 
 Base.convert(::Type{AbstractVector}, wv::UnitWeights{T}) where T = ones(T, length(wv))
-Base.convert(::Type{Vector}, wv::UnitWeights{T}) where T = ones(T, length(wv))
+Base.convert(::Type{Vector}, wv::UnitWeights{T}) where {T} = ones(T, length(wv))
 
 @propagate_inbounds function Base.getindex(wv::UnitWeights{T}, i::Integer) where T
     @boundscheck checkbounds(wv, i)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -289,7 +289,7 @@ end
     UnitWeights{T}(length(i))
 end
 
-Base.getindex(wv::UnitWeights, ::Colon) = wv
+Base.getindex(wv::UnitWeights{T}, ::Colon) where {T} = UnitWeights{T}(wv.len)
 
 """
     uweights(s::Integer)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -560,7 +560,7 @@ end
 Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::Int; init::Bool=true) =
     wsum!(R, A, w, dim; init=init)
 
-Base.sum(A::AbstractArray, w::AbstractWeights{<:Real}; dims::Union{Colon,Int}=Colon()) =
+Base.sum(A::AbstractArray, w::AbstractWeights{<:Real}; dims::Union{Colon,Int}=:) =
     wsum(A, w, dims)
 
 function Base.sum(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=Colon())

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -22,7 +22,6 @@ sum(wv::AbstractWeights) = wv.sum
 isempty(wv::AbstractWeights) = isempty(wv.values)
 size(wv::AbstractWeights) = size(wv.values)
 
-Base.convert(::Type{AbstractVector}, wv::AbstractWeights) = wv.values
 Base.convert(::Type{Vector}, wv::AbstractWeights) = convert(Vector, wv.values)
 
 @propagate_inbounds function Base.getindex(wv::AbstractWeights, i::Integer)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -345,22 +345,6 @@ Compute the weighted sum of an array `v` with weights `w`, optionally over the d
 wsum(v::AbstractVector, w::AbstractVector) = dot(v, w)
 wsum(v::AbstractArray, w::AbstractVector) = dot(vec(v), w)
 
-# Note: the methods for BitArray and SparseMatrixCSC are to avoid ambiguities
-Base.sum(v::BitArray, w::AbstractWeights) = wsum(v, w.values)
-Base.sum(v::SparseArrays.SparseMatrixCSC, w::AbstractWeights) = wsum(v, w.values)
-Base.sum(v::AbstractArray, w::AbstractWeights) = dot(v, w.values)
-
-for v in (AbstractArray{<:Number}, BitArray, SparseArrays.SparseMatrixCSC, AbstractArray)
-    @eval begin
-        function Base.sum(v::$v, w::UnitWeights)
-            if length(v) != length(w)
-                throw(DimensionMismatch("Inconsistent array dimension."))
-            end
-            return sum(v)
-        end
-    end
-end
-
 ## wsum along dimension
 #
 #  Brief explanation of the algorithm:
@@ -562,11 +546,11 @@ end
 
 ## extended sum! and wsum
 
-Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real};
-          dims::Union{Nothing,Int}=nothing, init::Bool=true) = wsum!(R, A, w.values, dims; init=init)
+Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::Int; init::Bool=true) =
+    wsum!(R, A, values(w), dim; init=init)
 
 Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}; dims::Union{Nothing,Int}=nothing) =
-    wsum(A, w.values, dims)
+    dims == nothing ? wsum(A, w.values) : wsum(A, w.values, dims)
 
 function Base.sum(A::AbstractArray{<:Number}, w::UnitWeights; dims::Union{Nothing,Int}=nothing)
     size(A, dims) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -553,8 +553,13 @@ Base.sum(A::AbstractArray{<:Number}, w::AbstractWeights{<:Real}; dims::Union{Not
     dims == nothing ? wsum(A, w.values) : wsum(A, w.values, dims)
 
 function Base.sum(A::AbstractArray{<:Number}, w::UnitWeights; dims::Union{Nothing,Int}=nothing)
-    size(A, dims) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
-    return sum(A, dims=dims)
+    if dims == nothing
+        size(A, dims) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
+        return sum(A)
+    else
+        length(A) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
+        return sum(A, dims=dims)
+    end
 end
 
 ##### Weighted means #####

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -610,7 +610,7 @@ w = rand(n)
 mean(x, weights(w))
 ```
 """
-mean(A::AbstractArray, w::AbstractWeights; dims::Union{Colon,Int}=Colon()) =
+mean(A::AbstractArray, w::AbstractWeights; dims::Union{Colon,Int}=:) =
     _mean(A, w, dims)
 _mean(A::AbstractArray, w::AbstractWeights, dims::Colon) =
     sum(A, w) / sum(w)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -31,7 +31,7 @@ end
 
 @propagate_inbounds function Base.getindex(wv::W, i::AbstractArray) where W <: AbstractWeights
     @boundscheck checkbounds(wv, i)
-    v = wv.values[i]
+    @inbounds v = wv.values[i]
     W(v, sum(v))
 end
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -26,7 +26,7 @@ Base.convert(::Type{Vector}, wv::AbstractWeights) = convert(Vector, wv.values)
 
 @propagate_inbounds function Base.getindex(wv::AbstractWeights, i::Integer)
     @boundscheck checkbounds(wv, i)
-    wv.values[i]
+    @inbounds wv.values[i]
 end
 
 @propagate_inbounds function Base.getindex(wv::W, i::AbstractArray) where W <: AbstractWeights

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -133,8 +133,8 @@ w2 = rand(8)
 @test size(wsum(x, w1, 1)) == (1, 8)
 @test size(wsum(x, w2, 2)) == (6, 1)
 
-@test wsum(x, w1, 1) ≈ sum(x .* w1, dims = 1)
-@test wsum(x, w2, 2) ≈ sum(x .* w2', dims = 2)
+@test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
+@test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
 
 x = rand(6, 5, 4)
 w1 = rand(6)
@@ -145,23 +145,23 @@ w3 = rand(4)
 @test size(wsum(x, w2, 2)) == (6, 1, 4)
 @test size(wsum(x, w3, 3)) == (6, 5, 1)
 
-@test wsum(x, w1, 1) ≈ sum(x .* w1, dims = 1)
-@test wsum(x, w2, 2) ≈ sum(x .* w2', dims = 2)
-@test wsum(x, w3, 3) ≈ sum(x .* reshape(w3, 1, 1, 4), dims = 3)
+@test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
+@test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
+@test wsum(x, w3, 3) ≈ sum(x .* reshape(w3, 1, 1, 4), dims=3)
 
 v = view(x, 2:4, :, :)
 
-@test wsum(v, w1[1:3], 1) ≈ sum(v .* w1[1:3], dims = 1)
-@test wsum(v, w2, 2)      ≈ sum(v .* w2', dims = 2)
-@test wsum(v, w3, 3)      ≈ sum(v .* reshape(w3, 1, 1, 4), dims = 3)
+@test wsum(v, w1[1:3], 1) ≈ sum(v .* w1[1:3], dims=1)
+@test wsum(v, w2, 2)      ≈ sum(v .* w2', dims=2)
+@test wsum(v, w3, 3)      ≈ sum(v .* reshape(w3, 1, 1, 4), dims=3)
 
 ## wsum for Arrays with non-BlasReal elements
 x = rand(1:100, 6, 8)
 w1 = rand(6)
 w2 = rand(8)
 
-@test wsum(x, w1, 1) ≈ sum(x .* w1, dims = 1)
-@test wsum(x, w2, 2) ≈ sum(x .* w2', dims = 2)
+@test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
+@test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
 
 ## wsum!
 x = rand(6)
@@ -181,19 +181,19 @@ w2 = rand(8)
 
 r = ones(1, 8)
 @test wsum!(r, x, w1, 1; init=true) === r
-@test r ≈ sum(x .* w1, dims = 1)
+@test r ≈ sum(x .* w1, dims=1)
 
 r = ones(1, 8)
 @test wsum!(r, x, w1, 1; init=false) === r
-@test r ≈ sum(x .* w1, dims = 1) .+ 1.0
+@test r ≈ sum(x .* w1, dims=1) .+ 1.0
 
 r = ones(6)
 @test wsum!(r, x, w2, 2; init=true) === r
-@test r ≈ sum(x .* w2', dims = 2)
+@test r ≈ sum(x .* w2', dims=2)
 
 r = ones(6)
 @test wsum!(r, x, w2, 2; init=false) === r
-@test r ≈ sum(x .* w2', dims = 2) .+ 1.0
+@test r ≈ sum(x .* w2', dims=2) .+ 1.0
 
 x = rand(8, 6, 5)
 w1 = rand(8)
@@ -202,27 +202,27 @@ w3 = rand(5)
 
 r = ones(1, 6, 5)
 @test wsum!(r, x, w1, 1; init=true) === r
-@test r ≈ sum(x .* w1, dims = 1)
+@test r ≈ sum(x .* w1, dims=1)
 
 r = ones(1, 6, 5)
 @test wsum!(r, x, w1, 1; init=false) === r
-@test r ≈ sum(x .* w1, dims = 1) .+ 1.0
+@test r ≈ sum(x .* w1, dims=1) .+ 1.0
 
 r = ones(8, 1, 5)
 @test wsum!(r, x, w2, 2; init=true) === r
-@test r ≈ sum(x .* w2', dims = 2)
+@test r ≈ sum(x .* w2', dims=2)
 
 r = ones(8, 1, 5)
 @test wsum!(r, x, w2, 2; init=false) === r
-@test r ≈ sum(x .* w2', dims = 2) .+ 1.0
+@test r ≈ sum(x .* w2', dims=2) .+ 1.0
 
 r = ones(8, 6)
 @test wsum!(r, x, w3, 3; init=true) === r
-@test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims = 3)
+@test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3)
 
 r = ones(8, 6)
 @test wsum!(r, x, w3, 3; init=false) === r
-@test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims = 3) .+ 1.0
+@test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3) .+ 1.0
 
 ## the sum and mean syntax
 a = reshape(1.0:27.0, 3, 3, 3)
@@ -232,9 +232,9 @@ a = reshape(1.0:27.0, 3, 3, 3)
     @test sum(1:3, f([1.0, 1.0, 0.5]))             ≈ 4.5
 
     for wt in ([1.0, 1.0, 1.0], [1.0, 0.2, 0.0], [0.2, 0.0, 1.0])
-        @test sum(a, f(wt), dims = 1)  ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims = 1)
-        @test sum(a, f(wt), dims = 2)  ≈ sum(a.*reshape(wt, 1, length(wt), 1), dims = 2)
-        @test sum(a, f(wt), dims = 3)  ≈ sum(a.*reshape(wt, 1, 1, length(wt)), dims = 3)
+        @test sum(a, f(wt), dims=1)  ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims=1)
+        @test sum(a, f(wt), dims=2)  ≈ sum(a.*reshape(wt, 1, length(wt), 1), dims=2)
+        @test sum(a, f(wt), dims=3)  ≈ sum(a.*reshape(wt, 1, 1, length(wt)), dims=3)
     end
 end
 
@@ -467,20 +467,20 @@ end
     @test sum([1.0, 2.0, 3.0], wt) ≈ 6.0
     @test mean([1.0, 2.0, 3.0], wt) ≈ 2.0
 
-    @test sum(a, wt, dims = 1) ≈ sum(a, dims = 1)
-    @test sum(a, wt, dims = 2) ≈ sum(a, dims = 2)
-    @test sum(a, wt, dims = 3) ≈ sum(a, dims = 3)
+    @test sum(a, wt, dims=1) ≈ sum(a, dims=1)
+    @test sum(a, wt, dims=2) ≈ sum(a, dims=2)
+    @test sum(a, wt, dims=3) ≈ sum(a, dims=3)
 
-    @test wsum(a, wt, dims = 1) ≈ sum(a, dims = 1)
-    @test wsum(a, wt, dims = 2) ≈ sum(a, dims = 2)
-    @test wsum(a, wt, dims = 3) ≈ sum(a, dims = 3)
+    @test wsum(a, wt, 1) ≈ sum(a, dims=1)
+    @test wsum(a, wt, 2) ≈ sum(a, dims=2)
+    @test wsum(a, wt, 3) ≈ sum(a, dims=3)
 
-    @test mean(a, wt, dims = 1) ≈ mean(a, dims = 1)
-    @test mean(a, wt, dims = 2) ≈ mean(a, dims = 2)
-    @test mean(a, wt, dims = 3) ≈ mean(a, dims = 3)
+    @test mean(a, wt, dims=1) ≈ mean(a, dims=1)
+    @test mean(a, wt, dims=2) ≈ mean(a, dims=2)
+    @test mean(a, wt, dims=3) ≈ mean(a, dims=3)
 
     @test_throws DimensionMismatch sum(a, wt)
-    @test_throws DimensionMismatch sum(a, wt, 4)
+    @test_throws DimensionMismatch sum(a, wt, dims=4)
     @test_throws DimensionMismatch wsum(a, wt, 4)
     @test_throws DimensionMismatch mean(a, wt, dims=4)
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -250,8 +250,6 @@ end
     end
 end
 
-
-# Quantile fweights
 @testset "Quantile fweights" begin
     data = (
         [7, 1, 2, 4, 10],
@@ -429,9 +427,8 @@ end
     v = [7, 1, 2, 4, 10]
     w = [1, 1/3, 1/3, 1/3, 1]
     answer = 6.0
-    @test quantile(data[1], f(w), 0.5)    ≈  answer atol = 1e-5
+    @test quantile(data[1], f(w), 0.5) ≈ answer atol = 1e-5
 end
-
 
 @testset "Median $f" for f in weight_funcs
     data = [4, 3, 2, 1]

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -116,118 +116,120 @@ end
 
 ## wsum
 
-x = [6., 8., 9.]
-w = [2., 3., 4.]
-p = [1. 2. ; 3. 4.]
-q = [1., 2., 3., 4.]
+@testset "wsum" begin
+    x = [6., 8., 9.]
+    w = [2., 3., 4.]
+    p = [1. 2. ; 3. 4.]
+    q = [1., 2., 3., 4.]
 
-@test wsum(Float64[], Float64[]) === 0.0
-@test wsum(x, w) === 72.0
-@test wsum(p, q) === 29.0
+    @test wsum(Float64[], Float64[]) === 0.0
+    @test wsum(x, w) === 72.0
+    @test wsum(p, q) === 29.0
 
-## wsum along dimension
+    ## wsum along dimension
 
-@test wsum(x, w, 1) == [72.0]
+    @test wsum(x, w, 1) == [72.0]
 
-x  = rand(6, 8)
-w1 = rand(6)
-w2 = rand(8)
+    x  = rand(6, 8)
+    w1 = rand(6)
+    w2 = rand(8)
 
-@test size(wsum(x, w1, 1)) == (1, 8)
-@test size(wsum(x, w2, 2)) == (6, 1)
+    @test size(wsum(x, w1, 1)) == (1, 8)
+    @test size(wsum(x, w2, 2)) == (6, 1)
 
-@test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
-@test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
+    @test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
+    @test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
 
-x = rand(6, 5, 4)
-w1 = rand(6)
-w2 = rand(5)
-w3 = rand(4)
+    x = rand(6, 5, 4)
+    w1 = rand(6)
+    w2 = rand(5)
+    w3 = rand(4)
 
-@test size(wsum(x, w1, 1)) == (1, 5, 4)
-@test size(wsum(x, w2, 2)) == (6, 1, 4)
-@test size(wsum(x, w3, 3)) == (6, 5, 1)
+    @test size(wsum(x, w1, 1)) == (1, 5, 4)
+    @test size(wsum(x, w2, 2)) == (6, 1, 4)
+    @test size(wsum(x, w3, 3)) == (6, 5, 1)
 
-@test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
-@test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
-@test wsum(x, w3, 3) ≈ sum(x .* reshape(w3, 1, 1, 4), dims=3)
+    @test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
+    @test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
+    @test wsum(x, w3, 3) ≈ sum(x .* reshape(w3, 1, 1, 4), dims=3)
 
-v = view(x, 2:4, :, :)
+    v = view(x, 2:4, :, :)
 
-@test wsum(v, w1[1:3], 1) ≈ sum(v .* w1[1:3], dims=1)
-@test wsum(v, w2, 2)      ≈ sum(v .* w2', dims=2)
-@test wsum(v, w3, 3)      ≈ sum(v .* reshape(w3, 1, 1, 4), dims=3)
+    @test wsum(v, w1[1:3], 1) ≈ sum(v .* w1[1:3], dims=1)
+    @test wsum(v, w2, 2)      ≈ sum(v .* w2', dims=2)
+    @test wsum(v, w3, 3)      ≈ sum(v .* reshape(w3, 1, 1, 4), dims=3)
 
-## wsum for Arrays with non-BlasReal elements
+    ## wsum for Arrays with non-BlasReal elements
 
-x = rand(1:100, 6, 8)
-w1 = rand(6)
-w2 = rand(8)
+    x = rand(1:100, 6, 8)
+    w1 = rand(6)
+    w2 = rand(8)
 
-@test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
-@test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
+    @test wsum(x, w1, 1) ≈ sum(x .* w1, dims=1)
+    @test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
 
-## wsum!
+    ## wsum!
 
-x = rand(6)
-w = rand(6)
+    x = rand(6)
+    w = rand(6)
 
-r = ones(1)
-@test wsum!(r, x, w, 1; init=true) === r
-@test r ≈ [dot(x, w)]
+    r = ones(1)
+    @test wsum!(r, x, w, 1; init=true) === r
+    @test r ≈ [dot(x, w)]
 
-r = ones(1)
-@test wsum!(r, x, w, 1; init=false) === r
-@test r ≈ [dot(x, w) + 1.0]
+    r = ones(1)
+    @test wsum!(r, x, w, 1; init=false) === r
+    @test r ≈ [dot(x, w) + 1.0]
 
-x = rand(6, 8)
-w1 = rand(6)
-w2 = rand(8)
+    x = rand(6, 8)
+    w1 = rand(6)
+    w2 = rand(8)
 
-r = ones(1, 8)
-@test wsum!(r, x, w1, 1; init=true) === r
-@test r ≈ sum(x .* w1, dims=1)
+    r = ones(1, 8)
+    @test wsum!(r, x, w1, 1; init=true) === r
+    @test r ≈ sum(x .* w1, dims=1)
 
-r = ones(1, 8)
-@test wsum!(r, x, w1, 1; init=false) === r
-@test r ≈ sum(x .* w1, dims=1) .+ 1.0
+    r = ones(1, 8)
+    @test wsum!(r, x, w1, 1; init=false) === r
+    @test r ≈ sum(x .* w1, dims=1) .+ 1.0
 
-r = ones(6)
-@test wsum!(r, x, w2, 2; init=true) === r
-@test r ≈ sum(x .* w2', dims=2)
+    r = ones(6)
+    @test wsum!(r, x, w2, 2; init=true) === r
+    @test r ≈ sum(x .* w2', dims=2)
 
-r = ones(6)
-@test wsum!(r, x, w2, 2; init=false) === r
-@test r ≈ sum(x .* w2', dims=2) .+ 1.0
+    r = ones(6)
+    @test wsum!(r, x, w2, 2; init=false) === r
+    @test r ≈ sum(x .* w2', dims=2) .+ 1.0
 
-x = rand(8, 6, 5)
-w1 = rand(8)
-w2 = rand(6)
-w3 = rand(5)
+    x = rand(8, 6, 5)
+    w1 = rand(8)
+    w2 = rand(6)
+    w3 = rand(5)
 
-r = ones(1, 6, 5)
-@test wsum!(r, x, w1, 1; init=true) === r
-@test r ≈ sum(x .* w1, dims=1)
+    r = ones(1, 6, 5)
+    @test wsum!(r, x, w1, 1; init=true) === r
+    @test r ≈ sum(x .* w1, dims=1)
 
-r = ones(1, 6, 5)
-@test wsum!(r, x, w1, 1; init=false) === r
-@test r ≈ sum(x .* w1, dims=1) .+ 1.0
+    r = ones(1, 6, 5)
+    @test wsum!(r, x, w1, 1; init=false) === r
+    @test r ≈ sum(x .* w1, dims=1) .+ 1.0
 
-r = ones(8, 1, 5)
-@test wsum!(r, x, w2, 2; init=true) === r
-@test r ≈ sum(x .* w2', dims=2)
+    r = ones(8, 1, 5)
+    @test wsum!(r, x, w2, 2; init=true) === r
+    @test r ≈ sum(x .* w2', dims=2)
 
-r = ones(8, 1, 5)
-@test wsum!(r, x, w2, 2; init=false) === r
-@test r ≈ sum(x .* w2', dims=2) .+ 1.0
+    r = ones(8, 1, 5)
+    @test wsum!(r, x, w2, 2; init=false) === r
+    @test r ≈ sum(x .* w2', dims=2) .+ 1.0
 
-r = ones(8, 6)
-@test wsum!(r, x, w3, 3; init=true) === r
-@test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3)
+    r = ones(8, 6)
+    @test wsum!(r, x, w3, 3; init=true) === r
+    @test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3)
 
-r = ones(8, 6)
-@test wsum!(r, x, w3, 3; init=false) === r
-@test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3) .+ 1.0
+    r = ones(8, 6)
+    @test wsum!(r, x, w3, 3; init=false) === r
+    @test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3) .+ 1.0
+end
 
 ## sum, mean and quantile
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -232,9 +232,9 @@ a = reshape(1.0:27.0, 3, 3, 3)
     @test sum(1:3, f([1.0, 1.0, 0.5]))             ≈ 4.5
 
     for wt in ([1.0, 1.0, 1.0], [1.0, 0.2, 0.0], [0.2, 0.0, 1.0])
-        @test sum(a, f(wt), 1)  ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims = 1)
-        @test sum(a, f(wt), 2)  ≈ sum(a.*reshape(wt, 1, length(wt), 1), dims = 2)
-        @test sum(a, f(wt), 3)  ≈ sum(a.*reshape(wt, 1, 1, length(wt)), dims = 3)
+        @test sum(a, f(wt), dims = 1)  ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims = 1)
+        @test sum(a, f(wt), dims = 2)  ≈ sum(a.*reshape(wt, 1, length(wt), 1), dims = 2)
+        @test sum(a, f(wt), dims = 3)  ≈ sum(a.*reshape(wt, 1, 1, length(wt)), dims = 3)
     end
 end
 
@@ -467,17 +467,17 @@ end
     @test sum([1.0, 2.0, 3.0], wt) ≈ 6.0
     @test mean([1.0, 2.0, 3.0], wt) ≈ 2.0
 
-    @test sum(a, wt, 1) ≈ sum(a, dims=1)
-    @test sum(a, wt, 2) ≈ sum(a, dims=2)
-    @test sum(a, wt, 3) ≈ sum(a, dims=3)
+    @test sum(a, wt, dims = 1) ≈ sum(a, dims = 1)
+    @test sum(a, wt, dims = 2) ≈ sum(a, dims = 2)
+    @test sum(a, wt, dims = 3) ≈ sum(a, dims = 3)
 
-    @test wsum(a, wt, 1) ≈ sum(a, dims=1)
-    @test wsum(a, wt, 2) ≈ sum(a, dims=2)
-    @test wsum(a, wt, 3) ≈ sum(a, dims=3)
+    @test wsum(a, wt, dims = 1) ≈ sum(a, dims = 1)
+    @test wsum(a, wt, dims = 2) ≈ sum(a, dims = 2)
+    @test wsum(a, wt, dims = 3) ≈ sum(a, dims = 3)
 
-    @test mean(a, wt, dims=1) ≈ mean(a, dims=1)
-    @test mean(a, wt, dims=2) ≈ mean(a, dims=2)
-    @test mean(a, wt, dims=3) ≈ mean(a, dims=3)
+    @test mean(a, wt, dims = 1) ≈ mean(a, dims = 1)
+    @test mean(a, wt, dims = 2) ≈ mean(a, dims = 2)
+    @test mean(a, wt, dims = 3) ≈ mean(a, dims = 3)
 
     @test_throws DimensionMismatch sum(a, wt)
     @test_throws DimensionMismatch sum(a, wt, 4)

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -4,7 +4,8 @@ using LinearAlgebra, Random, SparseArrays, Test
 @testset "StatsBase.Weights" begin
 weight_funcs = (weights, aweights, fweights, pweights)
 
-# Construction
+## Construction
+
 @testset "$f" for f in weight_funcs
     @test isa(f([1, 2, 3]), AbstractWeights{Int})
     @test isa(f([1., 2., 3.]), AbstractWeights{Float64})
@@ -17,7 +18,7 @@ weight_funcs = (weights, aweights, fweights, pweights)
     wv = f(w)
     @test eltype(wv) === Float64
     @test length(wv) === 3
-    @test values(wv) === w
+    @test values(wv) ==  w
     @test sum(wv) === 6.0
     @test !isempty(wv)
 
@@ -25,7 +26,7 @@ weight_funcs = (weights, aweights, fweights, pweights)
     bv = f(b)
     @test eltype(bv) === Bool
     @test length(bv) === 3
-    @test values(bv) === b
+    @test values(bv) ==  b
     @test sum(bv)    === 3
     @test !isempty(bv)
 
@@ -114,6 +115,7 @@ end
 end
 
 ## wsum
+
 x = [6., 8., 9.]
 w = [2., 3., 4.]
 p = [1. 2. ; 3. 4.]
@@ -124,6 +126,7 @@ q = [1., 2., 3., 4.]
 @test wsum(p, q) === 29.0
 
 ## wsum along dimension
+
 @test wsum(x, w, 1) == [72.0]
 
 x  = rand(6, 8)
@@ -156,6 +159,7 @@ v = view(x, 2:4, :, :)
 @test wsum(v, w3, 3)      ≈ sum(v .* reshape(w3, 1, 1, 4), dims=3)
 
 ## wsum for Arrays with non-BlasReal elements
+
 x = rand(1:100, 6, 8)
 w1 = rand(6)
 w2 = rand(8)
@@ -164,6 +168,7 @@ w2 = rand(8)
 @test wsum(x, w2, 2) ≈ sum(x .* w2', dims=2)
 
 ## wsum!
+
 x = rand(6)
 w = rand(6)
 
@@ -224,7 +229,8 @@ r = ones(8, 6)
 @test wsum!(r, x, w3, 3; init=false) === r
 @test r ≈ sum(x .* reshape(w3, (1, 1, 5)), dims=3) .+ 1.0
 
-## the sum and mean syntax
+## sum, mean and quantile
+
 a = reshape(1.0:27.0, 3, 3, 3)
 
 @testset "Sum $f" for f in weight_funcs


### PR DESCRIPTION
This pull request:

* removes the type of the values vector as a parameter of weights;
* deprecates the `values` method;
* adds `dims` as a keyword argument of `sum`  (in line with the unweighted version).

It addresses issues #358 and #371.

I have not dropped the tests of `values` yet.