### PR TITLE
Fix _addcounts_radix_sort for empty input array

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -336,6 +336,9 @@ const BaseRadixSortSafeTypes = Union{Int8, Int16, Int32, Int64, Int128,
 radixsort_safe(::Type{T}) where T = T<:BaseRadixSortSafeTypes
 
 function _addcounts_radix_sort_loop!(cm::Dict{T}, sx::AbstractArray{T}) where T
+    if isempty(sx)
+      return cm
+    end
     last_sx = sx[1]
     tmpcount = get(cm, last_sx, 0) + 1
 

--- a/src/counts.jl
+++ b/src/counts.jl
@@ -336,9 +336,7 @@ const BaseRadixSortSafeTypes = Union{Int8, Int16, Int32, Int64, Int128,
 radixsort_safe(::Type{T}) where T = T<:BaseRadixSortSafeTypes
 
 function _addcounts_radix_sort_loop!(cm::Dict{T}, sx::AbstractArray{T}) where T
-    if isempty(sx)
-      return cm
-    end
+    isempty(sx) && return cm
     last_sx = sx[1]
     tmpcount = get(cm, last_sx, 0) + 1
 

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -108,6 +108,9 @@ cm_any_itr = countmap((i for i in xx))
 @test cm_any_itr isa Dict{Any,Int} # no knowledge about type
 @test cm_missing == cm
 
+# with empty array
+@test countmap(Int[]) == Dict{Int, Int}()
+
 # testing the radixsort-based addcounts
 xx = repeat([6, 1, 3, 1], outer=100_000)
 cm = Dict{Int, Int}()


### PR DESCRIPTION
This PR introduces a test to keep `_addcounts_radix_sort_loop!` from attempting to index an empty array. This error was causing `countmap` to fail for an input of an empty array (a test which demonstrates this has also been added).

Definitely happy to change this if the fix should be added in another place.