### PR TITLE
add a fast binnedStatistic function to match SciPy functionality

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -2,6 +2,7 @@ using Base.Cartesian
 
 import Base: show, ==, push!, append!, float
 import LinearAlgebra: norm, normalize, normalize!
+import Statistics: median
 
 
 ## Fast getindex function for multiple arrays, returns a tuple of array elements
@@ -577,3 +578,93 @@ Calculate the midpoints (pairwise mean of consecutive elements).
 midpoints(v::AbstractVector) = [middle(v[i - 1], v[i]) for i in 2:length(v)]
 
 midpoints(r::AbstractRange) = r[1:(end - 1)] .+ (step(r) / 2)
+
+#binned statistics -- fast histograms with a statistic calculated at each bin
+"""
+Compute a fast binned statistic for an array of y-values along some array of x-values,
+essentially a histogram with the chosen statistic computed at each bin.
+
+This function is an analog to the existing scipy.stats.binned_statistic function, but written in native Julia, and this implementation is faster than the SciPy version!
+
+Returns the bin edges, bin centers, and corresponding binned statistic. Currently implemented stats operations are sum, mean, median, variance, and standard deviation.
+The median is implementation is much slower than the others (~10x slower than sum, which is the fastest), but included to match with scipy.stats.binned_statistic. It could easily be improved but left in lazy state for now.
+
+Usage examples:
+x = rand(2048,2048); y = rand(2048,2048)
+edges, centers, binnedSum = binnedStatistic(x,y,nbins=500,statistic=:sum)
+
+edges, centers, binnedSum = binnedStatistic(x,y) #defaults to :sum with 100 bins
+
+edges, centers, binnedVar = binnedStatistic(x,y,statistic=:var) #compute the variance in each bin, leaving default of 100 bins
+
+This can technically be done with the existing Histogram functionality above, but it's very slow, and this new way is ~15-20x faster.
+Example using existing histogram routine in StatsBase:
+
+function histSum(x::Array,y::Array,bins::Int=100) #compute the sum on each bin in a histogram, using the existing functionality in StatsBase
+    h = fit(Histogram, vec(x), aweights(y), nbins=bins)
+    h.edges, h.weights
+end
+
+julia> x = rand(2048,2048); y = rand(2048,2048)
+julia> using BenchmarkTools
+julia> @btime histSum(x,y)
+    268.793 ms (8 allocations: 1.20 KiB)
+
+if using this new, faster version we obtain a ~15-20x speed-up:
+
+julia> @btime binnedStatistic(x,y)
+    14.165 ms (3 allocations: 1.83 KiB)
+
+These tests were performed using Julia 1.6.1 on a system running Linux Mint 20.3 Cinnamon with a Intel Core i7-1065G7 CPU (4 cores @ 1.3 GHz)
+"""
+
+function binnedStatistic(x::Array{Float64,}, y::Array{Float64,}; nbins::Int=100, statistic::Symbol=:sum)
+    if length(x) > 0 && nbins < 1
+        throw(ArgumentError("number of bins must be ≥ 1 for a non-empty array, got $nbins"))
+    end
+    if length(vec(x)) != length(vec(y))
+        throw(ArgumentError("length of x must match length of y"))
+    end
+    binMax, binMin = maximum(x), minimum(x) #this is faster for some reason?
+    result = zeros(nbins)
+    Δ = nbins / (binMax - binMin) #spacing
+    if statistic == :sum
+        for (x, y) in zip(x, y)
+            i = min(nbins, 1 + floor(Int, Δ * (x - binMin))) #which bin are we in at this x?
+            result[i] += y
+        end
+    elseif statistic == :mean || statistic == :std || statistic == :var
+        N = zeros(nbins)
+        for (x, y) in zip(x, y)
+            i = min(nbins, 1 + floor(Int, Δ * (x - binMin)))
+            result[i] += y
+            N[i] += 1 #need to keep track of number of counts in each bin for mean, std, var
+        end
+        N[N .== 0.] .= 1. #no dividing by zero
+        result ./= N
+        if statistic == :std || statistic == :var
+            μ = copy(result)
+            result = zeros(nbins)
+            for (x, y) in zip(x, y)
+                i = min(nbins, 1 + floor(Int, Δ * (x - binMin)))
+                result[i] += (y-μ[i])^2
+            end
+            result ./= N
+            if statistic == :std
+                @. result = √result
+            end
+        end
+    elseif statistic == :median
+        tmp = [{Array{Float64}(undef,0) for i = 1:nbins]
+        for (x, y) in zip(x, y)
+            i = min(nbins, 1 + floor(Int, Δ * (x - binMin)))
+            push!(tmp[i],y)
+        end
+        result = [length(tmp[i]) > 0 ? median(tmp[i]) : 0. for i=1:nbins]
+    else
+        throw(ArgumentError("Valid statistic options are :sum, :mean, :std, or :var, got $statistic"))
+    end
+    edges = range(binMin, stop=binMax, length=nbins+1)
+    centers = [(edges[i]+edges[i+1])/2 for i=1:length(edges)-1]
+    return edges, centers, result
+end


### PR DESCRIPTION
Disclaimer: This is my first pull request to a "real" project ever, so apologies if I've done anything wrong and appreciate your help!

I recently decided to switch a project I was working on from Python to Julia for performance reasons, but one thing I needed that did not appear to exist yet in Julia was an analogue to the [SciPy `binned_statistic`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binned_statistic.html) function, so I figured this would be a fun challenge to write my own! With some [help from the community](https://discourse.julialang.org/t/weighted-histogram-2x-as-slow-in-julia-vs-python/74953) I was able to make it even faster than the SciPy implementation.

This is a generalization of the histogram function where a statistic is computed on each bin. I only needed the sum use case, but before submitting this pull request I've generalized the code to compute other common statistics at each bin -- in this implementation the statistics options are sum, mean, median, standard deviation, and variance. There is a long doc-string I wrote up before the function in the file that has more info + usage examples.

Technically this can be accomplished (albeit much slower) via existing functionality in StatsBase, i.e. the following bit of code would produce a "summed histogram": 

```julia
function histSum(x::Array,y::Array,bins::Int=100)
    h = fit(Histogram, vec(x), aweights(y), nbins=bins)
    h.edges, h.weights
end
```

However this is prohibitively slow, both compared to the Python version and my new implementation, so I thought it might be nice to have this as a function that all Julia/StatsBase users could benefit from if they ever need something similar! In testing on my machine the speed-up between my new version and the way that uses the existing functionality for the sum statistic is ~15-20x. The only slow statistic (but still faster than existing functionality) is my current implementation of median, which is pretty hacky/lazy but I was trying to closer match the SciPy functionality. Happy to write up corresponding documentation for this and hope to continue to improve performance + available options if this is well-received and actually helpful!

I added this new function to the bottom of `hist.jl` as that seemed like the best place for it, but of course happy for it to be moved around / turned into a different file / whatever.