### PR TITLE
fix sequential sampling with replacement

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -891,7 +891,8 @@ efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::AbstractWeights, x::Abstra
 
 function sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray;
                  replace::Bool=true, ordered::Bool=false)
-    1 == firstindex(a) == firstindex(wv) == firstindex(x) || throw(ArgumentError("non 1-based arrays are not supported"))
+    1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
+        throw(ArgumentError("non 1-based arrays are not supported"))
     n = length(a)
     k = length(x)
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -944,9 +944,9 @@ sample(a::AbstractArray, wv::AbstractWeights, dims::Dims;
 
 Select a weighted sample from an array `a` and store the result in `x`. Sampling
 probabilities are proportional to the weights given in `w`. `replace` dictates
-whether sampling is performed with replacement. . `ordered` dictates whether
-an ordered sample (also called a sequential sample)—a sample where
-items appear in the same order as in `a`—should be taken.
+whether sampling is performed with replacement. `ordered` dictates whether
+an ordered sample (also called a sequential sample, i.e. a sample where
+items appear in the same order as in `a`) should be taken.
 
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -79,7 +79,8 @@ sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractRange, x::AbstractArray) 
     sort!(sampler!(rng, a, x), rev=step(a)<0)
 
 # weighted case:
-sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray) =
+sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray,
+                wv::AbstractWeights, x::AbstractArray) =
     sample_ordered!(rng, a, x) do rng, a, x
         sampler!(rng, a, wv, x)
     end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -72,7 +72,7 @@ function direct_sample_ordered!(rng::AbstractRNG, a::AbstractArray, x::AbstractA
     return x
 end
 
-direct_sample_ordered!(rng::AbstractRNG, a::AbstractRange, x::AbstractArray) =
+direct_sample_ordered!(rng::AbstractRNG, a::AbstractRange, x::AbstractArray{<:Real}) =
     sort!(direct_sample!(rng, a, x), rev=step(a)<0)
 
 ### draw a pair of distinct integers in [1:n]
@@ -586,7 +586,7 @@ function direct_sample_ordered!(rng::AbstractRNG, a::AbstractArray, wv::Abstract
     return x
 end
 
-direct_sample_ordered!(rng::AbstractRNG, a::AbstractRange, wv::AbstractWeights, x::AbstractArray) =
+direct_sample_ordered!(rng::AbstractRNG, a::AbstractRange, wv::AbstractWeights, x::AbstractArray{<:Real}) =
     sort!(direct_sample!(rng, a, wv, x), rev=step(a)<0)
 
 function make_alias_table!(w::AbstractVector{Float64}, wsum::Float64,

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -514,8 +514,8 @@ Select a random, optionally weighted sample from an array `a` specifying
 the dimensions `dims` of the output array. Sampling probabilities are
 proportional to the weights given in `wv`, if provided. `replace` dictates
 whether sampling is performed with replacement. `ordered` dictates whether
-an ordered sample (also called a sequential sample)—a sample where
-items appear in the same order as in `a`—should be taken.
+an ordered sample (also called a sequential sample, i.e. a sample where
+items appear in the same order as in `a`) should be taken.
 
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -444,6 +444,7 @@ Optionally specify a random number generator `rng` as the first argument
 """
 function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
                  replace::Bool=true, ordered::Bool=false)
+    1 == firstindex(a) == firstindex(x) || throw(ArgumentError("non 1-based arrays are not supported"))
     n = length(a)
     k = length(x)
     k == 0 && return x
@@ -887,6 +888,7 @@ efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::AbstractWeights, x::Abstra
 
 function sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray;
                  replace::Bool=true, ordered::Bool=false)
+    1 == firstindex(a) == firstindex(wv) == firstindex(x) || throw(ArgumentError("non 1-based arrays are not supported"))
     n = length(a)
     k = length(x)
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -64,7 +64,7 @@ function sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, x::Abstra
     else
         indices = Array{Int}(undef, k)
         sort!(sampler!(rng, Base.OneTo(n), indices))
-        for i = 1:k
+        @inbounds for i = 1:k
             x[i] = a[indices[i]]
         end
     end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -43,7 +43,7 @@ end
 direct_sample!(a::AbstractArray, x::AbstractArray) = direct_sample!(Random.GLOBAL_RNG, a, x)
 
 # check whether we can use T to store indices 1:n exactly
-for T in unique([Int,Int64,UInt64,Int128,UInt128])
+for T in unique!([Int,Int64,UInt64,Int128,UInt128])
     @eval isexact(n, ::Type{$T}) = true
 end
 isexact(n, ::Type{T}) where {T<:Integer} = n ≤ typemax(T)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -54,7 +54,7 @@ storeindices(n, k, ::Type{T}) where {T<:Base.HWNumber}  = _storeindices(n, k, T)
 storeindices(n, k, T) = false
 
 # order results of a sampler that does not order automatically
-function sample_ordered!(sampler!::F, rng::AbstractRNG, a::AbstractArray, x::AbstractArray) where {F}
+function sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, x::AbstractArray)
     n, k = length(a), length(x)
     if storeindices(n, k, eltype(x))
         sort!(sampler!(rng, Base.OneTo(n), x), by=real, lt=<)
@@ -72,11 +72,11 @@ function sample_ordered!(sampler!::F, rng::AbstractRNG, a::AbstractArray, x::Abs
 end
 
 # special case of a range (or any sorted array) can be done more efficiently
-sample_ordered!(sampler!::F, rng::AbstractRNG, a::AbstractRange, x::AbstractArray) where {F} =
+sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractRange, x::AbstractArray) =
     sort!(sampler!(rng, a, x), rev=step(a)<0)
 
 # weighted case:
-sample_ordered!(sampler!::F, rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray) where {F} =
+sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray) =
     sample_ordered!(rng, a, x) do rng, a, x
         sampler!(rng, a, wv, x)
     end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -572,13 +572,13 @@ direct_sample!(a::AbstractArray, wv::AbstractWeights, x::AbstractArray) =
 function direct_sample_ordered!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray)
     n, k = length(a), length(x)
     if isexact(n, eltype(x))
-        sort!(direct_sample!(rng, Base.OneTo(n), wv, x), by=real)
+        sort!(sample!(rng, Base.OneTo(n), wv, x, replace=true, ordered=false), by=real)
         for i = 1:k
             x[i] = a[Int(x[i])]
         end
     else
         indices = Array{Int}(undef, k)
-        sort!(direct_sample!(rng, Base.OneTo(n), wv, indices))
+        sort!(sample!(rng, Base.OneTo(n), wv, indices, replace=true, ordered=false))
         for i = 1:k
             x[i] = a[indices[i]]
         end
@@ -587,7 +587,7 @@ function direct_sample_ordered!(rng::AbstractRNG, a::AbstractArray, wv::Abstract
 end
 
 direct_sample_ordered!(rng::AbstractRNG, a::AbstractRange, wv::AbstractWeights, x::AbstractArray{<:Real}) =
-    sort!(direct_sample!(rng, a, wv, x), rev=step(a)<0)
+    sort!(sample!(rng, a, wv, x, replace=true, ordered=false), rev=step(a)<0)
 
 function make_alias_table!(w::AbstractVector{Float64}, wsum::Float64,
                            a::AbstractVector{Float64},

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -448,7 +448,8 @@ Optionally specify a random number generator `rng` as the first argument
 """
 function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
                  replace::Bool=true, ordered::Bool=false)
-    1 == firstindex(a) == firstindex(x) || throw(ArgumentError("non 1-based arrays are not supported"))
+    1 == firstindex(a) == firstindex(x) ||
+        throw(ArgumentError("non 1-based arrays are not supported"))
     n = length(a)
     k = length(x)
     k == 0 && return x

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -438,8 +438,8 @@ and store the result in `x`. A polyalgorithm is used for sampling.
 Sampling probabilities are proportional to the weights given in `wv`,
 if provided. `replace` dictates whether sampling is performed with
 replacement. `ordered` dictates whether
-an ordered sample (also called a sequential sample)—a sample where
-items appear in the same order as in `a`—should be taken.
+an ordered sample (also called a sequential sample, i.e. a sample where
+items appear in the same order as in `a`) should be taken.
 
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -58,7 +58,7 @@ function sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, x::Abstra
     n, k = length(a), length(x)
     if storeindices(n, k, eltype(x))
         sort!(sampler!(rng, Base.OneTo(n), x), by=real, lt=<)
-        for i = 1:k
+        @inbounds for i = 1:k
             x[i] = a[Int(x[i])]
         end
     else

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -825,7 +825,8 @@ Noting `k=length(x)` and `n=length(a)`, this algorithm takes ``O(k \\log(k) \\lo
 processing time to draw ``k`` elements. It consumes ``O(k \\log(n / k))`` random numbers.
 """
 function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
-                                         wv::AbstractWeights, x::AbstractArray; ordered::Bool=false)
+                                         wv::AbstractWeights, x::AbstractArray;
+                                         ordered::Bool=false)
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -493,8 +493,8 @@ Select a random, optionally weighted sample of size `n` from an array `a`
 using a polyalgorithm. Sampling probabilities are proportional to the weights
 given in `wv`, if provided. `replace` dictates whether sampling is performed
 with replacement. `ordered` dictates whether
-an ordered sample (also called a sequential sample)—a sample where
-items appear in the same order as in `a`—should be taken.
+an ordered sample (also called a sequential sample, i.e. a sample where
+items appear in the same order as in `a`) should be taken.
 
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -43,9 +43,6 @@ end
 direct_sample!(a::AbstractArray, x::AbstractArray) = direct_sample!(Random.GLOBAL_RNG, a, x)
 
 # check whether we can use T to store indices 1:n exactly
-for T in unique!([Int,UInt,Int64,UInt64,Int128,UInt128])
-    @eval isexact(n, ::Type{$T}) = true
-end
 isexact(n, ::Type{T}) where {T<:Integer} = n ≤ typemax(T)
 isexact(n, ::Type{BigInt}) = false # bigint is too expensive
 for T in (Float32, Float64)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -868,11 +868,17 @@ function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
         threshold = pq[1].first
         X = threshold * randexp(rng)
     end
-
-    # fill output array with items from final queue
-    ordered && sort!(pq, by=last)
-    @inbounds for i in 1:k
-        x[i] = a[pq[i].second]
+    if ordered
+        # fill output array with items sorted as in a
+        sort!(pq, by=last)
+        @inbounds for i in 1:k
+            x[i] = a[pq[i].second]
+        end
+    else
+        # fill output array with items in descending order
+        @inbounds for i in k:-1:1
+            x[i] = a[heappop!(pq).second]
+        end
     end
     return x
 end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -56,6 +56,9 @@ storeindices(n, k, T) = false
 # order results of a sampler that does not order automatically
 function sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, x::AbstractArray)
     n, k = length(a), length(x)
+    # todo: if eltype(x) <: Real && eltype(a) <: Real,
+    #       in some cases it might be faster to check
+    #       issorted(a) to see if we can just sort x
     if storeindices(n, k, eltype(x))
         sort!(sampler!(rng, Base.OneTo(n), x), by=real, lt=<)
         @inbounds for i = 1:k
@@ -71,7 +74,7 @@ function sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractArray, x::Abstra
     return x
 end
 
-# special case of a range (or any sorted array) can be done more efficiently
+# special case of a range can be done more efficiently
 sample_ordered!(sampler!, rng::AbstractRNG, a::AbstractRange, x::AbstractArray) =
     sort!(sampler!(rng, a, x), rev=step(a)<0)
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -980,8 +980,8 @@ Select a weighted random sample of size `n` from `a` with probabilities proporti
 to the weights given in `w` if `a` is present, otherwise select a random sample of size
 `n` of the weights given in `w`. `replace` dictates whether sampling is performed with
 replacement. `ordered` dictates whether
-an ordered sample (also called a sequential sample)—a sample where
-items appear in the same order as in `a`—should be taken.
+an ordered sample (also called a sequential sample, i.e. a sample where
+items appear in the same order as in `a`) should be taken.
 
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -883,7 +883,8 @@ function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
     end
     return x
 end
-efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::AbstractWeights, x::AbstractArray; ordered::Bool=false) =
+efraimidis_aexpj_wsample_norep!(a::AbstractArray, wv::AbstractWeights, x::AbstractArray;
+                                ordered::Bool=false) =
     efraimidis_aexpj_wsample_norep!(Random.GLOBAL_RNG, a, wv, x; ordered=ordered)
 
 function sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray;

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -221,4 +221,4 @@ Random.seed!(1);
 
 @test sample([1, 2], Weights([1, 1]), (2,2)) == ones(2,2)
 @test sample([1, 2], Weights([0, 1]), (2,2)) == [2 2 ; 2 2]
-@test sample(collect(1:4), Weights(1:4), (2,2), replace=false) == [2 3; 1 4]
+@test sample(collect(1:4), Weights(1:4), (2,2), replace=false) == [4 1; 3 2]

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -27,19 +27,19 @@ end
 
 #### sample with replacement
 
-function check_sample_wrep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=false)
+function check_sample_wrep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=false, rev::Bool=false)
     vmin, vmax = vrgn
     (amin, amax) = extrema(a)
     @test vmin <= amin <= amax <= vmax
     n = vmax - vmin + 1
     p0 = fill(1/n, n)
     if ordered
-        @test issorted(a)
+        @test issorted(a; rev=rev)
         if ptol > 0
             @test isapprox(proportions(a, vmin:vmax), p0, atol=ptol)
         end
     else
-        @test !issorted(a)
+        @test !issorted(a; rev=rev)
         ncols = size(a,2)
         if ncols == 1
             @test isapprox(proportions(a, vmin:vmax), p0, atol=ptol)
@@ -68,11 +68,15 @@ test_rng_use(direct_sample!, 1:10, zeros(Int, 6))
 a = sample(3:12, n)
 check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 
-a = sample(3:12, n; ordered=true)
-check_sample_wrep(a, (3, 12), 5.0e-3; ordered=true)
+for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
+    r = rev ? reverse(3:12) : (3:12)
+    r = T===Int ? r : T.(r)
+    aa = Int.(sample(r, n; ordered=true))
+    check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=true, rev=rev)
 
-a = sample(3:12, 10; ordered=true)
-check_sample_wrep(a, (3, 12), 0; ordered=true)
+    aa = Int.(sample(r, 10; ordered=true))
+    check_sample_wrep(aa, (3, 12), 0; ordered=true, rev=rev)
+end
 
 test_rng_use(sample, 1:10, 10)
 
@@ -91,7 +95,7 @@ test_rng_use(samplepair, 1000)
 
 #### sample without replacement
 
-function check_sample_norep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=false)
+function check_sample_norep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=false, rev::Bool=false)
     # each column of a for one run
 
     vmin, vmax = vrgn
@@ -103,7 +107,7 @@ function check_sample_norep(a::AbstractArray, vrgn, ptol::Real; ordered::Bool=fa
         aj = view(a,:,j)
         @assert allunique(aj)
         if ordered
-            @assert issorted(aj)
+            @assert issorted(aj, rev=rev)
         end
     end
 
@@ -178,6 +182,9 @@ check_sample_norep(a, (3, 12), 0; ordered=false)
 a = sample(3:12, 5; replace=false, ordered=true)
 check_sample_norep(a, (3, 12), 0; ordered=true)
 
+a = sample(reverse(3:12), 5; replace=false, ordered=true)
+check_sample_norep(a, (3, 12), 0; ordered=true, rev=true)
+
 # tests of multidimensional sampling
 
 a = sample(3:12, (2, 2); replace=false)
@@ -214,4 +221,4 @@ Random.seed!(1);
 
 @test sample([1, 2], Weights([1, 1]), (2,2)) == ones(2,2)
 @test sample([1, 2], Weights([0, 1]), (2,2)) == [2 2 ; 2 2]
-@test sample(collect(1:4), Weights(1:4), (2,2), replace=false) == [4 1; 3 2]
+@test sample(collect(1:4), Weights(1:4), (2,2), replace=false) == [2 3; 1 4]

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -78,6 +78,8 @@ for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64
     check_sample_wrep(aa, (3, 12), 0; ordered=true, rev=rev)
 end
 
+@test StatsBase._storeindices(1, 1, BigFloat) == StatsBase._storeindices(1, 1, BigFloat) == false
+
 test_rng_use(sample, 1:10, 10)
 
 @testset "sampling pairs" begin

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -57,7 +57,8 @@ end
 
 #### weighted sampling without replacement
 
-function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real; ordered::Bool=false, rev::Bool=false)
+function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real;
+                             ordered::Bool=false, rev::Bool=false)
     # each column of a for one run
 
     vmin, vmax = vrgn

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -5,19 +5,20 @@ Random.seed!(1234)
 
 #### weighted sample with replacement
 
-function check_wsample_wrep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real; ordered::Bool=false)
+function check_wsample_wrep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real; ordered::Bool=false, rev::Bool=false)
     K = length(wv)
     (vmin, vmax) = vrgn
     (amin, amax) = extrema(a)
     @test vmin <= amin <= amax <= vmax
     p0 = wv ./ sum(wv)
+    rev && reverse!(p0)
     if ordered
-        @test issorted(a)
+        @test issorted(a; rev=rev)
         if ptol > 0
             @test isapprox(proportions(a, vmin:vmax), p0, atol=ptol)
         end
     else
-        @test !issorted(a)
+        @test !issorted(a; rev=rev)
         ncols = size(a,2)
         if ncols == 1
             @test isapprox(proportions(a, vmin:vmax), p0, atol=ptol)
@@ -45,13 +46,17 @@ check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
 a = sample(4:7, wv, n; ordered=false)
 check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
 
-a = sample(4:7, wv, n; ordered=true)
-check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=true)
+for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
+    r = rev ? reverse(4:7) : (4:7)
+    r = T===Int ? r : T.(r)
+    aa = Int.(sample(r, wv, n; ordered=true))
+    check_wsample_wrep(aa, (4, 7), wv, 5.0e-3; ordered=true, rev=rev)
+end
 
 
 #### weighted sampling without replacement
 
-function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real; ordered::Bool=false)
+function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real; ordered::Bool=false, rev::Bool=false)
     # each column of a for one run
 
     vmin, vmax = vrgn
@@ -63,12 +68,13 @@ function check_wsample_norep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::
         aj = view(a,:,j)
         @assert allunique(aj)
         if ordered
-            @assert issorted(aj)
+            @assert issorted(aj; rev=rev)
         end
     end
 
     if ptol > 0
         p0 = wv ./ sum(wv)
+        rev && reverse!(p0)
         @test isapprox(proportions(a[1,:], vmin:vmax), p0, atol=ptol)
     end
 end
@@ -110,5 +116,9 @@ test_rng_use(efraimidis_aexpj_wsample_norep!, 4:7, wv, zeros(Int, 2))
 a = sample(4:7, wv, 3; replace=false, ordered=false)
 check_wsample_norep(a, (4, 7), wv, -1; ordered=false)
 
-a = sample(4:7, wv, 3; replace=false, ordered=true)
-check_wsample_norep(a, (4, 7), wv, -1; ordered=true)
+for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
+    r = rev ? reverse(4:7) : (4:7)
+    r = T===Int ? r : T.(r)
+    aa = Int.(sample(r, wv, 3; replace=false, ordered=true))
+    check_wsample_norep(aa, (4, 7), wv, -1; ordered=true, rev=rev)
+end

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -52,6 +52,8 @@ for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64
     r = T===Int ? r : T.(r)
     aa = Int.(sample(r, wv, n; ordered=true))
     check_wsample_wrep(aa, (4, 7), wv, 5.0e-3; ordered=true, rev=rev)
+    aa = Int.(sample(r, wv, 10; ordered=true))
+    check_wsample_wrep(aa, (4, 7), wv, -1; ordered=true, rev=rev)
 end
 
 

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -5,7 +5,8 @@ Random.seed!(1234)
 
 #### weighted sample with replacement
 
-function check_wsample_wrep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real; ordered::Bool=false, rev::Bool=false)
+function check_wsample_wrep(a::AbstractArray, vrgn, wv::AbstractWeights, ptol::Real;
+                            ordered::Bool=false, rev::Bool=false)
     K = length(wv)
     (vmin, vmax) = vrgn
     (amin, amax) = extrema(a)


### PR DESCRIPTION
Fixes #675.   I also noticed that *weighted* sampling *without* replacement had the same problem, and I fixed it there too.

To do:
- [x] Tests
- [x] Improved documentation of the `ordered` keyword`.