### PR TITLE
Stop using the deprecated values function

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -48,7 +48,7 @@ function addcounts!(r::AbstractArray, x::IntegerArray, levels::IntUnitRange, wv:
     m0 = levels[1]
     m1 = levels[end]
     b = m0 - 1
-    w = values(wv)
+    w = convert(Vector, wv)
 
     @inbounds for i in 1 : length(x)
         xi = x[i]
@@ -160,7 +160,7 @@ function addcounts!(r::AbstractArray, x::IntegerArray, y::IntegerArray,
 
     bx = mx0 - 1
     by = my0 - 1
-    w = values(wv)
+    w = convert(Vector, wv)
 
     for i = 1:n
         xi = x[i]
@@ -326,7 +326,7 @@ radixsort_safe(::Type) = false
 function _addcounts_radix_sort_loop!(cm::Dict{T}, sx::AbstractArray{T}) where T
     last_sx = sx[1]
     tmpcount = get(cm, last_sx, 0) + 1
-    
+
     # now the data is sorted: can just run through and accumulate values before
     # adding into the Dict
     @inbounds for i in 2:length(sx)
@@ -358,7 +358,7 @@ end
 function addcounts!(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractVector{W}) where {T,W<:Real}
     n = length(x)
     length(wv) == n || throw(DimensionMismatch())
-    w = values(wv)
+    w = convert(Vector, wv)
     z = zero(W)
 
     for i = 1 : n

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -27,9 +27,9 @@ _unscaled_covzm(x::DenseMatrix, dims::Colon)   = unscaled_covzm(x)
 _unscaled_covzm(x::DenseMatrix, dims::Integer) = unscaled_covzm(x, dims)
 
 _unscaled_covzm(x::DenseMatrix, wv::AbstractWeights, dims::Colon)   =
-    _symmetrize!(unscaled_covzm(x, _scalevars(x, values(wv))))
+    _symmetrize!(unscaled_covzm(x, _scalevars(x, convert(Vector, wv))))
 _unscaled_covzm(x::DenseMatrix, wv::AbstractWeights, dims::Integer) =
-    _symmetrize!(unscaled_covzm(x, _scalevars(x, values(wv), dims), dims))
+    _symmetrize!(unscaled_covzm(x, _scalevars(x, convert(Vector, wv), dims), dims))
 
 """
     scattermat(X, [wv::AbstractWeights]; mean=nothing, dims=1)

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -316,7 +316,7 @@ function append!(h::AbstractHistogram{T,N}, vs::NTuple{N,AbstractVector}, wv::Ab
     end
     h
 end
-append!(h::AbstractHistogram{T,N}, vs::NTuple{N,AbstractVector}, wv::AbstractWeights) where {T,N} = append!(h, vs, values(wv))
+append!(h::AbstractHistogram{T,N}, vs::NTuple{N,AbstractVector}, wv::AbstractWeights) where {T,N} = append!(h, vs, convert(Vector, wv))
 
 
 # Turn kwargs nbins into a type-stable tuple of integers:

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -54,7 +54,7 @@ end
 function varm!(R::AbstractArray, A::RealArray, w::AbstractWeights, M::RealArray,
                     dim::Int; corrected::DepBool=nothing)
     corrected = depcheck(:varm!, corrected)
-    rmul!(_wsum_centralize!(R, abs2, A, values(w), M, dim, true),
+    rmul!(_wsum_centralize!(R, abs2, A, convert(Vector, w), M, dim, true),
           varcorrection(w, corrected))
 end
 
@@ -234,7 +234,7 @@ end
 function _moment2(v::RealArray, wv::AbstractWeights, m::Real; corrected=false)
     n = length(v)
     s = 0.0
-    w = values(wv)
+    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
         @inbounds s += (z * z) * w[i]
@@ -256,7 +256,7 @@ end
 function _moment3(v::RealArray, wv::AbstractWeights, m::Real)
     n = length(v)
     s = 0.0
-    w = values(wv)
+    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
         @inbounds s += (z * z * z) * w[i]
@@ -277,7 +277,7 @@ end
 function _moment4(v::RealArray, wv::AbstractWeights, m::Real)
     n = length(v)
     s = 0.0
-    w = values(wv)
+    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
         @inbounds s += abs2(z * z) * w[i]
@@ -298,7 +298,7 @@ end
 function _momentk(v::RealArray, k::Int, wv::AbstractWeights, m::Real)
     n = length(v)
     s = 0.0
-    w = values(wv)
+    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
         @inbounds s += (z ^ k) * w[i]
@@ -364,7 +364,7 @@ function skewness(v::RealArray, wv::AbstractWeights, m::Real)
     length(wv) == n || throw(DimensionMismatch("Inconsistent array lengths."))
     cm2 = 0.0   # empirical 2nd centered moment (variance)
     cm3 = 0.0   # empirical 3rd centered moment
-    w = values(wv)
+    w = convert(Vector, wv)
 
     @inbounds for i = 1:n
         x_i = v[i]
@@ -411,7 +411,7 @@ function kurtosis(v::RealArray, wv::AbstractWeights, m::Real)
     length(wv) == n || throw(DimensionMismatch("Inconsistent array lengths."))
     cm2 = 0.0  # empirical 2nd centered moment (variance)
     cm4 = 0.0  # empirical 4th centered moment
-    w = values(wv)
+    w = convert(Vector, wv)
 
     @inbounds for i = 1 : n
         x_i = v[i]

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -412,7 +412,7 @@ Optionally specify a random number generator `rng` as the first argument
 """
 function sample(rng::AbstractRNG, wv::AbstractWeights)
     t = rand(rng) * sum(wv)
-    w = values(wv)
+    w = convert(Vector, wv)
     n = length(w)
     i = 1
     cw = w[1]
@@ -530,7 +530,7 @@ function alias_sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, 
     # create alias table
     ap = Vector{Float64}(undef, n)
     alias = Vector{Int}(undef, n)
-    make_alias_table!(values(wv), sum(wv), ap, alias)
+    make_alias_table!(convert(Vector, wv), sum(wv), ap, alias)
 
     # sampling
     s = RangeGenerator(1:n)
@@ -561,7 +561,7 @@ function naive_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
     k = length(x)
 
     w = Vector{Float64}(undef, n)
-    copyto!(w, values(wv))
+    copyto!(w, convert(Vector, wv))
     wsum = sum(wv)
 
     for i = 1:k

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -18,7 +18,7 @@ weight_funcs = (weights, aweights, fweights, pweights)
     wv = f(w)
     @test eltype(wv) === Float64
     @test length(wv) === 3
-    @test values(wv) ==  w
+    @test convert(Vector, wv) ==  w
     @test sum(wv) === 6.0
     @test !isempty(wv)
 
@@ -26,7 +26,7 @@ weight_funcs = (weights, aweights, fweights, pweights)
     bv = f(b)
     @test eltype(bv) === Bool
     @test length(bv) === 3
-    @test values(bv) ==  b
+    @test convert(Vector, bv) ==  b
     @test sum(bv)    === 3
     @test !isempty(bv)
 
@@ -44,20 +44,20 @@ end
     # Check getindex & sum
     @test wv[1] === 1.
     @test sum(wv) === 6.
-    @test values(wv) == w
+    @test convert(Vector, wv) == w
 
     # Test setindex! success
     @test (wv[1] = 4) === 4             # setindex! returns original val
     @test wv[1] === 4.                  # value correctly converted and set
     @test sum(wv) === 9.                # sum updated
-    @test values(wv) == [4., 2., 3.]    # Test state of all values
+    @test convert(Vector, wv) == [4., 2., 3.]    # Test state of all values
 
     # Test mulivalue setindex!
     wv[1:2] = [3., 5.]
     @test wv[1] === 3.
     @test wv[2] === 5.
     @test sum(wv) === 11.
-    @test values(wv) == [3., 5., 3.]   # Test state of all values
+    @test convert(Vector, wv) == [3., 5., 3.]   # Test state of all values
 
     # Test failed setindex! due to conversion error
     w = [1, 2, 3]
@@ -66,7 +66,7 @@ end
     @test_throws InexactError wv[1] = 1.5   # Returns original value
     @test wv[1] === 1                       # value not updated
     @test sum(wv) === 6                     # sum not corrupted
-    @test values(wv) == [1, 2, 3]           # Test state of all values
+    @test convert(Vector, wv) == [1, 2, 3]           # Test state of all values
 end
 
 @testset "$f, isequal and ==" for f in weight_funcs
@@ -106,7 +106,7 @@ end
     @test length(wv) === 3
     @test size(wv) === (3,)
     @test sum(wv) === 3.
-    @test values(wv) == fill(1.0, 3)
+    @test convert(Vector, wv) == fill(1.0, 3)
     @test StatsBase.varcorrection(wv) == 1/3
     @test !isequal(wv, fweights(fill(1.0, 3)))
     @test isequal(wv, uweights(3))

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -10,7 +10,7 @@ function check_wsample_wrep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::R
     (vmin, vmax) = vrgn
     (amin, amax) = extrema(a)
     @test vmin <= amin <= amax <= vmax
-    p0 = values(wv) ./ sum(wv)
+    p0 = convert(Vector, wv) ./ sum(wv)
     if ordered
         @test issorted(a)
         if ptol > 0
@@ -68,7 +68,7 @@ function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::
     end
 
     if ptol > 0
-        p0 = values(wv) ./ sum(wv)
+        p0 = convert(Vector, wv) ./ sum(wv)
         @test isapprox(proportions(a[1,:], vmin:vmax), p0, atol=ptol)
     end
 end


### PR DESCRIPTION
There are currently many deprecation warnings because of the remaining use of `values` and it slows down CI quite a bit (and is just annoying).