### PR TITLE
Deprecate `varm` and `stdm`

### DIFF
--- a/src/cov.jl
+++ b/src/cov.jl
@@ -100,7 +100,7 @@ cov(x::DenseMatrix, w::AbstractWeights, dims::Int=1; corrected::DepBool=nothing)
 
 function corm(x::DenseMatrix, mean, w::AbstractWeights, vardim::Int=1)
     c = covm(x, mean, w, vardim; corrected=false)
-    s = stdm(x, w, mean, vardim; corrected=false)
+    s = std(x, w, vardim; mean=mean, corrected=false)
     cov2cor!(c, s)
 end
 

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -39,3 +39,10 @@ end
 ### Deprecated September 2019
 @deprecate sum(A::AbstractArray, w::AbstractWeights, dims::Int) sum(A, w, dims=dims)
 @deprecate values(wv::AbstractWeights) convert(Vector, wv)
+
+### Deprecated November 2021
+@deprecate stdm(x::RealArray, w::AbstractWeights, m::Real; corrected::DepBool=nothing) std(x, w, mean=m, corrected=corrected) false
+@deprecate varm(x::RealArray, w::AbstractWeights, m::Real; corrected::DepBool=nothing) var(x, w, mean=m, corrected=corrected) false
+@deprecate stdm(x::RealArray, w::AbstractWeights, m::RealArray, dim::Int; corrected::DepBool=nothing) std(x, w, dim, mean=m, corrected=corrected) false
+@deprecate varm(x::RealArray, w::AbstractWeights, m::RealArray, dim::Int; corrected::DepBool=nothing) var(x, w, dim, mean=m, corrected=corrected) false
+@deprecate varm!(R::AbstractArray, x::RealArray, w::AbstractWeights, m::RealArray, dim::Int; corrected::DepBool=nothing) var!(R, x, w, dim, mean=m, corrected=corrected) false

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -20,13 +20,13 @@ w = [3.84, 2.70, 8.29, 8.91, 9.71, 0.0]
     @testset "Variance" begin
         @test var(x, wv; corrected=false)           ≈ expected_var
         @test var(x, wv; mean=m, corrected=false)   ≈ expected_var
-        @test varm(x, wv, m; corrected=false)   ≈ expected_var
+        @test varm(x, wv, m; corrected=false)       ≈ expected_var
     end
 
     @testset "Standard Deviation" begin
         @test std(x, wv; corrected=false)           ≈ expected_std
         @test std(x, wv; mean=m, corrected=false)   ≈ expected_std
-        @test stdm(x, wv, m; corrected=false)   ≈ expected_std
+        @test stdm(x, wv, m; corrected=false)       ≈ expected_std
     end
 
     @testset "Mean and Variance" begin
@@ -64,7 +64,7 @@ expected_std = sqrt.(expected_var)
         else
             @test var(x, wv; corrected=true)           ≈ expected_var[i]
             @test var(x, wv; mean=m, corrected=true)   ≈ expected_var[i]
-            @test varm(x, wv, m; corrected=true)   ≈ expected_var[i]
+            @test varm(x, wv, m; corrected=true)       ≈ expected_var[i]
         end
     end
 
@@ -74,7 +74,7 @@ expected_std = sqrt.(expected_var)
         else
             @test std(x, wv; corrected=true)           ≈ expected_std[i]
             @test std(x, wv; mean=m, corrected=true)   ≈ expected_std[i]
-            @test stdm(x, wv, m; corrected=true)   ≈ expected_std[i]
+            @test stdm(x, wv, m; corrected=true)       ≈ expected_std[i]
         end
     end
 
@@ -123,12 +123,12 @@ w2 = [3.84, 2.70, 8.29, 8.91, 9.71, 0.0]
     expected_std2 = sqrt.(expected_var2)
 
     @testset "Variance" begin
-        @test var(x, wv1, 1; corrected=false) ≈ expected_var1
-        @test var(x, wv2, 2; corrected=false) ≈ expected_var2
+        @test var(x, wv1, 1; corrected=false)          ≈ expected_var1
+        @test var(x, wv2, 2; corrected=false)          ≈ expected_var2
         @test var(x, wv1, 1; mean=m1, corrected=false) ≈ expected_var1
         @test var(x, wv2, 2; mean=m2, corrected=false) ≈ expected_var2
-        @test varm(x, wv1, m1, 1; corrected=false) ≈ expected_var1
-        @test varm(x, wv2, m2, 2; corrected=false) ≈ expected_var2
+        @test varm(x, wv1, m1, 1; corrected=false)     ≈ expected_var1
+        @test varm(x, wv2, m2, 2; corrected=false)     ≈ expected_var2
     end
 
     @testset "Standard Deviation" begin
@@ -136,8 +136,8 @@ w2 = [3.84, 2.70, 8.29, 8.91, 9.71, 0.0]
         @test std(x, wv2, 2; corrected=false)          ≈ expected_std2
         @test std(x, wv1, 1; mean=m1, corrected=false) ≈ expected_std1
         @test std(x, wv2, 2; mean=m2, corrected=false) ≈ expected_std2
-        @test stdm(x, wv1, m1, 1; corrected=false) ≈ expected_std1
-        @test stdm(x, wv2, m2, 2; corrected=false) ≈ expected_std2
+        @test stdm(x, wv1, m1, 1; corrected=false)     ≈ expected_std1
+        @test stdm(x, wv2, m2, 2; corrected=false)     ≈ expected_std2
     end
 
     @testset "Mean and Variance" begin
@@ -190,12 +190,12 @@ end
         if isa(wv1, Weights)
             @test_throws ArgumentError var(x, wv1, 1; corrected=true)
         else
-            @test var(x, wv1, 1; corrected=true) ≈ expected_var1
-            @test var(x, wv2, 2; corrected=true) ≈ expected_var2
+            @test var(x, wv1, 1; corrected=true)          ≈ expected_var1
+            @test var(x, wv2, 2; corrected=true)          ≈ expected_var2
             @test var(x, wv1, 1; mean=m1, corrected=true) ≈ expected_var1
             @test var(x, wv2, 2; mean=m2, corrected=true) ≈ expected_var2
-            @test varm(x, wv1, m1, 1; corrected=true) ≈ expected_var1
-            @test varm(x, wv2, m2, 2; corrected=true) ≈ expected_var2
+            @test varm(x, wv1, m1, 1; corrected=true)     ≈ expected_var1
+            @test varm(x, wv2, m2, 2; corrected=true)     ≈ expected_var2
         end
     end
 
@@ -207,8 +207,8 @@ end
             @test std(x, wv2, 2; corrected=true)          ≈ expected_std2
             @test std(x, wv1, 1; mean=m1, corrected=true) ≈ expected_std1
             @test std(x, wv2, 2; mean=m2, corrected=true) ≈ expected_std2
-            @test stdm(x, wv1, m1, 1; corrected=true) ≈ expected_std1
-            @test stdm(x, wv2, m2, 2; corrected=true) ≈ expected_std2
+            @test stdm(x, wv1, m1, 1; corrected=true)     ≈ expected_std1
+            @test stdm(x, wv2, m2, 2; corrected=true)     ≈ expected_std2
         end
     end
 

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -20,11 +20,13 @@ w = [3.84, 2.70, 8.29, 8.91, 9.71, 0.0]
     @testset "Variance" begin
         @test var(x, wv; corrected=false)           ≈ expected_var
         @test var(x, wv; mean=m, corrected=false)   ≈ expected_var
+        @test varm(x, wv, m; corrected=false)   ≈ expected_var
     end
 
     @testset "Standard Deviation" begin
         @test std(x, wv; corrected=false)           ≈ expected_std
         @test std(x, wv; mean=m, corrected=false)   ≈ expected_std
+        @test stdm(x, wv, m; corrected=false)   ≈ expected_std
     end
 
     @testset "Mean and Variance" begin
@@ -62,6 +64,7 @@ expected_std = sqrt.(expected_var)
         else
             @test var(x, wv; corrected=true)           ≈ expected_var[i]
             @test var(x, wv; mean=m, corrected=true)   ≈ expected_var[i]
+            @test varm(x, wv, m; corrected=true)   ≈ expected_var[i]
         end
     end
 
@@ -71,6 +74,7 @@ expected_std = sqrt.(expected_var)
         else
             @test std(x, wv; corrected=true)           ≈ expected_std[i]
             @test std(x, wv; mean=m, corrected=true)   ≈ expected_std[i]
+            @test stdm(x, wv, m; corrected=true)   ≈ expected_std[i]
         end
     end
 
@@ -123,6 +127,8 @@ w2 = [3.84, 2.70, 8.29, 8.91, 9.71, 0.0]
         @test var(x, wv2, 2; corrected=false) ≈ expected_var2
         @test var(x, wv1, 1; mean=m1, corrected=false) ≈ expected_var1
         @test var(x, wv2, 2; mean=m2, corrected=false) ≈ expected_var2
+        @test varm(x, wv1, m1, 1; corrected=false) ≈ expected_var1
+        @test varm(x, wv2, m2, 2; corrected=false) ≈ expected_var2
     end
 
     @testset "Standard Deviation" begin
@@ -130,6 +136,8 @@ w2 = [3.84, 2.70, 8.29, 8.91, 9.71, 0.0]
         @test std(x, wv2, 2; corrected=false)          ≈ expected_std2
         @test std(x, wv1, 1; mean=m1, corrected=false) ≈ expected_std1
         @test std(x, wv2, 2; mean=m2, corrected=false) ≈ expected_std2
+        @test stdm(x, wv1, m1, 1; corrected=false) ≈ expected_std1
+        @test stdm(x, wv2, m2, 2; corrected=false) ≈ expected_std2
     end
 
     @testset "Mean and Variance" begin
@@ -186,6 +194,8 @@ end
             @test var(x, wv2, 2; corrected=true) ≈ expected_var2
             @test var(x, wv1, 1; mean=m1, corrected=true) ≈ expected_var1
             @test var(x, wv2, 2; mean=m2, corrected=true) ≈ expected_var2
+            @test varm(x, wv1, m1, 1; corrected=true) ≈ expected_var1
+            @test varm(x, wv2, m2, 2; corrected=true) ≈ expected_var2
         end
     end
 
@@ -197,6 +207,8 @@ end
             @test std(x, wv2, 2; corrected=true)          ≈ expected_std2
             @test std(x, wv1, 1; mean=m1, corrected=true) ≈ expected_std1
             @test std(x, wv2, 2; mean=m2, corrected=true) ≈ expected_std2
+            @test stdm(x, wv1, m1, 1; corrected=true) ≈ expected_std1
+            @test stdm(x, wv2, m2, 2; corrected=true) ≈ expected_std2
         end
     end
 


### PR DESCRIPTION
`varm` and `stdm` are redundant with `var(..., mean=m)` and `std(..., mean=m)`. Moreover, their status is not clear: they are technically exported by Statistics (but not by StatsBase itself), but their docstrings are not included in the manual. They were only tested indirectly, so add tests to ensure deprecations work.

The status of `varm!` is even weirder as it's imported from Statistics, but Statistics does not export it, and it has no docstrings. Keep a deprecation just in case.