### PR TITLE
Correct docstrings of autocor and autocov

### DIFF
--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -55,7 +55,7 @@ Compute the autocovariance of a vector or matrix `x` at `lags` and store the res
 in `r`. `demean` denotes whether the mean of `x` should be subtracted from `x`
 before computing the autocovariance.
 
-If `x` is a vector, `r` must be a vector of the same length as `x`.
+If `x` is a vector, `r` must be a vector of the same length as `lags`.
 If `x` is a matrix, `r` must be a matrix of size `(length(lags), size(x,2))`, and
 where each column in the result will correspond to a column in `x`.
 
@@ -101,7 +101,7 @@ Compute the autocovariance of a vector or matrix `x`, optionally specifying
 the `lags` at which to compute the autocovariance. `demean` denotes whether
 the mean of `x` should be subtracted from `x` before computing the autocovariance.
 
-If `x` is a vector, return a vector of the same length as `x`.
+If `x` is a vector, return a vector of the same length as `lags`.
 If `x` is a matrix, return a matrix of size `(length(lags), size(x,2))`,
 where each column in the result corresponds to a column in `x`.
 
@@ -132,7 +132,7 @@ Compute the autocorrelation function (ACF) of a vector or matrix `x` at `lags`
 and store the result in `r`. `demean` denotes whether the mean of `x` should
 be subtracted from `x` before computing the ACF.
 
-If `x` is a vector, `r` must be a vector of the same length as `x`.
+If `x` is a vector, `r` must be a vector of the same length as `lags`.
 If `x` is a matrix, `r` must be a matrix of size `(length(lags), size(x,2))`, and
 where each column in the result will correspond to a column in `x`.
 
@@ -181,7 +181,7 @@ Compute the autocorrelation function (ACF) of a vector or matrix `x`,
 optionally specifying the `lags`. `demean` denotes whether the mean
 of `x` should be subtracted from `x` before computing the ACF.
 
-If `x` is a vector, return a vector of the same length as `x`.
+If `x` is a vector, return a vector of the same length as `lags`.
 If `x` is a matrix, return a matrix of size `(length(lags), size(x,2))`,
 where each column in the result corresponds to a column in `x`.
 


### PR DESCRIPTION
If `x` is a vector then `autocov` and `autocor` as well as their mutating versions return a vector of length `length(lags)` and not a vector of the same length as `x`.