### PR TITLE
fix breaking zscore changes (backport to 0.32 branch)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.32.1"
+version = "0.32.2"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -280,6 +280,7 @@ function fit(::Type{UnitRangeTransform}, X::AbstractMatrix{<:Real};
         l, tmin, tmax = _compute_extrema(X')
     elseif dims == nothing
         Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
+        dims = 2
         l, tmin, tmax = _compute_extrema(X')
     else
         throw(DomainError(dims, "fit only accept dims to be 1 or 2."))

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -63,9 +63,9 @@ struct ZScoreTransform{T<:Real} <: AbstractDataTransform
         new{T}(l, dims, m, s)
     end
 
-    function ZScoreTransform(dims::Int, m::Vector{T}, s::Vector{T}) where T
-        Base.depwarn("ZScoreTransform(dims, m, s) is deprecated: use ZScoreTransform(len, dims, m, s) instead", :ZScoreTransform)
-        ZScoreTransform(max(length(m), length(s)), dims, m, s)
+    function ZScoreTransform(l::Int, m::Vector{T}, s::Vector{T}) where T
+        Base.depwarn("ZScoreTransform(len, m, s) is deprecated: use ZScoreTransform(len, 2, m, s) instead", :ZScoreTransform)
+        ZScoreTransform(l, 2, m, s)
     end
 end
 

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -62,6 +62,11 @@ struct ZScoreTransform{T<:Real} <: AbstractDataTransform
         lens == l || lens == 0 || throw(DimensionMismatch("Inconsistent dimensions."))
         new{T}(l, dims, m, s)
     end
+
+    function ZScoreTransform(dims::Int, m::Vector{T}, s::Vector{T}) where T
+        Base.depwarn("ZScoreTransform(dims, m, s) is deprecated: use ZScoreTransform(len, dims, m, s) instead", :ZScoreTransform)
+        ZScoreTransform(max(length(m), length(s)), dims, m, s)
+    end
 end
 
 function Base.getproperty(t::ZScoreTransform, p::Symbol)
@@ -118,6 +123,7 @@ function fit(::Type{ZScoreTransform}, X::AbstractMatrix{<:Real};
         m, s = mean_and_std(X, 2)
     elseif dims === nothing
         Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
+        dims = 2
         m, s = mean_and_std(X, 2)
     else
         throw(DomainError(dims, "fit only accept dims to be 1 or 2."))
@@ -131,6 +137,7 @@ function fit(::Type{ZScoreTransform}, X::AbstractVector{<:Real};
              dims::Union{Integer,Nothing}=nothing, center::Bool=true, scale::Bool=true)
     if dims == nothing
         Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
+        dims = 1
     elseif dims != 1
         throw(DomainError(dims, "fit only accepts dims=1 over a vector. Try fit(t, x, dims=1)."))
     end

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -135,10 +135,7 @@ end
 
 function fit(::Type{ZScoreTransform}, X::AbstractVector{<:Real};
              dims::Union{Integer,Nothing}=nothing, center::Bool=true, scale::Bool=true)
-    if dims == nothing
-        Base.depwarn("fit(t, x) is deprecated: use fit(t, x, dims=2) instead", :fit)
-        dims = 1
-    elseif dims != 1
+    if dims != 1
         throw(DomainError(dims, "fit only accepts dims=1 over a vector. Try fit(t, x, dims=1)."))
     end
 


### PR DESCRIPTION
fixes #556 

#490 introduced breaking changes to the constructor of the ZScoreTransform type, adding a fourth mandatory argument.  It also introduced an error in cases where the previous default (without `dims=`) was used for `fit` and everything the calls it.  This PR fixes those by adding an inner constructor with a depwarn for ZScoreTransform, and re-setting the default dims inside the call to `fit` when `dims=nothing`.