### PR TITLE
Use dot-notation: quantile.(d, X)

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -337,7 +337,7 @@ end
 Compute the interquartile range (IQR) of collection `x`, i.e. the 75th percentile
 minus the 25th percentile.
 """
-iqr(x) = (q = quantile(x, [.25, .75]); q[2] - q[1])
+iqr(x) = (q = quantile.(x, [.25, .75]); q[2] - q[1])
 
 # Generalized variance
 """


### PR DESCRIPTION
`StatsBase.iqr()` calls `Distributions.quantile()`.

https://github.com/JuliaStats/StatsBase.jl/blob/54cc6fe2e2f709623b9c75275884f9b295fdbd35/src/scalarstats.jl#L340

However, calling `iqr()` emits a warning, reproduced by the following code.

```julia
using StatsBase, Statistics, Distributions

prices = 0:20:600
probs = pweights([100-99, 99-99, 99-99, 99-99, 99-99, 99-98, 98-94, 94-90, 90-81, 81-74, 74-72, 72-69, 69-67, 67-64, 64-61, 61-58, 58-55, 55-52, 52-48, 48-44, 44-40, 40-36, 36-31, 31-26, 26-21, 21-15, 15-9, 9-3, 3-0, 0-0, 0-0] / 100)

avg_price = mean(prices, probs)
dev_price = std(prices, probs, mean=avg_price)

price_dist = Normal(avg_price, dev_price)
range = iqr(price_dist)
```

```
┌ Warning: `quantile(d::UnivariateDistribution, X::AbstractArray)` is deprecated, use `quantile.(d, X)` instead.
│   caller = iqr(::Normal{Float64}) at scalarstats.jl:340
└ @ StatsBase ~/.julia/packages/StatsBase/548SN/src/scalarstats.jl:340
```

The warning stems from [a line in Distributions](https://github.com/JuliaStats/Distributions.jl/blob/20c91d9efcc5f96913bf8e38be2e3fb14b21942b/src/deprecates.jl#L39).