### PR TITLE
fix call of floatrange on 1.7+

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -96,7 +96,7 @@ function histrange(lo::F, hi::F, n::Integer, closed::Symbol=:left) where F
             len += one(F)
         end
     end
-    Base.floatrange(start,step,len,divisor)
+    Base.floatrange(start,step,Int(len),divisor)
 end
 
 histrange(vs::NTuple{N,AbstractVector},nbins::NTuple{N,Integer},closed::Symbol) where {N} =


### PR DESCRIPTION
Not sure if this conversion should be made in the Base funtion. Was changed in https://github.com/JuliaLang/julia/pull/41619.