### PR TITLE
add empty! for histogram

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -538,6 +538,15 @@ set to zero.
 Base.zero(h::Histogram{T,N,E}) where {T,N,E} =
     Histogram{T,N,E}(deepcopy(h.edges), zero(h.weights), h.closed, h.isdensity)
 
+"""
+    empty!(h::Histogram)
+
+Set all the elements of h.weights to zero.
+"""
+function Base.empty!(h::Histogram)
+    h.weights .= zero(eltype(h.weights))
+    h
+end
 
 """
     merge!(target::Histogram, others::Histogram...)

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -210,6 +210,16 @@ end
     @test h.isdensity == h2.isdensity
 end
 
+@testset "Histogram empty" begin
+    h = fit(Histogram, (rand(100), rand(100)))
+    h2 = empty!(deepcopy(h))
+    @test all(x -> x≈0, h2.weights)
+    @test !(h.weights === h2.weights)
+    @test h.edges == h2.edges
+    @test h.closed == h2.closed
+    @test h.isdensity == h2.isdensity
+end
+
 
 @testset "Histogram merge" begin
     histograms = [fit(Histogram, (rand(100), 10 * rand(100)), (0:0.1:1, 0:1:10)) for _ in 1:10]


### PR DESCRIPTION
compare:
```
julia> @btime zero(h) setup=(h = fit(Histogram, rand(10^4), 0:0.01:1))
  50.156 ns (2 allocations: 976 bytes)
```

with empty:
```
julia> @btime empty!(h) setup=(h = fit(Histogram, rand(10^4), 0:0.01:1))
  12.697 ns (0 allocations: 0 bytes)
```

tests included.
