### PR TITLE
Enhance ranking code

### DIFF
--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -42,12 +42,11 @@ end
 
 
 """
-    ordinalrank(x; sortkwargs...)
+    ordinalrank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [ordinal ranking](https://en.wikipedia.org/wiki/Ranking#Ordinal_ranking_.28.221234.22_ranking.29)
-("1234" ranking) of an array. The `lt` keyword allows providing a custom "less
-than" function; use `rev=true` to reverse the sorting order.
-All items in `x` are given distinct, successive ranks based on their
+("1234" ranking) of an array. Supports the same keyword arguments as `sort(x; sortkwargs...)`
+function. All items in `x` are given distinct, successive ranks based on their
 position in `sort(x; sortkwargs...)`.
 Missing values are assigned rank `missing`.
 """
@@ -80,11 +79,10 @@ end
 
 
 """
-    competerank(x; sortkwargs...)
+    competerank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [standard competition ranking](http://en.wikipedia.org/wiki/Ranking#Standard_competition_ranking_.28.221224.22_ranking.29)
-("1224" ranking) of an array. The `lt` keyword allows providing a custom "less
-than" function; use `rev=true` to reverse the sorting order.
+("1224" ranking) of an array. Supports the same keyword arguments as `sort(x)` function.
 Items that compare equal are given the same rank, then a gap is left
 in the rankings the size of the number of tied items - 1.
 Missing values are assigned rank `missing`.
@@ -118,12 +116,11 @@ end
 
 
 """
-    denserank(x; sortkwargs...)
+    denserank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [dense ranking](http://en.wikipedia.org/wiki/Ranking#Dense_ranking_.28.221223.22_ranking.29)
-("1223" ranking) of an array. The `lt` keyword allows providing a custom "less
-than" function; use `rev=true` to reverse the sorting order. Items that
-compare equal receive the same ranking, and the next subsequent rank is
+("1223" ranking) of an array. Supports the same keyword arguments as `sort(x)` function.
+Items that compare equal receive the same ranking, and the next subsequent rank is
 assigned with no gap.
 Missing values are assigned rank `missing`.
 """
@@ -165,12 +162,11 @@ end
 
 # order (aka. rank), resolving ties using the mean rank
 """
-    tiedrank(x; sortkwargs...)
+    tiedrank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [tied ranking](http://en.wikipedia.org/wiki/Ranking#Fractional_ranking_.28.221_2.5_2.5_4.22_ranking.29),
 also called fractional or "1 2.5 2.5 4" ranking,
-of an array. The `lt` keyword allows providing a custom "less
-than" function; use `rev=true` to reverse the sorting order.
+of an array. Supports the same keyword arguments as `sort(x)` function.
 Items that compare equal receive the mean of the
 rankings they would have been assigned under ordinal ranking.
 Missing values are assigned rank `missing`.

--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -23,7 +23,6 @@ end
 function _rank(f!, x::AbstractArray{>: Missing}, R::Type=Int; sortkwargs...)
     inds = findall(!ismissing, vec(x))
     isempty(inds) && return missings(R, size(x))
-    T = nonmissingtype(eltype(x))
     xv = disallowmissing(view(vec(x), inds))
     ordv = sortperm(xv; sortkwargs...)
     rks = missings(R, size(x))

--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -64,17 +64,14 @@ function _competerank!(rks::AbstractArray, x::AbstractArray, p::IntegerArray)
         v = x[p1]
         rks[p1] = k = 1
 
-        i = 2
-        while i <= n
+        for i in 2:n
             pi = p[i]
             xi = x[pi]
-            if xi == v
-                rks[pi] = k
-            else
-                rks[pi] = k = i
+            if xi != v
                 v = xi
+                k = i
             end
-            i += 1
+            rks[pi] = k
         end
     end
 
@@ -105,17 +102,14 @@ function _denserank!(rks::AbstractArray, x::AbstractArray, p::IntegerArray)
         v = x[p1]
         rks[p1] = k = 1
 
-        i = 2
-        while i <= n
+        for i in 2:n
             pi = p[i]
             xi = x[pi]
-            if xi == v
-                rks[pi] = k
-            else
-                rks[pi] = (k += 1)
+            if xi != v
                 v = xi
+                k += 1
             end
-            i += 1
+            rks[pi] = k
         end
     end
 
@@ -145,8 +139,7 @@ function _tiedrank!(rks::AbstractArray, x::AbstractArray, p::IntegerArray)
         v = x[p[1]]
 
         s = 1  # starting index of current range
-        e = 2  # pass-by-end index of current range
-        while e <= n
+        for e in 2:n # e is pass-by-end index of current range
             cx = x[p[e]]
             if cx != v
                 # fill average rank to s : e-1
@@ -158,10 +151,9 @@ function _tiedrank!(rks::AbstractArray, x::AbstractArray, p::IntegerArray)
                 s = e
                 v = cx
             end
-            e += 1
         end
 
-        # the last range (e == n+1)
+        # the last range
         ar = (s + n) / 2
         for i = s : n
             rks[p[i]] = ar

--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -45,9 +45,9 @@ end
     ordinalrank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [ordinal ranking](https://en.wikipedia.org/wiki/Ranking#Ordinal_ranking_.28.221234.22_ranking.29)
-("1234" ranking) of an array. Supports the same keyword arguments as `sort(x; sortkwargs...)`
-function. All items in `x` are given distinct, successive ranks based on their
-position in `sort(x; sortkwargs...)`.
+("1234" ranking) of an array. Supports the same keyword arguments as the `sort` function.
+All items in `x` are given distinct, successive ranks based on their position
+in the sorted vector.
 Missing values are assigned rank `missing`.
 """
 ordinalrank(x::AbstractArray; sortkwargs...) =
@@ -82,9 +82,9 @@ end
     competerank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [standard competition ranking](http://en.wikipedia.org/wiki/Ranking#Standard_competition_ranking_.28.221224.22_ranking.29)
-("1224" ranking) of an array. Supports the same keyword arguments as `sort(x)` function.
-Items that compare equal are given the same rank, then a gap is left
-in the rankings the size of the number of tied items - 1.
+("1224" ranking) of an array. Supports the same keyword arguments as the `sort` function.
+Equal (*"tied"*) items are given the same rank, and the next rank comes after a gap
+that is equal to the number of tied items - 1.
 Missing values are assigned rank `missing`.
 """
 competerank(x::AbstractArray; sortkwargs...) =
@@ -119,8 +119,8 @@ end
     denserank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [dense ranking](http://en.wikipedia.org/wiki/Ranking#Dense_ranking_.28.221223.22_ranking.29)
-("1223" ranking) of an array. Supports the same keyword arguments as `sort(x)` function.
-Items that compare equal receive the same ranking, and the next subsequent rank is
+("1223" ranking) of an array. Supports the same keyword arguments as the `sort` function.
+Equal items receive the same rank, and the next subsequent rank is
 assigned with no gap.
 Missing values are assigned rank `missing`.
 """
@@ -160,15 +160,14 @@ function _tiedrank!(rks::AbstractArray, x::AbstractArray, p::IntegerArray)
     return rks
 end
 
-# order (aka. rank), resolving ties using the mean rank
 """
     tiedrank(x; lt=isless, by=identity, rev::Bool=false, ...)
 
 Return the [tied ranking](http://en.wikipedia.org/wiki/Ranking#Fractional_ranking_.28.221_2.5_2.5_4.22_ranking.29),
 also called fractional or "1 2.5 2.5 4" ranking,
-of an array. Supports the same keyword arguments as `sort(x)` function.
-Items that compare equal receive the mean of the
-rankings they would have been assigned under ordinal ranking.
+of an array. Supports the same keyword arguments as the `sort` function.
+Equal (*"tied"*) items receive the mean of the ranks they would
+have been assigned under the ordinal ranking (see [`ordinalrank`](@ref)).
 Missing values are assigned rank `missing`.
 """
 tiedrank(x::AbstractArray; sortkwargs...) =

--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -24,12 +24,9 @@ function _rank(f!, x::AbstractArray{>: Missing}, R::Type=Int; sortkwargs...)
     inds = findall(!ismissing, vec(x))
     isempty(inds) && return missings(R, size(x))
     T = nonmissingtype(eltype(x))
-    xv = Vector{T}(undef, length(inds))
-    @inbounds for (i, ind) in enumerate(inds)
-        xv[i] = x[ind]
-    end
-    rks = missings(R, size(x))
+    xv = disallowmissing(view(vec(x), inds))
     ordv = sortperm(xv; sortkwargs...)
+    rks = missings(R, size(x))
     f!(view(rks, inds), xv, ordv)
     return rks
 end

--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -20,10 +20,8 @@ function ordinalrank!(rks::AbstractArray, x::AbstractArray, p::IntegerArray)
     n = _check_randparams(rks, x, p)
 
     if n > 0
-        i = 1
-        while i <= n
+        @inbounds for i in eachindex(p)
             rks[p[i]] = i
-            i += 1
         end
     end
 


### PR DESCRIPTION
Small cleanups in the ranking code. Added `@inbounds` annotations for speed.
Common code is moved into `_rank()` method, which allows to:
  * correctly support n-dim arrays (n>1). If generic array input was not intended, I can tighten signatures to only allow `x::AbstractVector`
  * `sortperm()` kwargs are just passed through, so, in addition to *lt* and *rev*, ranking also supports *by* (so it could be applied to custom types) and *alg*
  * no function-generating macros are required to support missing values