### PR TITLE
Remove unnecessary convert(Vector, wv) calls

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -48,12 +48,11 @@ function addcounts!(r::AbstractArray, x::IntegerArray, levels::IntUnitRange, wv:
     m0 = levels[1]
     m1 = levels[end]
     b = m0 - 1
-    w = convert(Vector, wv)
 
     @inbounds for i in 1 : length(x)
         xi = x[i]
         if m0 <= xi <= m1
-            r[xi - b] += w[i]
+            r[xi - b] += wv[i]
         end
     end
     return r
@@ -160,13 +159,12 @@ function addcounts!(r::AbstractArray, x::IntegerArray, y::IntegerArray,
 
     bx = mx0 - 1
     by = my0 - 1
-    w = convert(Vector, wv)
 
     for i = 1:n
         xi = x[i]
         yi = y[i]
         if (mx0 <= xi <= mx1) && (my0 <= yi <= my1)
-            r[xi - bx, yi - by] += w[i]
+            r[xi - bx, yi - by] += wv[i]
         end
     end
     return r
@@ -358,12 +356,11 @@ end
 function addcounts!(cm::Dict{T}, x::AbstractArray{T}, wv::AbstractVector{W}) where {T,W<:Real}
     n = length(x)
     length(wv) == n || throw(DimensionMismatch())
-    w = convert(Vector, wv)
     z = zero(W)
 
     for i = 1 : n
         @inbounds xi = x[i]
-        @inbounds wi = w[i]
+        @inbounds wi = wv[i]
         cm[xi] = get(cm, xi, z) + wi
     end
     return cm

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -15,7 +15,7 @@ function _symmetrize!(a::DenseMatrix)
     return a
 end
 
-function _scalevars(x::DenseMatrix, s::DenseVector, dims::Int)
+function _scalevars(x::DenseMatrix, s::AbstractWeights, dims::Int)
     dims == 1 ? Diagonal(s) * x :
     dims == 2 ? x * Diagonal(s) :
     error("dims should be either 1 or 2.")
@@ -27,9 +27,9 @@ _unscaled_covzm(x::DenseMatrix, dims::Colon)   = unscaled_covzm(x)
 _unscaled_covzm(x::DenseMatrix, dims::Integer) = unscaled_covzm(x, dims)
 
 _unscaled_covzm(x::DenseMatrix, wv::AbstractWeights, dims::Colon)   =
-    _symmetrize!(unscaled_covzm(x, _scalevars(x, convert(Vector, wv))))
+    _symmetrize!(unscaled_covzm(x, _scalevars(x, wv)))
 _unscaled_covzm(x::DenseMatrix, wv::AbstractWeights, dims::Integer) =
-    _symmetrize!(unscaled_covzm(x, _scalevars(x, convert(Vector, wv), dims), dims))
+    _symmetrize!(unscaled_covzm(x, _scalevars(x, wv, dims), dims))
 
 """
     scattermat(X, [wv::AbstractWeights]; mean=nothing, dims=1)

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -316,8 +316,6 @@ function append!(h::AbstractHistogram{T,N}, vs::NTuple{N,AbstractVector}, wv::Ab
     end
     h
 end
-append!(h::AbstractHistogram{T,N}, vs::NTuple{N,AbstractVector}, wv::AbstractWeights) where {T,N} = append!(h, vs, convert(Vector, wv))
-
 
 # Turn kwargs nbins into a type-stable tuple of integers:
 function _nbins_tuple(vs::NTuple{N,AbstractVector}, nbins) where N

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -234,10 +234,9 @@ end
 function _moment2(v::RealArray, wv::AbstractWeights, m::Real; corrected=false)
     n = length(v)
     s = 0.0
-    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
-        @inbounds s += (z * z) * w[i]
+        @inbounds s += (z * z) * wv[i]
     end
 
     varcorrection(wv, corrected) * s
@@ -256,10 +255,9 @@ end
 function _moment3(v::RealArray, wv::AbstractWeights, m::Real)
     n = length(v)
     s = 0.0
-    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
-        @inbounds s += (z * z * z) * w[i]
+        @inbounds s += (z * z * z) * wv[i]
     end
     s / sum(wv)
 end
@@ -277,10 +275,9 @@ end
 function _moment4(v::RealArray, wv::AbstractWeights, m::Real)
     n = length(v)
     s = 0.0
-    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
-        @inbounds s += abs2(z * z) * w[i]
+        @inbounds s += abs2(z * z) * wv[i]
     end
     s / sum(wv)
 end
@@ -298,10 +295,9 @@ end
 function _momentk(v::RealArray, k::Int, wv::AbstractWeights, m::Real)
     n = length(v)
     s = 0.0
-    w = convert(Vector, wv)
     for i = 1:n
         @inbounds z = v[i] - m
-        @inbounds s += (z ^ k) * w[i]
+        @inbounds s += (z ^ k) * wv[i]
     end
     s / sum(wv)
 end
@@ -364,11 +360,10 @@ function skewness(v::RealArray, wv::AbstractWeights, m::Real)
     length(wv) == n || throw(DimensionMismatch("Inconsistent array lengths."))
     cm2 = 0.0   # empirical 2nd centered moment (variance)
     cm3 = 0.0   # empirical 3rd centered moment
-    w = convert(Vector, wv)
 
     @inbounds for i = 1:n
         x_i = v[i]
-        w_i = w[i]
+        w_i = wv[i]
         z = x_i - m
         z2w = z * z * w_i
         cm2 += z2w
@@ -411,11 +406,10 @@ function kurtosis(v::RealArray, wv::AbstractWeights, m::Real)
     length(wv) == n || throw(DimensionMismatch("Inconsistent array lengths."))
     cm2 = 0.0  # empirical 2nd centered moment (variance)
     cm4 = 0.0  # empirical 4th centered moment
-    w = convert(Vector, wv)
 
     @inbounds for i = 1 : n
         x_i = v[i]
-        w_i = w[i]
+        w_i = wv[i]
         z = x_i - m
         z2 = z * z
         z2w = z2 * w_i

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -412,13 +412,12 @@ Optionally specify a random number generator `rng` as the first argument
 """
 function sample(rng::AbstractRNG, wv::AbstractWeights)
     t = rand(rng) * sum(wv)
-    w = convert(Vector, wv)
-    n = length(w)
+    n = length(wv)
     i = 1
-    cw = w[1]
+    cw = wv[1]
     while cw < t && i < n
         i += 1
-        @inbounds cw += w[i]
+        @inbounds cw += wv[i]
     end
     return i
 end
@@ -530,7 +529,7 @@ function alias_sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, 
     # create alias table
     ap = Vector{Float64}(undef, n)
     alias = Vector{Int}(undef, n)
-    make_alias_table!(convert(Vector, wv), sum(wv), ap, alias)
+    make_alias_table!(wv, sum(wv), ap, alias)
 
     # sampling
     s = RangeGenerator(1:n)
@@ -561,7 +560,7 @@ function naive_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
     k = length(x)
 
     w = Vector{Float64}(undef, n)
-    copyto!(w, convert(Vector, wv))
+    copyto!(w, wv)
     wsum = sum(wv)
 
     for i = 1:k

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -18,7 +18,7 @@ weight_funcs = (weights, aweights, fweights, pweights)
     wv = f(w)
     @test eltype(wv) === Float64
     @test length(wv) === 3
-    @test convert(Vector, wv) ==  w
+    @test wv ==  w
     @test sum(wv) === 6.0
     @test !isempty(wv)
 
@@ -44,20 +44,20 @@ end
     # Check getindex & sum
     @test wv[1] === 1.
     @test sum(wv) === 6.
-    @test convert(Vector, wv) == w
+    @test wv == w
 
     # Test setindex! success
     @test (wv[1] = 4) === 4             # setindex! returns original val
     @test wv[1] === 4.                  # value correctly converted and set
     @test sum(wv) === 9.                # sum updated
-    @test convert(Vector, wv) == [4., 2., 3.]    # Test state of all values
+    @test wv == [4., 2., 3.]    # Test state of all values
 
     # Test mulivalue setindex!
     wv[1:2] = [3., 5.]
     @test wv[1] === 3.
     @test wv[2] === 5.
     @test sum(wv) === 11.
-    @test convert(Vector, wv) == [3., 5., 3.]   # Test state of all values
+    @test wv == [3., 5., 3.]   # Test state of all values
 
     # Test failed setindex! due to conversion error
     w = [1, 2, 3]
@@ -66,7 +66,7 @@ end
     @test_throws InexactError wv[1] = 1.5   # Returns original value
     @test wv[1] === 1                       # value not updated
     @test sum(wv) === 6                     # sum not corrupted
-    @test convert(Vector, wv) == [1, 2, 3]           # Test state of all values
+    @test wv == [1, 2, 3]           # Test state of all values
 end
 
 @testset "$f, isequal and ==" for f in weight_funcs
@@ -106,7 +106,7 @@ end
     @test length(wv) === 3
     @test size(wv) === (3,)
     @test sum(wv) === 3.
-    @test convert(Vector, wv) == fill(1.0, 3)
+    @test wv == fill(1.0, 3)
     @test StatsBase.varcorrection(wv) == 1/3
     @test !isequal(wv, fweights(fill(1.0, 3)))
     @test isequal(wv, uweights(3))

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -10,7 +10,7 @@ function check_wsample_wrep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::R
     (vmin, vmax) = vrgn
     (amin, amax) = extrema(a)
     @test vmin <= amin <= amax <= vmax
-    p0 = convert(Vector, wv) ./ sum(wv)
+    p0 = wv ./ sum(wv)
     if ordered
         @test issorted(a)
         if ptol > 0
@@ -68,7 +68,7 @@ function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::
     end
 
     if ptol > 0
-        p0 = convert(Vector, wv) ./ sum(wv)
+        p0 = wv ./ sum(wv)
         @test isapprox(proportions(a[1,:], vmin:vmax), p0, atol=ptol)
     end
 end


### PR DESCRIPTION
`AbstractWeights <: AbstractVector` for a long time now. `convert` has to allocate a vector when `UnitWeights` is passed.

See #543.