### PR TITLE
Fix vector eltype in `crosscov`

### DIFF
--- a/src/signalcorr.jl
+++ b/src/signalcorr.jl
@@ -255,7 +255,7 @@ function crosscov!(r::RealVector, x::RealVector, y::RealVector, lags::IntegerVec
     T = typeof(zero(eltype(x)) / 1)
     zx::Vector{T} = demean ? x .- mean(x) : x
     S = typeof(zero(eltype(y)) / 1)
-    zy::Vector{T} = demean ? y .- mean(y) : y
+    zy::Vector{S} = demean ? y .- mean(y) : y
     for k = 1 : m  # foreach lag value
         r[k] = _crossdot(zx, zy, lx, lags[k]) / lx
     end
@@ -406,7 +406,7 @@ function crosscor!(r::RealVector, x::RealVector, y::RealVector, lags::IntegerVec
     T = typeof(zero(eltype(x)) / 1)
     zx::Vector{T} = demean ? x .- mean(x) : x
     S = typeof(zero(eltype(y)) / 1)
-    zy::Vector{T} = demean ? y .- mean(y) : y
+    zy::Vector{S} = demean ? y .- mean(y) : y
     sc = sqrt(dot(zx, zx) * dot(zy, zy))
     for k = 1 : m  # foreach lag value
         r[k] = _crossdot(zx, zy, lx, lags[k]) / sc

--- a/test/signalcorr.jl
+++ b/test/signalcorr.jl
@@ -92,6 +92,11 @@ c22 = crosscov(x2, x2)
 @test crosscov(x,  x)  ≈ cat([c11 c21], [c12 c22], dims=3)
 @test crosscov(realx,  realx)  ≈ cat([c11 c21], [c12 c22], dims=3)
 
+# issue #805: avoid converting one input to the other's eltype
+@test crosscov([34566.5345, 3466.4566], Float16[1, 10]) ≈
+    crosscov(Float16[1, 10], [34566.5345, 3466.4566]) ≈
+    crosscov([34566.5345, 3466.4566], Float16[1, 10])
+
 rcor0 = [0.230940107675850,
         -0.230940107675850,
          0.057735026918963,
@@ -117,6 +122,11 @@ c22 = crosscor(x2, x2)
 @test crosscor(realx1, realx)  ≈ [c11 c12]
 @test crosscor(x,  x)  ≈ cat([c11 c21], [c12 c22], dims=3)
 @test crosscor(realx, realx)  ≈ cat([c11 c21], [c12 c22], dims=3)
+
+# issue #805: avoid converting one input to the other's eltype
+@test crosscor([34566.5345, 3466.4566], Float16[1, 10]) ≈
+    crosscor(Float16[1, 10], [34566.5345, 3466.4566]) ≈
+    crosscor([34566.5345, 3466.4566], Float16[1, 10])
 
 
 ## pacf


### PR DESCRIPTION
Introduced by https://github.com/JuliaStats/StatsBase.jl/pull/567. Fixes https://github.com/JuliaStats/StatsBase.jl/issues/802.

It doesn't seem easy to find a case where this would make a difference visible from the outside.