### PR TITLE
Allow only 1-based indexed vectors in AbstractWeights

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -15,7 +15,7 @@ macro weights(name)
         end
         function $(esc(name))(values::AbstractVector{<:Real})
             Base.require_one_based_indexing(values)
-            $(esc(name))(values, sum(values))
+            return $(esc(name))(values, sum(values))
         end
     end
 end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -5,7 +5,7 @@ abstract type AbstractWeights{S<:Real, T<:Real, V<:AbstractVector{T}} <: Abstrac
     @weights name
 
 Generates a new generic weight type with specified `name`, which subtypes `AbstractWeights`
-and stores the `values` (`V<:RealVector`) and `sum` (`S<:Real`).
+and stores the `values` (`V<:RealVector` using 1-based indexing) and `sum` (`S<:Real`).
 """
 macro weights(name)
     return quote
@@ -13,7 +13,10 @@ macro weights(name)
             values::V
             sum::S
         end
-        $(esc(name))(values::AbstractVector{<:Real}) = $(esc(name))(values, sum(values))
+        function $(esc(name))(values::AbstractVector{<:Real})
+            Base.require_one_based_indexing(values)
+            $(esc(name))(values, sum(values))
+        end
     end
 end
 


### PR DESCRIPTION
Currently we have:
```
julia> Weights(OffsetArray([1,2,3], -2))
3-element Weights{Int64, Int64, OffsetVector{Int64, Vector{Int64}}}:
                 3
        1320009728
 20547999722963018
```
I propose to require that `AbstractWeights` take a vector using 1-based indexing. This is a safer option to the alternative, where we would recalculate indices everywhere (this is possible, but I think error prone, so it is better to be defensive)