### PR TITLE
fix weighted computations for non-real arrays

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -357,8 +357,8 @@ Base.:(==)(x::AbstractWeights, y::AbstractWeights)   = false
 
 Compute the weighted sum of an array `v` with weights `w`, optionally over the dimension `dim`.
 """
-wsum(v::AbstractVector, w::AbstractVector) = dot(v, w)
-wsum(v::AbstractArray, w::AbstractVector) = dot(vec(v), w)
+wsum(v::AbstractVector, w::AbstractVector) = dot(w, v)
+wsum(v::AbstractArray, w::AbstractVector) = dot(w, vec(v))
 wsum(v::AbstractArray, w::AbstractVector, dims::Colon) = wsum(v, w)
 
 ## wsum along dimension

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -239,6 +239,7 @@ a = reshape(1.0:27.0, 3, 3, 3)
 @testset "Sum $f" for f in weight_funcs
     @test sum([1.0, 2.0, 3.0], f([1.0, 0.5, 0.5])) ≈ 3.5
     @test sum(1:3, f([1.0, 1.0, 0.5]))             ≈ 4.5
+    @test sum([1 + 2im, 2 + 3im], f([1.0, 0.5])) ≈ 2 + 3.5im
 
     for wt in ([1.0, 1.0, 1.0], [1.0, 0.2, 0.0], [0.2, 0.0, 1.0])
         @test sum(a, f(wt), dims=1)  ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims=1)
@@ -250,6 +251,7 @@ end
 @testset "Mean $f" for f in weight_funcs
     @test mean([1:3;], f([1.0, 1.0, 0.5])) ≈ 1.8
     @test mean(1:3, f([1.0, 1.0, 0.5]))    ≈ 1.8
+    @test mean([1 + 2im, 4 + 5im], f([1.0, 0.5])) ≈ 2 + 3im
 
     for wt in ([1.0, 1.0, 1.0], [1.0, 0.2, 0.0], [0.2, 0.0, 1.0])
         @test mean(a, f(wt), dims=1) ≈ sum(a.*reshape(wt, length(wt), 1, 1), dims=1)/sum(wt)


### PR DESCRIPTION
This fixes https://github.com/JuliaStats/StatsBase.jl/issues/518 following suggestion from @nalimilan. The linked issue also contains a long discussion on the best approach, but looks like no decision and fix followed from there. So here I just take the simplest approach to make the computations correct.