### PR TITLE
Fix #631, summarystats returned NaN quantiles for arrays with mean 0

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -660,7 +660,7 @@ function summarystats(a::AbstractArray{T}) where T<:Union{Real,Missing}
     R = typeof(m)
     n = length(a)
     ns = length(s)
-    qs = if m == 0 || n == 0
+    qs = if n == 0
         R[NaN, NaN, NaN, NaN, NaN]
     elseif T >: Missing
         quantile!(s, [0.00, 0.25, 0.50, 0.75, 1.00])

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -660,7 +660,7 @@ function summarystats(a::AbstractArray{T}) where T<:Union{Real,Missing}
     R = typeof(m)
     n = length(a)
     ns = length(s)
-    qs = if n == 0
+    qs = if ns == 0
         R[NaN, NaN, NaN, NaN, NaN]
     elseif T >: Missing
         quantile!(s, [0.00, 0.25, 0.50, 0.75, 1.00])

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -217,3 +217,23 @@ s = summarystats(1:5)
 @test s.median ≈ 3.0
 @test s.q25    ≈ 2.0
 @test s.q75    ≈ 4.0
+
+# Issue #631
+s = summarystats(-2:2)
+@test isa(s, StatsBase.SummaryStats)
+@test s.min == -2.0
+@test s.max == 2.0
+@test s.mean   ≈ 0.0
+@test s.median ≈ 0.0
+@test s.q25    ≈ -1.0
+@test s.q75    ≈ +1.0
+
+# Issue #631
+s = summarystats(zeros(10))
+@test isa(s, StatsBase.SummaryStats)
+@test s.min == 0.0
+@test s.max == 0.0
+@test s.mean   ≈ 0.0
+@test s.median ≈ 0.0
+@test s.q25    ≈ 0.0
+@test s.q75    ≈ 0.0

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -219,7 +219,7 @@ s = summarystats(1:5)
 @test s.q75    ≈ 4.0
 
 # Issue #631
-s = summarystats(-2:2)
+s = summarystats([-2, -1, 0, 1, 2, missing])
 @test isa(s, StatsBase.SummaryStats)
 @test s.min == -2.0
 @test s.max == 2.0
@@ -237,3 +237,11 @@ s = summarystats(zeros(10))
 @test s.median ≈ 0.0
 @test s.q25    ≈ 0.0
 @test s.q75    ≈ 0.0
+
+# Issue #631
+s = summarystats(Union{Float64,Missing}[missing, missing])
+@test isa(s, StatsBase.SummaryStats)
+@test s.nobs == 2
+@test s.nmiss == 2
+@test isnan(s.mean)
+@test isnan(s.median)


### PR DESCRIPTION
Removed check `mean(a) == 0`, added two tests