### PR TITLE
pointwiseloglikelihood

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -193,6 +193,7 @@ export
     nobs,
     nulldeviance,
     nullloglikelihood,
+    pointwiseloglikelihood,
     rss,
     score,
     stderror,

--- a/src/statmodels.jl
+++ b/src/statmodels.jl
@@ -77,6 +77,24 @@ nullloglikelihood(model::StatisticalModel) =
     error("nullloglikelihood is not defined for $(typeof(model)).")
 
 """
+    pointwiseloglikelihood(model::StatisticalModel)
+
+Return a vector of each observation's contribution to the log-likelihood of the model.
+
+In general, `sum(pointwiseloglikehood(model)) == loglikelihood(model)`.
+"""
+pointwiseloglikelihood(model::StatisticalModel) =
+    error("pointwiseloglikelihood(model::StatisticalModel) is not defined for $(typeof(model)).")
+
+"""
+    pointwiseloglikelihood(model::StatisticalModel, observation)
+
+Return the log-likelihood of `observation` contribution under `model`.
+"""
+pointwiseloglikelihood(model::StatisticalModel, observation) =
+    error("pointwiseloglikelihood(model::StatisticalModel, observation) is not defined for $(typeof(model)).")
+
+"""
     score(model::StatisticalModel)
 
 Return the score of the model, that is the gradient of the


### PR DESCRIPTION
This introduces `pointwiseloglikelihood`:

1. single argument variant for computing each observation's contribution to the log likelihood. This is useful for things like [Vuong's Test](https://en.wikipedia.org/wiki/Vuong%27s_closeness_test). Using this, we could add a generic `vuongtest` to `StatsModels.jl`. 
2. two argument variant for computing the log-likelihood of an observation under the model.  This can be used in various cross-validation regimes and other things examining out-of-sample error.

Assuming that this lands, I would write the associated methods for `GLM.jl` and `MixedModels.jl` and add the delegation for `TableRegressionModel` to `StatsModels.jl`.
