### PR TITLE
Make CoefTable implement the Tables.jl interface

### DIFF
--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -420,6 +420,23 @@ mutable struct CoefTable
     end
 end
 
+Base.length(ct::CoefTable) = length(ct.cols[1])
+function Base.eltype(ct::CoefTable)
+    nmtype = isempty(ct.rownms) ? String : eltype(ct.rownms)
+    NamedTuple{(Symbol("Name"), Symbol.(ct.colnms)...),
+               Tuple{nmtype, eltype.(ct.cols)...}}
+end
+
+function Base.iterate(ct::CoefTable, i::Integer=1)
+    if i in 1:length(ct)
+        nm = isempty(ct.rownms) ? string('[', i, ']') : ct.rownms[i]
+        nt = eltype(ct)((nm, getindex.(ct.cols, Ref(i))...))
+        (nt, i+1)
+    else
+        nothing
+    end
+end
+
 """
 Show a p-value using 6 characters, either using the standard 0.XXXX
 representation or as <Xe-YY.

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -41,14 +41,14 @@ ct = CoefTable(m, ["Estimate", "Stderror", "df", "p"], [], 4)
 ──────────────────────────────────────────"""
 @test length(ct) === 3
 @test eltype(ct) ==
-NamedTuple{(:Name, :Estimate, :Stderror, :df, :p),
-           Tuple{String,Float64,Float64,Float64,Float64}}
+    NamedTuple{(:Estimate, :Stderror, :df, :p),
+               Tuple{Float64,Float64,Float64,Float64}}
 @test collect(ct) == [
-    (Name = "[1]", Estimate = 0.11258244478647295, Stderror = 0.05664544616214151,
+    (Estimate = 0.11258244478647295, Stderror = 0.05664544616214151,
      df = 0.38181274408522614, p = 0.8197779704008801)
-    (Name = "[2]", Estimate = 0.36831406658084287, Stderror = 0.12078054506961555,
+    (Estimate = 0.36831406658084287, Stderror = 0.12078054506961555,
      df = 0.8151038332483567, p = 0.6699313951612162)
-    (Name = "[3]", Estimate = 0.3444540231363058, Stderror = 0.17957407667101322,
+    (Estimate = 0.3444540231363058, Stderror = 0.17957407667101322,
      df = 0.2422083248151139, p = 0.4530583319523316)
 ]
 

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -7,9 +7,10 @@ v2 = ["Good", "Great", "Bad"]
 v3 = [1, 56, 2]
 v4 = [-12.56, 0.1326, 2.68e-16]
 v5 = [0.12, 0.3467, 1.345e-16]
-@test sprint(show, CoefTable(Any[v1, v2, v3, v4, v5],
-    ["Estimate", "Comments", "df", "t", "p"],
-    ["x1", "x2", "x3"], 5, 4)) == """
+ct = CoefTable(Any[v1, v2, v3, v4, v5],
+               ["Estimate", "Comments", "df", "t", "p"],
+               ["x1", "x2", "x3"], 5, 4)
+@test sprint(show, ct) == """
 ───────────────────────────────────────────────
          Estimate  Comments  df       t       p
 ───────────────────────────────────────────────
@@ -17,10 +18,20 @@ x1    1.45666         Good    1  -12.56  0.1200
 x2  -23.14            Great  56    0.13  0.3467
 x3    1.56734e-13     Bad     2    0.00  <1e-15
 ───────────────────────────────────────────────"""
+@test length(ct) === 3
+@test eltype(ct) ==
+    NamedTuple{(:Name, :Estimate, :Comments, :df, :t, :p),
+               Tuple{String,Float64,String,Int,Float64,Float64}}
+@test collect(ct) == [
+    (Name = "x1", Estimate = 1.45666, Comments = "Good", df = 1, t = -12.56, p = 0.12)
+    (Name = "x2", Estimate = -23.14, Comments = "Great", df = 56, t = 0.1326, p = 0.3467)
+    (Name = "x3", Estimate = 1.56734e-13, Comments = "Bad", df = 2, t = 2.68e-16, p = 1.345e-16)
+]
 
 Random.seed!(10)
 m = rand(3,4)
-@test sprint(show, CoefTable(m, ["Estimate", "Stderror", "df", "p"], [], 4)) == """
+ct = CoefTable(m, ["Estimate", "Stderror", "df", "p"], [], 4)
+@test sprint(show, ct) == """
 ──────────────────────────────────────────
      Estimate   Stderror        df       p
 ──────────────────────────────────────────
@@ -28,6 +39,18 @@ m = rand(3,4)
 [2]  0.368314  0.120781   0.815104  0.6699
 [3]  0.344454  0.179574   0.242208  0.4531
 ──────────────────────────────────────────"""
+@test length(ct) === 3
+@test eltype(ct) ==
+NamedTuple{(:Name, :Estimate, :Stderror, :df, :p),
+           Tuple{String,Float64,Float64,Float64,Float64}}
+@test collect(ct) == [
+    (Name = "[1]", Estimate = 0.11258244478647295, Stderror = 0.05664544616214151,
+     df = 0.38181274408522614, p = 0.8197779704008801)
+    (Name = "[2]", Estimate = 0.36831406658084287, Stderror = 0.12078054506961555,
+     df = 0.8151038332483567, p = 0.6699313951612162)
+    (Name = "[3]", Estimate = 0.3444540231363058, Stderror = 0.17957407667101322,
+     df = 0.2422083248151139, p = 0.4530583319523316)
+]
 
 @test sprint(show, PValue(1.0)) == "1.0000"
 @test sprint(show, PValue(1e-1)) == "0.1000"


### PR DESCRIPTION
This allows retrieving the contents of a `CoefTable` object in a convenient form, notably a `DataFrame`. To avoid introducing a dependency on Tables.jl, `CoefTable` has to iterate `NamedTuple`s, so that it implements the row-table interface implicitly. This is inefficient since `CoefTable` uses a column-based storage, but given the typical size of such tables it should not matter.