### PR TITLE
Make sum and wsum doc consistent with code

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -537,7 +537,7 @@ wsumtype(::Type{T}, ::Type{T}) where {T<:BlasReal} = T
 
 """
     wsum!(R::AbstractArray, A::AbstractArray,
-          w::AbstractWeights{<:Real}, dim::Int;
+          w::AbstractVector, dim::Int;
           init::Bool=true)
 Compute the weighted sum of `A` with weights `w` over the dimension `dim` and store
 the result in `R`. If `init=false`, the sum is added to `R` rather than starting
@@ -576,7 +576,7 @@ Base.sum!(R::AbstractArray, A::AbstractArray, w::AbstractWeights{<:Real}, dim::I
     wsum!(R, A, w, dim; init=init)
 
 """
-    sum(v::AbstractArray, w::AbstractVector{<:Real}; [dims])
+    sum(v::AbstractArray, w::AbstractWeights{<:Real}; [dims])
 
 Compute the weighted sum of an array `v` with weights `w`,
 optionally over the dimension `dims`.


### PR DESCRIPTION
First thought there was type piracy going on with

```
?sum

[...]

  ────────────────────────────────────────────────

  sum(v::AbstractArray, w::AbstractVector{<:Real}; [dims])

  Compute the weighted sum of an array v with weights w, optionally over the dimension dims.
```

but it's the documentation that was wrong :)