### PR TITLE
Import `adjr²` from StatsAPI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.33.15"
+version = "0.33.16"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -28,7 +28,7 @@ import StatsAPI: pairwise, pairwise!, params, params!,
                  deviance, islinear, nulldeviance, loglikelihood, nullloglikelihood,
                  loglikelihood, loglikelihood, score, nobs, dof, mss, rss,
                  informationmatrix, stderror, vcov, weights, isfitted, fit, fit!,
-                 aic, aicc, bic, r2, r², adjr2
+                 aic, aicc, bic, r2, r², adjr2, adjr²
 
     ## tackle compatibility issues
 


### PR DESCRIPTION
It was overlooked, making it completely unusable by packages which do not import it from StatsAPI.