### PR TITLE
Remove deprecations in `crossentropy` and `kldivergence`

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -591,17 +591,10 @@ Compute the cross entropy between `p` and `q`, optionally specifying a real
 number `b` such that the result is scaled by `1/log(b)`.
 """
 function crossentropy(p::AbstractArray{<:Real}, q::AbstractArray{<:Real})
-    length(p) == length(q) || throw(DimensionMismatch("Inconsistent array length."))
-
-    # handle empty collections
+    length(p) == length(q) || throw(DimensionMismatch("inconsistent array length"))
     if isempty(p)
-        Base.depwarn(
-            "support for empty collections will be removed since they do not " *
-            "represent proper probability distributions",
-            :crossentropy,
-        )
-        # return zero for empty arrays
-        return xlogy(zero(eltype(p)), zero(eltype(q)))
+        throw(ArgumentError("empty collections are not supported since they do not " *
+                            "represent proper probability distributions"))
     end
 
     # use pairwise summation (https://github.com/JuliaLang/julia/pull/31020)
@@ -622,19 +615,10 @@ that is the sum `pᵢ * log(pᵢ / qᵢ)`. Optionally a real number `b`
 can be specified such that the divergence is scaled by `1/log(b)`.
 """
 function kldivergence(p::AbstractArray{<:Real}, q::AbstractArray{<:Real})
-    length(p) == length(q) || throw(DimensionMismatch("Inconsistent array length."))
-
-    # handle empty collections
+    length(p) == length(q) || throw(DimensionMismatch("inconsistent array length"))
     if isempty(p)
-        Base.depwarn(
-            "support for empty collections will be removed since they do not "*
-            "represent proper probability distributions",
-            :kldivergence,
-        )
-        # return zero for empty arrays
-        pzero = zero(eltype(p))
-        qzero = zero(eltype(q))
-        return xlogy(pzero, zero(pzero / qzero))
+        throw(ArgumentError("empty collections are not supported since they do not " *
+                            "represent proper probability distributions"))
     end
 
     # use pairwise summation (https://github.com/JuliaLang/julia/pull/31020)

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -214,10 +214,9 @@ scale = rand()
 @test @inferred(crossentropy([1//5, 3//10, 1//2], [0.3, 0.4, 0.3], 2)) ≈ 1.6124543443825532
 @test @inferred(crossentropy([1//5, 3//10, 1//2], [0.3f0, 0.4f0, 0.3f0], 2f0)) isa Float32
 
-# deprecated, should throw an `ArgumentError` at some point
-logpattern = (:warn, "support for empty collections will be removed since they do not represent proper probability distributions")
-@test iszero(@test_logs logpattern @inferred(crossentropy(Float64[], Float64[])))
-@test iszero(@test_logs logpattern @inferred(crossentropy(Int[], Int[])))
+@test_throws DimensionMismatch crossentropy([1//2, 1//2], [0.3, 0.2, 0.5])
+@test_throws ArgumentError @inferred(crossentropy(Float64[], Float64[]))
+@test_throws ArgumentError @inferred(crossentropy(Int[], Int[]))
 
 ##### KL divergence
 @test @inferred(kldivergence([0.2, 0.3, 0.5], [0.3, 0.4, 0.3]))     ≈ 0.08801516852582819
@@ -228,10 +227,9 @@ logpattern = (:warn, "support for empty collections will be removed since they d
 @test @inferred(kldivergence([1//5, 3//10, 1//2], [0.3f0, 0.4f0, 0.3f0], 2f0)) isa Float32
 @test iszero(@inferred(kldivergence([0, 1], [0f0, 1f0])))
 
-# deprecated, should throw an `ArgumentError` at some point
-logpattern = (:warn, "support for empty collections will be removed since they do not represent proper probability distributions")
-@test iszero(@test_logs logpattern @inferred(kldivergence(Float64[], Float64[])))
-@test iszero(@test_logs logpattern @inferred(kldivergence(Int[], Int[])))
+@test_throws DimensionMismatch kldivergence([1//2, 1//2], [0.3, 0.2, 0.5])
+@test_throws ArgumentError @inferred(kldivergence(Float64[], Float64[]))
+@test_throws ArgumentError @inferred(kldivergence(Int[], Int[]))
 
 ##### summarystats
 


### PR DESCRIPTION
Follow-up to https://github.com/JuliaStats/StatsBase.jl/pull/714 that removes the deprecations introduced there and throws an error if empty collections are provided.