### PR TITLE
Tighten signature of weights constructor

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -13,7 +13,7 @@ macro weights(name)
             values::V
             sum::S
         end
-        $(esc(name))(vs) = $(esc(name))(vs, sum(vs))
+        $(esc(name))(values::AbstractVector{<:Real}) = $(esc(name))(values, sum(values))
     end
 end
 


### PR DESCRIPTION
This ensures the error is thrown earlier for clarity, instead of doing it from the two-argument constructor.

See https://discourse.julialang.org/t/using-weights-from-statsbase-in-julia-and-using-an-array/50820.