### PR TITLE
Allow computing the correlation matrix from the covariance matrix only

### DIFF
--- a/src/cov.jl
+++ b/src/cov.jl
@@ -132,6 +132,13 @@ deviations `s`. Use `StatsBase.cov2cor!` for an in-place version.
 cov2cor(C::AbstractMatrix, s::AbstractArray) = cov2cor!(copy(C), s)
 
 """
+     cov2cor(C)
+
+ Compute the correlation matrix from the covariance matrix `C`. Use `StatsBase.cov2cor!` for an in-place version.
+ """
+ cov2cor(C::AbstractMatrix) = cov2cor!(copy(C))
+
+"""
     cor2cov(C, s)
 
 Compute the covariance matrix from the correlation matrix `C` and a vector of standard

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -124,8 +124,6 @@ weight_funcs = (weights, aweights, fweights, pweights)
                 @test cov2cor(cov(X, dims = 2), std(X, dims = 2)) ≈ cor(X, dims = 2)
                 @test cov2cor(cov1, std1) ≈ cor1
                 @test cov2cor(cov2, std2) ≈ cor2
-                @test cov2cor(cov1) ≈ cor1
-                @test cov2cor(cov2) ≈ cor2
             end
             @testset "cor2cov" begin
                 @test cor2cov(cor(X, dims = 1), std(X, dims = 1)) ≈ cov(X, dims = 1)

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -122,8 +122,6 @@ weight_funcs = (weights, aweights, fweights, pweights)
             @testset "cov2cor" begin
                 @test cov2cor(cov(X, dims = 1), std(X, dims = 1)) ≈ cor(X, dims = 1)
                 @test cov2cor(cov(X, dims = 2), std(X, dims = 2)) ≈ cor(X, dims = 2)
-                @test cov2cor(cov(X, dims = 1)) ≈ cor(X, dims = 1)
-                @test cov2cor(cov(X, dims = 2)) ≈ cor(X, dims = 2)
                 @test cov2cor(cov1, std1) ≈ cor1
                 @test cov2cor(cov2, std2) ≈ cor2
                 @test cov2cor(cov1) ≈ cor1

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -122,8 +122,12 @@ weight_funcs = (weights, aweights, fweights, pweights)
             @testset "cov2cor" begin
                 @test cov2cor(cov(X, dims = 1), std(X, dims = 1)) ≈ cor(X, dims = 1)
                 @test cov2cor(cov(X, dims = 2), std(X, dims = 2)) ≈ cor(X, dims = 2)
+                @test cov2cor(cov(X, dims = 1)) ≈ cor(X, dims = 1)
+                @test cov2cor(cov(X, dims = 2)) ≈ cor(X, dims = 2)
                 @test cov2cor(cov1, std1) ≈ cor1
                 @test cov2cor(cov2, std2) ≈ cor2
+                @test cov2cor(cov1) ≈ cor1
+                @test cov2cor(cov2) ≈ cor2
             end
             @testset "cor2cov" begin
                 @test cor2cov(cor(X, dims = 1), std(X, dims = 1)) ≈ cov(X, dims = 1)


### PR DESCRIPTION
Following issue #652 in StatsBase.jl