### PR TITLE
Remove fptype

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -20,13 +20,6 @@ const IntegerMatrix{T<:Integer} = AbstractArray{T,2}
 
 const RealFP = Union{Float32, Float64}
 
-## conversion from real to fp types
-
-fptype(::Type{T}) where {T<:Union{Float32,Bool,Int8,UInt8,Int16,UInt16}} = Float32
-fptype(::Type{T}) where {T<:Union{Float64,Int32,UInt32,Int64,UInt64,Int128,UInt128}} = Float64
-fptype(::Type{Complex{Float32}}) = Complex{Float32}
-fptype(::Type{Complex{Float64}}) = Complex{Float64}
-
 # A convenient typealias for deprecating default corrected Bool
 const DepBool = Union{Bool, Nothing}
 

--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -43,7 +43,8 @@ end
 
 default_autolags(lx::Int) = 0 : default_laglen(lx)
 
-_autodot(x::AbstractVector{<:RealFP}, lx::Int, l::Int) = dot(x, 1:lx-l, x, 1+l:lx)
+_autodot(x::AbstractVector{<:RealFP}, lx::Int, l::Int) = dot(x, 1:(lx-l), x, (1+l):lx)
+_autodot(x::RealVector, lx::Int, l::Int) = dot(view(x, 1:(lx-l)), view(x, (1+l):lx))
 
 
 ## autocov
@@ -212,8 +213,20 @@ autocor(x::AbstractVecOrMat{<:Real}; demean::Bool=true) =
 
 default_crosslags(lx::Int) = (l=default_laglen(lx); -l:l)
 
-_crossdot(x::AbstractVector{T}, y::AbstractVector{T}, lx::Int, l::Int) where {T<:RealFP} =
-    (l >= 0 ? dot(x, 1:lx-l, y, 1+l:lx) : dot(x, 1-l:lx, y, 1:lx+l))
+function _crossdot(x::AbstractVector{T}, y::AbstractVector{T}, lx::Int, l::Int) where {T<:RealFP}
+    if l >= 0
+        dot(x, 1:(lx-l), y, (1+l):lx)
+    else
+        dot(x, (1-l):lx, y, 1:(lx+l))
+    end
+end
+function _crossdot(x::RealVector, y::RealVector, lx::Int, l::Int)
+    if l >= 0
+        dot(view(x, 1:(lx-l)), view(y, (1+l):lx))
+    else
+        dot(view(x, (1-l):lx), view(y, 1:(lx+l)))
+    end
+end
 
 ## crosscov
 

--- a/test/signalcorr.jl
+++ b/test/signalcorr.jl
@@ -22,6 +22,9 @@ x = [-2.133252557240862    -.7445937365828654;
 
 x1 = view(x, :, 1)
 x2 = view(x, :, 2)
+realx = convert(AbstractMatrix{Real}, x)
+realx1 = convert(AbstractVector{Real}, x1)
+realx2 = convert(AbstractVector{Real}, x2)
 
 # autocov & autocorr
 
@@ -40,7 +43,9 @@ racovx1 =  [1.839214242630635709475,
            -0.088687020167434751916]
 
 @test autocov(x1) ≈ racovx1
+@test autocov(realx1) ≈ racovx1
 @test autocov(x)  ≈ [autocov(x1) autocov(x2)]
+@test autocov(realx)  ≈ [autocov(realx1) autocov(realx2)]
 
 racorx1 = [0.999999999999999888978,
           -0.221173011668873431557,
@@ -54,7 +59,9 @@ racorx1 = [0.999999999999999888978,
           -0.048220059475281865091]
 
 @test autocor(x1) ≈ racorx1
+@test autocor(realx1) ≈ racorx1
 @test autocor(x)  ≈ [autocor(x1) autocor(x2)]
+@test autocor(realx)  ≈ [autocor(realx1) autocor(realx2)]
 
 
 # crosscov & crosscor
@@ -76,10 +83,14 @@ c11 = crosscov(x1, x1)
 c12 = crosscov(x1, x2)
 c21 = crosscov(x2, x1)
 c22 = crosscov(x2, x2)
+@test crosscov(realx1, realx2) ≈ c12
 
 @test crosscov(x,  x1) ≈ [c11 c21]
+@test crosscov(realx, realx1) ≈ [c11 c21]
 @test crosscov(x1, x)  ≈ [c11 c12]
+@test crosscov(realx1, realx)  ≈ [c11 c12]
 @test crosscov(x,  x)  ≈ cat([c11 c21], [c12 c22], dims=3)
+@test crosscov(realx,  realx)  ≈ cat([c11 c21], [c12 c22], dims=3)
 
 rcor0 = [0.230940107675850,
         -0.230940107675850,
@@ -98,10 +109,14 @@ c11 = crosscor(x1, x1)
 c12 = crosscor(x1, x2)
 c21 = crosscor(x2, x1)
 c22 = crosscor(x2, x2)
+@test crosscor(realx1, realx2) ≈ c12
 
 @test crosscor(x,  x1) ≈ [c11 c21]
+@test crosscor(realx, realx1) ≈ [c11 c21]
 @test crosscor(x1, x)  ≈ [c11 c12]
+@test crosscor(realx1, realx)  ≈ [c11 c12]
 @test crosscor(x,  x)  ≈ cat([c11 c21], [c12 c22], dims=3)
+@test crosscor(realx, realx)  ≈ cat([c11 c21], [c12 c22], dims=3)
 
 
 ## pacf
@@ -119,4 +134,3 @@ rpacfy = [-0.221173011668873,
           -0.175020669835420]
 
 @test pacf(x[:,1], 1:4, method=:yulewalker) ≈ rpacfy
-


### PR DESCRIPTION
This PR addresses https://github.com/JuliaStats/StatsBase.jl/issues/459 and fixes (at least parts of) https://github.com/TuringLang/MCMCChains.jl/issues/187.

`fptype` is replaced with `float` based on the element types of the input arguments. Additionally, many type restrictions are softened which allows to remove conversions of integer-valued arrays to floating point-valued arrays.