### PR TITLE
Update moments.jl

### DIFF
--- a/src/moments.jl
+++ b/src/moments.jl
@@ -132,25 +132,25 @@ function mean_and_std(x::RealArray, w::AbstractWeights; corrected::DepBool=nothi
 end
 
 
-function mean_and_var(x::RealArray, dim::Int; corrected::Bool=true)
+function mean_and_var(x::RealArray, dim::Any; corrected::Bool=true)
     m = mean(x, dims=dim)
     v = var(x, dims=dim, mean=m, corrected=corrected)
     m, v
 end
-function mean_and_std(x::RealArray, dim::Int; corrected::Bool=true)
+function mean_and_std(x::RealArray, dim::Any; corrected::Bool=true)
     m = mean(x, dims=dim)
     s = std(x, dims=dim, mean=m, corrected=corrected)
     m, s
 end
 
 
-function mean_and_var(x::RealArray, w::AbstractWeights, dims::Int;
+function mean_and_var(x::RealArray, w::AbstractWeights, dims::Any;
                       corrected::DepBool=nothing)
     m = mean(x, w, dims=dims)
     v = var(x, w, dims, mean=m, corrected=depcheck(:mean_and_var, :corrected, corrected))
     m, v
 end
-function mean_and_std(x::RealArray, w::AbstractWeights, dims::Int;
+function mean_and_std(x::RealArray, w::AbstractWeights, dims::Any;
                       corrected::DepBool=nothing)
     m = mean(x, w, dims=dims)
     s = std(x, w, dims, mean=m, corrected=depcheck(:mean_and_std, :corrected, corrected))


### PR DESCRIPTION
the current function `mean_and_var` and `mean_and_std` does not allow tuple type for the kwarg `dim`, as it is `dim::Int`. It should be changed to `dim::Any` to allow tuple type.