### PR TITLE
better NaN handling with ecdf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,9 @@ SortingAlgorithms = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[compat]
+julia = "1"
+
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -21,6 +24,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Dates", "DelimitedFiles", "Test"]
-
-[compat]
-julia = "1"

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -1,6 +1,5 @@
 # Empirical estimation of CDF and PDF
 
-
 ## Empirical CDF
 
 struct ECDF{T <: AbstractVector{<:Real}, W <: AbstractWeights{<:Real}}
@@ -9,6 +8,7 @@ struct ECDF{T <: AbstractVector{<:Real}, W <: AbstractWeights{<:Real}}
 end
 
 function (ecdf::ECDF)(x::Real)
+    isnan(x) && return NaN
     n = searchsortedlast(ecdf.sorted_values, x)
     evenweights = isempty(ecdf.weights)
     weightsum = evenweights ? length(ecdf.sorted_values) : sum(ecdf.weights)
@@ -54,6 +54,7 @@ evaluate CDF values on other samples.
 function is inside the interval ``(0,1)``; the function is defined for the whole real line.
 """
 function ecdf(X::RealVector; weights::AbstractVector{<:Real}=Weights(Float64[]))
+    any(isnan, X) && throw(ArgumentError("ecdf can not include NaN values"))
     isempty(weights) || length(X) == length(weights) || throw(ArgumentError("data and weight vectors must be the same size," *
         "got $(length(X)) and $(length(weights))"))
     ord = sortperm(X)

--- a/test/empirical.jl
+++ b/test/empirical.jl
@@ -12,6 +12,8 @@ using Test
     fnecdf = ecdf([0.5])
     @test fnecdf([zeros(5000); ones(5000)]) == [zeros(5000); ones(5000)]
     @test extrema(fnecdf) == (minimum(fnecdf), maximum(fnecdf)) == (0.5, 0.5)
+    @test isnan(ecdf([1,2,3])(NaN))
+    @test_throws ArgumentError ecdf([1, NaN])
 end
 
 @testset "Weighted ECDF" begin


### PR DESCRIPTION
Ref: https://github.com/JuliaStats/StatsBase.jl/issues/413

New behaviors:

```julia
julia> ecdf([1,2,3])(NaN)
NaN

julia> ecdf([1,2,NaN])
ERROR: ArgumentError: ecdf can not include NaN values
Stacktrace:
 [1] #ecdf#113(::Weights{Float64,Float64,Array{Float64,1}}, ::typeof(ecdf), ::Array{Float64,1}) at /Users/joshday/.julia/dev/StatsBase/src/empirical.jl:57
 [2] ecdf(::Array{Float64,1}) at /Users/joshday/.julia/dev/StatsBase/src/empirical.jl:57
 [3] top-level scope at REPL[11]:1
```

Side note:  I didn't actually touch the Project.toml file...did Pkg make that change for me?