### PR TITLE
Let CompatHelper run tests

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -21,4 +21,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
[Reference](https://juliaregistries.github.io/CompatHelper.jl/stable/#Installation,-step-2:-Set-up-the-SSH-deploy-key)