### PR TITLE
New version (~0.33.0~0.32.1) and update docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.2
+  - 1.3
+  - 1.4
   - nightly
 notifications:
   email: false
@@ -20,7 +21,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1.3
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.32.0"
+version = "0.33.0"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.33.0"
+version = "0.32.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Documenter = "~0.24"
+Documenter = "0.24"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Documenter = "~0.22"
+Documenter = "~0.24"

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -134,6 +134,8 @@ Histograms can be fitted to data using the `fit` method.
 # Examples
 ## Example illustrating `closed`
 ```jldoctest
+julia> using StatsBase
+
 julia> fit(Histogram, [2.],  1:3, closed=:left)
 Histogram{Int64,1,Tuple{UnitRange{Int64}}}
 edges:

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -127,8 +127,8 @@ julia> using StatsBase
 
 julia> indicatormat([1 2 2], 2)
 2×3 Array{Bool,2}:
-  true  false  false
- false   true   true
+ 1  0  0
+ 0  1  1
 ```
 """
 function indicatormat(x::IntegerArray, k::Integer; sparse::Bool=false)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -98,7 +98,7 @@ julia> X = [0.0 -0.5 0.5; 0.0 1.0 2.0]
  0.0   1.0  2.0
 
 julia> dt = fit(ZScoreTransform, X, dims=2)
-ZScoreTransform{Float64}(2, [0.0, 1.0], [0.5, 1.0])
+ZScoreTransform{Float64}(2, 2, [0.0, 1.0], [0.5, 1.0])
 
 julia> StatsBase.transform(dt, X)
 2×3 Array{Float64,2}:
@@ -257,7 +257,7 @@ julia> X = [0.0 -0.5 0.5; 0.0 1.0 2.0]
  0.0   1.0  2.0
 
 julia> dt = fit(UnitRangeTransform, X, dims=2)
-UnitRangeTransform{Float64}(2, true, [-0.5, 0.0], [1.0, 0.5])
+UnitRangeTransform{Float64}(2, 2, true, [-0.5, 0.0], [1.0, 0.5])
 
 julia> StatsBase.transform(dt, X)
 2×3 Array{Float64,2}:


### PR DESCRIPTION
fixes #547

The only substantive change here is that the docs are building with Documenter
0.24, I've updated some doctests, and I've changed .travis.yml to run CI on 1.3
and 1.4 instead of 1.2, and build docs using 1.3.