### PR TITLE
Stop using LinearAlgebra.copy_oftype

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -274,7 +274,7 @@ function mad(x; center=nothing, normalize::Union{Bool, Nothing}=nothing, constan
     # Knowing the eltype allows allocating a single array able to hold both original values
     # and differences from the center, instead of two arrays
     S = isconcretetype(T) ? promote_type(T, typeof(middle(zero(T)))) : T
-    x2 = x isa AbstractArray ? LinearAlgebra.copy_oftype(x, S) : collect(S, x)
+    x2 = x isa AbstractArray ? copyto!(similar(x, S), x) : collect(S, x)
     c = center === nothing ? median!(x2) : center
     if isconcretetype(T)
         x2 .= abs.(x2 .- c)


### PR DESCRIPTION
This undocumented function does not actually ensure that the result is mutable.
Use the same approach as `Base.copymutable`, which relies only on public API.

This avoids breakage due to https://github.com/JuliaLang/julia/pull/28956 (see [this log](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/d8c33b6_vs_ad7e59a/StatsBase.1.7.0-DEV-70af8d1ffd.log)).