### PR TITLE
Add :devianceratio variant to r² function

### DIFF
--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -222,9 +222,9 @@ In the above formulas, ``L`` is the likelihood of the model,
 ``L_0`` is the likelihood of the null model (the model with only an intercept),
 ``D`` is the deviance of the model (from the saturated model),
 ``D_0`` is the deviance of the null model,
-``n`` is the number of observations.
+``n`` is the number of observations (given by [`nobs`](@ref)).
 
-The deviance ratio R² matches the classical definition of R² for linear models.
+The deviance ratio and the CoxSnell R²'s both match the classical definition of R² for linear models.
 """
 function r2(obj::StatisticalModel, variant::Symbol)
     loglikbased = [:McFadden, :CoxSnell, :Nagelkerke]
@@ -269,13 +269,11 @@ Adjusted pseudo-coefficient of determination (adjusted pseudo R-squared).
 
 For nonlinear models, one of the several pseudo R² definitions must be chosen via `variant`.
 The only currently supported variants are `:MacFadden`, defined as ``1 - (\\log (L) - k)/\\log (L0)`` and
-`:devianceratio`, defined as ``1 - (D/df)/(D_0/df_0)``. 
-In this formula, ``L`` is the likelihood of the model, ``L0`` that of the null model
+`:devianceratio`, defined as ``1 - (D/(n-k))/(D_0/(n-1))``. 
+In these formulas, ``L`` is the likelihood of the model, ``L0`` that of the null model
 (the model including only the intercept), ``D`` is the deviance of the model,
-``D_0`` is the deviance of the null model, ``n`` is the number of observations (given by [`nobs`](@ref)),
-``k`` is the number of consumed degrees of freedom of the model (as returned by [`dof`](@ref)), 
-``df`` is the number of degrees of freedom of the model (``n - k``) and
-``df_0`` is the number of degrees of freedom of the null model (``n - 1``).
+``D_0`` is the deviance of the null model, ``n`` is the number of observations (given by [`nobs`](@ref)) and
+``k`` is the number of consumed degrees of freedom of the model (as returned by [`dof`](@ref)).
 """
 function adjr2(obj::StatisticalModel, variant::Symbol)
     if variant == :McFadden
@@ -285,7 +283,6 @@ function adjr2(obj::StatisticalModel, variant::Symbol)
         1 - (ll - k)/ll0
     elseif variant == :devianceratio
         n = nobs(obj)
-        # Number of explanatory variables
         k = dof(obj)
         dev  = deviance(obj)
         dev0 = nulldeviance(obj)

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -224,10 +224,11 @@ In the above formulas, ``L`` is the likelihood of the model,
 ``D_0`` is the deviance of the null model,
 ``n`` is the number of observations (given by [`nobs`](@ref)).
 
-The deviance ratio and the CoxSnell R²'s both match the classical definition of R² for linear models.
+The Cox-Snell and the deviance ratio variants both match the classical definition of R²
+for linear models.
 """
 function r2(obj::StatisticalModel, variant::Symbol)
-    loglikbased = [:McFadden, :CoxSnell, :Nagelkerke]
+    loglikbased = (:McFadden, :CoxSnell, :Nagelkerke)
     if variant in loglikbased
         ll = loglikelihood(obj)
         ll0 = nullloglikelihood(obj)
@@ -276,14 +277,13 @@ In these formulas, ``L`` is the likelihood of the model, ``L0`` that of the null
 ``k`` is the number of consumed degrees of freedom of the model (as returned by [`dof`](@ref)).
 """
 function adjr2(obj::StatisticalModel, variant::Symbol)
+    k = dof(obj)
     if variant == :McFadden
         ll = loglikelihood(obj)
         ll0 = nullloglikelihood(obj)
-        k = dof(obj)
         1 - (ll - k)/ll0
     elseif variant == :devianceratio
         n = nobs(obj)
-        k = dof(obj)
         dev  = deviance(obj)
         dev0 = nulldeviance(obj)
         1 - (dev*(n-1))/(dev0*(n-k))

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -216,13 +216,15 @@ Supported variants are:
 - `:MacFadden` (a.k.a. likelihood ratio index), defined as ``1 - \\log (L)/\\log (L_0)``;
 - `:CoxSnell`, defined as ``1 - (L_0/L)^{2/n}``;
 - `:Nagelkerke`, defined as ``(1 - (L_0/L)^{2/n})/(1 - L_0^{2/n})``.
+- `:deviance_ratio`, defined as ``1 - D/D_0``.
 
 In the above formulas, ``L`` is the likelihood of the model,
 ``L_0`` is the likelihood of the null model (the model with only an intercept),
-``n`` is the number of observations, ``y_i`` are the responses,
-``\\hat{y}_i`` are fitted values and ``\\bar{y}`` is the average response.
+``D`` is the deviance of the model (from the saturated model),
+``D_0`` is the deviance of the null model,
+``n`` is the number of observations.
 
-Cox and Snell's R² should match the classical R² for linear models.
+The deviance ratio R² matches the classical definition of R² for linear models.
 """
 function r2(obj::StatisticalModel, variant::Symbol)
     ll = loglikelihood(obj)
@@ -233,8 +235,12 @@ function r2(obj::StatisticalModel, variant::Symbol)
         1 - exp(2 * (ll0 - ll) / nobs(obj))
     elseif variant == :Nagelkerke
         (1 - exp(2 * (ll0 - ll) / nobs(obj))) / (1 - exp(2 * ll0 / nobs(obj)))
+    elseif variant == :deviance_ratio
+        dev  = deviance(obj)
+        dev0 = nulldeviance(obj)
+        1 - dev/dev0
     else
-        error("variant must be one of :McFadden, :CoxSnell or :Nagelkerke")
+        error("variant must be one of :McFadden, :CoxSnell, :Nagelkerke or :deviance_ratio")
     end
 end
 


### PR DESCRIPTION
Another generalization for R² to GLM is by using the deviance ratio (https://www.sciencedirect.com/science/article/pii/S0304407696018180). As deviance is zero for the saturated model, r² values are defined between 0 when the considered model is the null model, with the minimal number of parameters; and 1 when the model is the saturated model, with the maximal number of parameters.

Using this variant gives the same result ``mss/tss`` for OLS, which is mentioned in the last line of the doc. See https://github.com/JuliaStats/StatsBase.jl/issues/549

