### PR TITLE
Add bounds on dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"
+DataAPI = "1"
+DataStructures = "0.10, 0.11, 0.12, 0.13, 0.14, 0.17"
+Missings = "0.3, 0.4"
+SortingAlgorithms = "0.3"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
CompatHelper didn't include older version in the suggested bounds so instead I've prepared this one which includes all post Julia 1.0 versions of the dependencies.