### PR TITLE
Point to cov if not positive definite

### DIFF
--- a/src/reliability.jl
+++ b/src/reliability.jl
@@ -52,11 +52,9 @@ item 4: 0.7826
 """
 function cronbachalpha(covmatrix::AbstractMatrix{<:Real})
     if !isposdef(covmatrix)
-        msg = """
-            Covariance matrix must be positive definite.
-            Did you use `cronbachalpha(cov(Matrix(...)))`?
-            """
-        throw(ArgumentError(msg))
+         throw(ArgumentError("Covariance matrix must be positive definite. " *
+                             "Maybe you passed the data matrix instead of its covariance matrix? " *
+                             "If so, call `cronbachalpha(cov(...))` instead.")
     end
     k = size(covmatrix, 2)
     k > 1  || throw(ArgumentError("Covariance matrix must have more than one column."))

--- a/src/reliability.jl
+++ b/src/reliability.jl
@@ -52,9 +52,9 @@ item 4: 0.7826
 """
 function cronbachalpha(covmatrix::AbstractMatrix{<:Real})
     if !isposdef(covmatrix)
-         throw(ArgumentError("Covariance matrix must be positive definite. " *
-                             "Maybe you passed the data matrix instead of its covariance matrix? " *
-                             "If so, call `cronbachalpha(cov(...))` instead."))
+        throw(ArgumentError("Covariance matrix must be positive definite. " *
+                            "Maybe you passed the data matrix instead of its covariance matrix? " *
+                            "If so, call `cronbachalpha(cov(...))` instead."))
     end
     k = size(covmatrix, 2)
     k > 1  || throw(ArgumentError("Covariance matrix must have more than one column."))

--- a/src/reliability.jl
+++ b/src/reliability.jl
@@ -54,7 +54,7 @@ function cronbachalpha(covmatrix::AbstractMatrix{<:Real})
     if !isposdef(covmatrix)
          throw(ArgumentError("Covariance matrix must be positive definite. " *
                              "Maybe you passed the data matrix instead of its covariance matrix? " *
-                             "If so, call `cronbachalpha(cov(...))` instead.")
+                             "If so, call `cronbachalpha(cov(...))` instead."))
     end
     k = size(covmatrix, 2)
     k > 1  || throw(ArgumentError("Covariance matrix must have more than one column."))

--- a/src/reliability.jl
+++ b/src/reliability.jl
@@ -51,7 +51,13 @@ item 4: 0.7826
 ```
 """
 function cronbachalpha(covmatrix::AbstractMatrix{<:Real})
-    isposdef(covmatrix) || throw(ArgumentError("Covariance matrix must be positive definite."))
+    if !isposdef(covmatrix)
+        msg = """
+            Covariance matrix must be positive definite.
+            Did you use `cronbachalpha(cov(Matrix(...)))`?
+            """
+        throw(ArgumentError(msg))
+    end
     k = size(covmatrix, 2)
     k > 1  || throw(ArgumentError("Covariance matrix must have more than one column."))
     v = vec(sum(covmatrix, dims=1))


### PR DESCRIPTION
I was trying to calculate the Cronbach alpha for my dataset but got a `Covariance matrix must be positive definite.` error. Assuming that something was wrong with my data, I gave up and went to R's `psych` package only to figure out that the calculation worked there.

I asked @storopoli, and it turned out that I should use `cronbachalpha(cov(Matrix(...)))` which is indeed in the documentation, but well, also easy to miss... This PR makes it harder to miss the fact that you should pass a covariance matrix.