### PR TITLE
Define `IndexStyle` for `AbstractWeights`

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -23,6 +23,8 @@ isempty(wv::AbstractWeights) = isempty(wv.values)
 size(wv::AbstractWeights) = size(wv.values)
 Base.axes(wv::AbstractWeights) = Base.axes(wv.values)
 
+Base.IndexStyle(::Type{<:AbstractWeights{S,T,V}}) where {S,T,V} = IndexStyle(V)
+
 Base.dataids(wv::AbstractWeights) = Base.dataids(wv.values)
 
 Base.convert(::Type{Vector}, wv::AbstractWeights) = convert(Vector, wv.values)

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -14,6 +14,7 @@ weight_funcs = (weights, aweights, fweights, pweights)
     @test isempty(f(Float64[]))
     @test size(f([1, 2, 3])) == (3,)
     @test axes(f([1, 2, 3])) == (Base.OneTo(3),)
+    @test IndexStyle(f([1, 2, 3])) == IndexLinear()
 
     w  = [1., 2., 3.]
     wv = f(w)


### PR DESCRIPTION
Since indexing into a weight vector in turn indexes into its vector of values, the optimal index style for a weight vector is the same as that of its values. Currently it uses the default `IndexCartesian` since no more specific `IndexStyle` method is defined.

Before this commit:
```julia
julia> eachindex(1:3, weights(1:3))
3-element CartesianIndices{1, Tuple{Base.OneTo{Int64}}}:
 CartesianIndex(1,)
 CartesianIndex(2,)
 CartesianIndex(3,)
 ```

After:
```julia
julia> eachindex(1:3, weights(1:3))
Base.OneTo(3)
```