### PR TITLE
faster bin index for uniform edge

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -234,6 +234,15 @@ binindex(h::Histogram{T,N}, xs::NTuple{N,Real}) where {T,N} =
     end
 end
 
+@inline function _edge_binindex(edge::AbstractRange, closed::Symbol, x::Real)
+    n = if closed == :right
+        ceil(Int, (x-first(edge)) / step(edge))
+    else
+        n = round(Int, (x - first(edge)) / step(edge) + 1)
+        x < edge[n] ? n - 1 : n
+    end
+    clamp(n, 1, length(edge))
+end
 
 binvolume(h::AbstractHistogram{T,1}, binidx::Integer) where {T} = binvolume(h, (binidx,))
 binvolume(::Type{V}, h::AbstractHistogram{T,1}, binidx::Integer) where {V,T} = binvolume(V, h, (binidx,))


### PR DESCRIPTION
see #563

before:
```
julia> @benchmark fit(Histogram, $(rand(10^6)), 0:0.05:1; closed=:right)
BenchmarkTools.Trial:
  memory estimate:  320 bytes
  allocs estimate:  2
  --------------
  minimum time:     25.080 ms (0.00% GC)
  median time:      25.262 ms (0.00% GC)
  mean time:        25.308 ms (0.00% GC)
  maximum time:     27.498 ms (0.00% GC)
  --------------
  samples:          198
  evals/sample:     1

julia> @benchmark fit(Histogram, $(rand(10^6)), 0:0.05:1; closed=:left)
BenchmarkTools.Trial:
  memory estimate:  320 bytes
  allocs estimate:  2
  --------------
  minimum time:     25.962 ms (0.00% GC)
  median time:      26.176 ms (0.00% GC)
  mean time:        26.764 ms (0.00% GC)
  maximum time:     28.579 ms (0.00% GC)
  --------------
  samples:          187
  evals/sample:     1
```

after:
```
julia> @benchmark fit(Histogram, $(rand(10^6)), 0:0.05:1; closed=:right)
BenchmarkTools.Trial:
  memory estimate:  320 bytes
  allocs estimate:  2
  --------------
  minimum time:     9.181 ms (0.00% GC)
  median time:      9.534 ms (0.00% GC)
  mean time:        9.539 ms (0.00% GC)
  maximum time:     10.606 ms (0.00% GC)
  --------------
  samples:          525
  evals/sample:     1

julia> @benchmark fit(Histogram, $(rand(10^6)), 0:0.05:1; closed=:left)
BenchmarkTools.Trial:
  memory estimate:  320 bytes
  allocs estimate:  2
  --------------
  minimum time:     15.343 ms (0.00% GC)
  median time:      18.779 ms (0.00% GC)
  mean time:        18.766 ms (0.00% GC)
  maximum time:     18.947 ms (0.00% GC)
  --------------
  samples:          267
  evals/sample:     1
```
