### PR TITLE
fixed corkendall(RealMatrix, RealVector)

### DIFF
--- a/src/rankcorr.jl
+++ b/src/rankcorr.jl
@@ -143,8 +143,8 @@ function corkendall!(x::RealVector, y::RealVector, permx::AbstractVector{<:Integ
         if x[i - 1] == x[i]
             k += 1
         elseif k > 0
-            # Sort the corresponding chunk of y, so the rows of hcat(x,y) are 
-            # sorted first on x, then (where x values are tied) on y. Hence 
+            # Sort the corresponding chunk of y, so the rows of hcat(x,y) are
+            # sorted first on x, then (where x values are tied) on y. Hence
             # double ties can be counted by calling countties.
             sort!(view(y, (i - k - 1):(i - 1)))
             ntiesx += div(widen(k) * (k + 1), 2) # Must use wide integers here
@@ -176,8 +176,9 @@ matrices or vectors.
 corkendall(x::RealVector, y::RealVector) = corkendall!(copy(x), copy(y))
 
 function corkendall(X::RealMatrix, y::RealVector)
+    n = size(X, 2)
     permy = sortperm(y)
-    return([corkendall!(copy(y), X[:,i], permy) for i in 1:size(X, 2)])
+    return(reshape([corkendall!(copy(y), X[:,i], permy) for i in 1:n], n, 1))
 end
 
 function corkendall(x::RealVector, Y::RealMatrix)
@@ -217,7 +218,7 @@ end
 """
     countties(x::RealVector, lo::Integer, hi::Integer)
 
-Return the number of ties within `x[lo:hi]`. Assumes `x` is sorted. 
+Return the number of ties within `x[lo:hi]`. Assumes `x` is sorted.
 """
 function countties(x::AbstractVector, lo::Integer, hi::Integer)
     # Use of widen below prevents possible overflow errors when
@@ -246,9 +247,9 @@ const SMALL_THRESHOLD = 64
 # merge_sort! copied from Julia Base
 # (commit 28330a2fef4d9d149ba0fd3ffa06347b50067647, dated 20 Sep 2020)
 """
-    merge_sort!(v::AbstractVector, lo::Integer, hi::Integer, t::AbstractVector=similar(v, 0))    
+    merge_sort!(v::AbstractVector, lo::Integer, hi::Integer, t::AbstractVector=similar(v, 0))
 
-Mutates `v` by sorting elements `x[lo:hi]` using the merge sort algorithm. 
+Mutates `v` by sorting elements `x[lo:hi]` using the merge sort algorithm.
 This method is a copy-paste-edit of sort! in base/sort.jl, amended to return the bubblesort distance.
 """
 function merge_sort!(v::AbstractVector, lo::Integer, hi::Integer, t::AbstractVector=similar(v, 0))
@@ -300,7 +301,7 @@ midpoint(lo::Integer, hi::Integer) = midpoint(promote(lo, hi)...)
 """
     insertion_sort!(v::AbstractVector, lo::Integer, hi::Integer)
 
-Mutates `v` by sorting elements `x[lo:hi]` using the insertion sort algorithm. 
+Mutates `v` by sorting elements `x[lo:hi]` using the insertion sort algorithm.
 This method is a copy-paste-edit of sort! in base/sort.jl, amended to return the bubblesort distance.
 """
 function insertion_sort!(v::AbstractVector, lo::Integer, hi::Integer)


### PR DESCRIPTION
corkendall now returns a matrix with one column when operating on a Matrix-Vector input, the same behavior as `cor` and `corspearman`. The tests have been updated to reflect the change.

Fixes #672 and is related to #659 