### PR TITLE
Add tests for StatsAPI modeling functions

### DIFF
--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -21,7 +21,7 @@ import Statistics: mean, mean!, var, varm, varm!, std, stdm, cov, covm,
                    cor, corm, cov2cor!, unscaled_covzm, quantile, sqrt!,
                    median, middle
 using StatsAPI: StatisticalModel, RegressionModel
-import StatsAPI: pairwise, pairwise!,
+import StatsAPI: pairwise, pairwise!, params, params!,
                  fitted, response, responsename, meanresponse, modelmatrix,
                  crossmodelmatrix, leverage, cooksdistance, residuals, predict,
                  predict!, dof_residual, coef, coefnames, coeftable, confint,

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -21,7 +21,7 @@ import Statistics: mean, mean!, var, varm, varm!, std, stdm, cov, covm,
                    cor, corm, cov2cor!, unscaled_covzm, quantile, sqrt!,
                    median, middle
 using StatsAPI: StatisticalModel, RegressionModel
-import StatsAPI: pairwise, pairwise!, params, params!,
+import StatsAPI: pairwise, pairwise!,
                  fitted, response, responsename, meanresponse, modelmatrix,
                  crossmodelmatrix, leverage, cooksdistance, residuals, predict,
                  predict!, dof_residual, coef, coefnames, coeftable, confint,

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -187,4 +187,7 @@ end
               aic, aicc, bic, r2, r², adjr2, adjr²)
         @test f isa Function
     end
+    # Defined but not reexported
+    @test StatsBase.params isa Function
+    @test StatsBase.params! isa Function
 end

--- a/test/statmodels.jl
+++ b/test/statmodels.jl
@@ -1,6 +1,6 @@
 using StatsBase
 using StatsBase: PValue, TestStat
-using Test, Random
+using Test, Random, StatsAPI, LinearAlgebra
 
 v1 = [1.45666, -23.14, 1.56734e-13]
 v2 = ["Good", "Great", "Bad"]
@@ -131,3 +131,60 @@ end
 
 err = @test_throws ArgumentError ConvergenceException(10,.1,.2)
 @test err.value.msg == "Change must be greater than tol."
+
+struct MyStatisticalModel <: StatisticalModel
+end
+
+StatsAPI.vcov(::MyStatisticalModel) = [1 2; 3 4]
+StatsAPI.loglikelihood(::MyStatisticalModel) = 3
+StatsAPI.nullloglikelihood(::MyStatisticalModel) = 4
+StatsAPI.deviance(::MyStatisticalModel) = 25
+StatsAPI.nulldeviance(::MyStatisticalModel) = 40
+StatsAPI.dof(::MyStatisticalModel) = 5
+StatsAPI.nobs(::MyStatisticalModel) = 100
+
+@testset "StatisticalModel" begin
+    m = MyStatisticalModel()
+
+    @test stderror(m) == [1, 2]
+    @test aic(m) == 4
+    @test aicc(m) ≈ 4.638297872340425
+    @test bic(m) ≈ 17.02585092994046
+    @test r2(m, :McFadden) ≈ 0.25
+    @test r2(m, :CoxSnell) ≈ -0.020201340026755776
+    @test r2(m, :Nagelkerke) ≈ 0.24255074155803877
+    @test r2(m, :devianceratio) ≈ 0.375
+
+    @test_throws Union{ErrorException, ArgumentError} r2(m, :err)
+    @test_throws MethodError r2(m)
+    @test adjr2(m, :McFadden) ≈ 1.5
+    @test adjr2(m, :devianceratio) ≈ 0.3486842105263158
+    @test_throws Union{ErrorException, ArgumentError} adjr2(m, :err)
+
+    @test r2 === r²
+    @test adjr2 === adjr²
+end
+
+struct MyRegressionModel <: RegressionModel
+end
+
+StatsAPI.modelmatrix(::MyRegressionModel) = [1 2; 3 4]
+
+@testset "TestRegressionModel" begin
+    m = MyRegressionModel()
+
+    @test crossmodelmatrix(m) == [10 14; 14 20]
+    @test crossmodelmatrix(m) isa Symmetric
+end
+
+@testset "StatsAPI model reexports" begin
+    for f in (fitted, response, responsename, meanresponse,
+              modelmatrix, crossmodelmatrix, leverage, cooksdistance, residuals,
+              predict, predict!, dof_residual, coef, coefnames, coeftable, confint,
+              deviance, islinear, nulldeviance, loglikelihood, nullloglikelihood,
+              loglikelihood, loglikelihood, score, nobs, dof, mss, rss,
+              informationmatrix, stderror, vcov, weights, isfitted, fit, fit!,
+              aic, aicc, bic, r2, r², adjr2, adjr²)
+        @test f isa Function
+    end
+end


### PR DESCRIPTION
Ensure that we don't accidentally stop exporting some functions and that
fallbacks defined in StatsAPI work.
Stop importing `params` and `params!` as they are neither used nor reexported