### PR TITLE
corrected error message in corspearman

### DIFF
--- a/src/rankcorr.jl
+++ b/src/rankcorr.jl
@@ -91,7 +91,7 @@ end
 
 function corspearman(X::RealMatrix, Y::RealMatrix)
     size(X, 1) == size(Y, 1) ||
-        throw(ArgumentError("number of columns in each array must match"))
+        throw(ArgumentError("number of rows in each array must match"))
     nr = size(X, 2)
     nc = size(Y, 2)
     C = Matrix{Float64}(undef, nr, nc)


### PR DESCRIPTION
Currently the error thrown when `x` and `y` have a different number of rows states that the number of columns should match, so I corrected that to state that it's the number of _rows_ that need to match.