### PR TITLE
Fix `varcorrection` docstring for `UnitWeights`

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -347,7 +347,7 @@ uweights(::Type{T}, s::Int) where {T<:Real} = UnitWeights{T}(s)
 """
     varcorrection(w::UnitWeights, corrected=false)
 
-* `corrected=true`: ``\\frac{n}{n - 1}``, where ``n`` is the length of the weight vector
+* `corrected=true`: ``\\frac{1}{n - 1}``, where ``n`` is the length of the weight vector
 * `corrected=false`: ``\\frac{1}{n}``, where ``n`` is the length of the weight vector
 
 This definition is equivalent to the correction applied to unweighted data.


### PR DESCRIPTION
This didn't match the implementation. Fixes #784.