### PR TITLE
Reexport functions from Statistics

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -36,9 +36,7 @@ export
     quantile,
     quantile!,
     std,
-    stdm,
     var,
-    varm,
 
     ## weights
     AbstractWeights,    # abstract type to represent any weight vector

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -26,6 +26,20 @@ import StatsAPI: pairwise, pairwise!
 
 export
 
+    ## functions defined in Statistics
+    cor,
+    cov,
+    mean,
+    mean!,
+    median,
+    median!,
+    quantile,
+    quantile!,
+    std,
+    stdm,
+    var,
+    varm,
+
     ## weights
     AbstractWeights,    # abstract type to represent any weight vector
     Weights,            # to represent a generic weight vector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using StatsBase
 using Dates
 using LinearAlgebra
 using Random
-using Statistics
 
 tests = ["ambiguous",
          "weights",


### PR DESCRIPTION
It does not make any sense to avoid exporting functions from Statistics to which we add methods. These are documented in the manual but currently not available without typing `using Statistics`.
The only method from Statistics which we do not overload is `middle`, which this commit does not reexport for now.
Also don't reexport `stdm` and `varm` as they are currently not mentioned in the StatsBase manual (and should probably be deprecated, see https://github.com/JuliaStats/StatsBase.jl/pull/736).

It would even make sense to also include docstrings from Statistics in the StatsBase manual so that one can get them from a single place.