### PR TITLE
correct error message

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -916,7 +916,7 @@ function sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::Abs
             end
         end
     else
-        k <= n || error("Cannot draw $n samples from $k samples without replacement.")
+        k <= n || error("Cannot draw $k samples from $n samples without replacement.")
         efraimidis_aexpj_wsample_norep!(rng, a, wv, x; ordered=ordered)
     end
     return x


### PR DESCRIPTION
I noticed an incorrect order of parameters in an error message.

**Current behaviour**: 2 and 40 appear the wrong way around in the error message
```julia
julia > using StatsBase: sample, Weights
julia > sample(1:2, Weights([0.5, 0.5]), 40, replace = false)
ERROR: Cannot draw 2 samples from 40 samples without replacement.
Stacktrace:
...
```

**Updated behaviour**:
```julia
...
ERROR: Cannot draw 40 samples from 2 samples without replacement.
...
```