### PR TITLE
Improve performance of weighted sum

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -388,7 +388,11 @@ for W in (AnalyticWeights, FrequencyWeights, ProbabilityWeights, Weights)
         wsum(v::AbstractArray, w::$W, dims::Colon) = transpose(w.values) * vec(v)
     end
 end
-wsum(v::AbstractArray, w::UnitWeights, dims::Colon) = sum(v)
+
+function wsum(A::AbstractArray, w::UnitWeights, dims::Colon)
+    length(A) != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
+    return sum(A)
+end
 
 ## wsum along dimension
 #
@@ -612,12 +616,6 @@ optionally over the dimension `dims`.
 """
 Base.sum(A::AbstractArray, w::AbstractWeights{<:Real}; dims::Union{Colon,Int}=:) =
     wsum(A, w, dims)
-
-function Base.sum(A::AbstractArray, w::UnitWeights; dims::Union{Colon,Int}=:)
-    a = (dims === :) ? length(A) : size(A, dims)
-    a != length(w) && throw(DimensionMismatch("Inconsistent array dimension."))
-    return sum(A, dims=dims)
-end
 
 ##### Weighted means #####
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -382,6 +382,14 @@ Compute the weighted sum of an array `v` with weights `w`, optionally over the d
 """
 wsum(v::AbstractArray, w::AbstractVector, dims::Colon=:) = transpose(w) * vec(v)
 
+# Optimized methods (to ensure we use BLAS when possible)
+for W in (AnalyticWeights, FrequencyWeights, ProbabilityWeights, Weights)
+    @eval begin
+        wsum(v::AbstractArray, w::$W, dims::Colon) = transpose(w.values) * vec(v)
+    end
+end
+wsum(v::AbstractArray, w::UnitWeights, dims::Colon) = sum(v)
+
 ## wsum along dimension
 #
 #  Brief explanation of the algorithm:

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -476,7 +476,7 @@ end
 @testset "Sum, mean, quantiles and variance for unit weights" begin
     wt = uweights(Float64, 3)
 
-    @test sum([1.0, 2.0, 3.0], wt) ≈ 6.0
+    @test sum([1.0, 2.0, 3.0], wt) ≈ wsum([1.0, 2.0, 3.0], wt) ≈ 6.0
     @test mean([1.0, 2.0, 3.0], wt) ≈ 2.0
 
     @test sum(a, wt, dims=1) ≈ sum(a, dims=1)


### PR DESCRIPTION
The current code is calling the `AbstractArray` matrix multiplication fallback, which is slower than BLAS.

Fixes https://github.com/JuliaStats/StatsBase.jl/issues/775.

```julia
julia> using BenchmarkTools

julia> using StatsBase

julia> x = rand(1000); w = weights(rand(1000));

# master
julia> @btime wsum(x, w);
  1.029 μs (1 allocation: 16 bytes)

# This PR
julia> @btime wsum(x, w);
  97.572 ns (1 allocation: 16 bytes)
```

Tests appear to cover all weights types and `AbstractVector` already.