### PR TITLE
Micro-change `ordinalrank`

### DIFF
--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -42,7 +42,7 @@ position in `sort(x; lt = lt, rev = rev)`.
 Missing values are assigned rank `missing`.
 """
 ordinalrank(x::AbstractArray; lt = isless, rev::Bool = false) =
-    ordinalrank!(Array{Int}(undef, size(x)), x, sortperm(x; lt = lt, rev = rev))
+    ordinalrank!(similar(x), x, sortperm(x; lt = lt, rev = rev))
 
 
 # Competition ranking ("1224" ranking) -- resolve tied ranks using min


### PR DESCRIPTION
A micro-edit that changes to use `similar(x, Int)` in `ordinalrank`'s dispatch to `ordinalrank!` to improve type flexibility.