### PR TITLE
UnitWeights don't have `values` to return from `dataids`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.33.17"
+version = "0.33.18"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -304,6 +304,7 @@ length(wv::UnitWeights) = wv.len
 size(wv::UnitWeights) = tuple(length(wv))
 Base.axes(wv::UnitWeights) = tuple(Base.OneTo(length(wv)))
 
+Base.dataids(::UnitWeights) = ()
 Base.convert(::Type{Vector}, wv::UnitWeights{T}) where {T} = ones(T, length(wv))
 
 @propagate_inbounds function Base.getindex(wv::UnitWeights{T}, i::Integer) where T

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -568,4 +568,12 @@ end
     end
 end
 
+@testset "UnitWeights" begin
+    @test convert(Vector, uweights(3)) == ones(3)
+    @test !Base.mightalias(uweights(3), uweights(3))
+    @test Base.dataids(uweights(3)) == ()
+    @test length(uweights(3)) == 3
+    @test sum(uweights(3)) == 3
+end
+
 end # @testset StatsBase.Weights

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -117,6 +117,9 @@ end
     @test wv != fweights(fill(1.0, 3))
     @test wv == uweights(3)
     @test wv[[true, false, false]] == uweights(Float64, 1)
+    @test convert(Vector, wv) == ones(3)
+    @test !Base.mightalias(wv, uweights(Float64, 3))
+    @test Base.dataids(wv) == ()
 end
 
 ## wsum
@@ -566,14 +569,6 @@ end
         wv = eweights(1:10, λ; scale=false)
         @test eweights(1:10, λ; scale=true) ≈ wv / maximum(wv)
     end
-end
-
-@testset "UnitWeights" begin
-    @test convert(Vector, uweights(3)) == ones(3)
-    @test !Base.mightalias(uweights(3), uweights(3))
-    @test Base.dataids(uweights(3)) == ()
-    @test length(uweights(3)) == 3
-    @test sum(uweights(3)) == 3
 end
 
 end # @testset StatsBase.Weights


### PR DESCRIPTION
Current fallback can cause errors like this:

```
  type UnitWeights has no field values
  Stacktrace:
    [1] getproperty(x::StatsBase.UnitWeights{Int64}, f::Symbol)
      @ Base ./Base.jl:33
    [2] dataids(wv::StatsBase.UnitWeights{Int64})
      @ StatsBase ~/.julia/packages/StatsBase/n494Y/src/weights.jl:26
    [3] dataids(A::SubArray{Int64, 1, StatsBase.UnitWeights{Int64}, Tuple{Vector{Int64}}, false})
    ```