### PR TITLE
Adding support for more 

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -139,13 +139,9 @@ function FD(v::AbstractVector{T}) where {T <: Real}
     return 1
 end
 
-function bin_estimator(estimator::Int, v::AbstractVector{T}) where {T<:Real}
-    println("in my other estimator")
-    return estimator
-end
+bin_estimator(estimator::Int, v::AbstractVector{T}) where {T<:Real} = estimator
 
 function bin_estimator(estimator::String, v::AbstractVector{T}) where {T<:Real}
-    println("in My estimator")
     if (estimator == "sturges")
         return sturges(length(v))
     elseif (estimator == "scott")
@@ -153,7 +149,7 @@ function bin_estimator(estimator::String, v::AbstractVector{T}) where {T<:Real}
     elseif (estimator == "FD")
         return FD(v)
     else
-        throw(ArgumentError("estimator must be one of 'sturges', 'scott', 'FD'"))
+        throw(ArgumentError("estimator string must be one of 'sturges', 'scott', 'FD'"))
     end
 end
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -139,6 +139,24 @@ function FD(v::AbstractVector{T}) where {T <: Real}
     return 1
 end
 
+function bin_estimator(estimator::Int, v::AbstractVector{T}) where {T<:Real}
+    println("in my other estimator")
+    return estimator
+end
+
+function bin_estimator(estimator::String, v::AbstractVector{T}) where {T<:Real}
+    println("in My estimator")
+    if (estimator == "sturges")
+        return sturges(length(v))
+    elseif (estimator == "scott")
+        return scott(v)
+    elseif (estimator == "FD")
+        return FD(v)
+    else
+        throw(ArgumentError("estimator must be one of 'sturges', 'scott', 'FD'"))
+    end
+end
+
 
 abstract type AbstractHistogram{T<:Real,N,E} end
 
@@ -299,12 +317,12 @@ append!(h::AbstractHistogram{T,1}, v::AbstractVector, wv::Union{AbstractVector,A
 
 fit(::Type{Histogram{T}},v::AbstractVector, edg::AbstractVector; closed::Symbol=:left) where {T} =
     fit(Histogram{T},(v,), (edg,), closed=closed)
-fit(::Type{Histogram{T}},v::AbstractVector; closed::Symbol=:left, nbins=sturges(length(v))) where {T} =
-    fit(Histogram{T},(v,); closed=closed, nbins=nbins)
+fit(::Type{Histogram{T}},v::AbstractVector; closed::Symbol=:left, nbins="sturges") where {T} =
+    fit(Histogram{T},(v,); closed=closed, nbins=bin_estimator(nbins, v))
 fit(::Type{Histogram{T}},v::AbstractVector, wv::AbstractWeights, edg::AbstractVector; closed::Symbol=:left) where {T} =
     fit(Histogram{T},(v,), wv, (edg,), closed=closed)
-fit(::Type{Histogram{T}},v::AbstractVector, wv::AbstractWeights; closed::Symbol=:left, nbins=sturges(length(v))) where {T} =
-    fit(Histogram{T}, (v,), wv; closed=closed, nbins=nbins)
+fit(::Type{Histogram{T}},v::AbstractVector, wv::AbstractWeights; closed::Symbol=:left, nbins::String="sturges") where {T} =
+    fit(Histogram{T}, (v,), wv; closed=closed, nbins=bin_estimator(nbins, v))
 
 fit(::Type{Histogram}, v::AbstractVector, wv::AbstractWeights{W}, args...; kwargs...) where {W} = fit(Histogram{W}, v, wv, args...; kwargs...)
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -112,6 +112,34 @@ function sturges(n)  # Sturges' formula
     ceil(Integer, log2(n))+1
 end
 
+function ptp(v::AbstractVector)
+    e = extrema(v)
+    return e[2] - e[1]
+end
+
+function scott(v::AbstractVector{T}) where {T <: Real}
+    n = length(v)
+    h = 3.5 * std(v) * n^(-1/3)
+    # in the case of a 0 std we need to ensure we 
+    # don't divide by 0
+    if (h>0)
+        return ceil(Integer, ptp(v)/h)
+    end
+    return 1
+end
+
+function FD(v::AbstractVector{T}) where {T <: Real}
+    n = length(v)
+    h = 2 * iqr(v) * n ^ (-1 / 3)
+
+    if (h > 0)
+        return ceil(Integer, ptp(v)/h)
+    end
+    
+    return 1
+end
+
+
 abstract type AbstractHistogram{T<:Real,N,E} end
 
 # N-dimensional histogram object


### PR DESCRIPTION
Hi,

I've taken a stab at adding auto-binning for histograms in StatsBase.jl. Given that sturges estimator was the default, I've added the other 2 options available in R, the "scott" estimator and the "FD" estimator. This was inspired by #524 and the fact I've been drawing histograms and sturges is not really that good for large non-normal datasets.

While I'm confident in the implementations of the estimators, I'm less confident about things like API changes and default behaviour changes, especially with things like julia's multiple dispatch and kwargs being sort of unclear (to me). Things like the if statement on the string is a very pythonic thing to do, but I'm a little less confident with the julia way of doing things.

I've got some tests to add before this goes much further, but I'd also like to get a sense on how interested the maintainers would be in having this in StatsBase.jl. 

I can also add the extra estimators available in numpy if there's interest there