### PR TITLE
Allow for describe to operate over an entire Matrix

### DIFF
--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -897,6 +897,7 @@ median, 75th percentile, and maxmimum.
 function summarystats(a::AbstractArray{T}) where T<:Union{Real,Missing}
     # `mean` doesn't fail on empty input but rather returns `NaN`, so we can use the
     # return type to populate the `SummaryStats` structure.
+    a = length(size(a)) != 1 ? a[:] : a
     s = T >: Missing ? collect(skipmissing(a)) : a
     m = mean(s)
     R = typeof(m)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -90,3 +90,16 @@ describe(io, fill("s", 3))
                            Type:           String
                            Number Unique:  1
                            """
+describe(io, reshape(collect(1:100), (10, 10)))
+@test String(take!(io)) == """
+                           Summary Stats:
+                           Length:         100
+                           Missing Count:  0
+                           Mean:           50.500000
+                           Minimum:        1.000000
+                           1st Quartile:   25.750000
+                           Median:         50.500000
+                           3rd Quartile:   75.250000
+                           Maximum:        100.000000
+                           Type:           $Int
+                           """


### PR DESCRIPTION
As discussed [here](https://discourse.julialang.org/t/how-to-get-a-quick-description-of-a-vector-matrix-like-pd-dataframe-describe/78013/5) currently if you pass a matrix to describe you get an error from `quantile!`
```Julia
julia> describe(reshape(collect(1:100), (10, 10)))
ERROR: MethodError: no method matching quantile!(::Matrix{Int64}, ::Vector{Float64}; sorted=false, alpha=1.0, beta=1.0)
Closest candidates are:
  quantile!(::AbstractArray, ::AbstractVector, ::AbstractArray; sorted, alpha, beta) at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:936
  quantile!(::AbstractVector, ::Union{Tuple{Vararg{Real}}, AbstractArray}; sorted, alpha, beta) at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:953
Stacktrace:
 [1] quantile(itr::Matrix{Int64}, p::Vector{Float64}; sorted::Bool, alpha::Float64, beta::Float64)
   @ Statistics /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:1070
 [2] quantile(itr::Matrix{Int64}, p::Vector{Float64})
   @ Statistics /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:1070
 [3] summarystats(a::Matrix{Int64})
   @ StatsBase ~/.julia/packages/StatsBase/pJqvO/src/scalarstats.jl:915
 [4] describe(io::Base.TTY, a::Matrix{Int64})
   @ StatsBase ~/.julia/packages/StatsBase/pJqvO/src/scalarstats.jl:943
 [5] describe(x::Matrix{Int64})
   @ StatsBase ~/.julia/packages/StatsBase/pJqvO/src/scalarstats.jl:941
 [6] top-level scope
   @ REPL[3]:1
```

I made a small change which vectorises a matrix and provides a description for the whole matrix. 

```Julia 
julia> describe(reshape(collect(1:100), (10, 10)))
Summary Stats:
Length:         100
Missing Count:  0
Mean:           50.500000
Minimum:        1.000000
1st Quartile:   25.750000
Median:         50.500000
3rd Quartile:   75.250000
Maximum:        100.000000
Type:           Int64
```

In the future a dims argument could be useful. 
