### PR TITLE
Fix `countmap` with `-0.0`

### DIFF
--- a/src/counts.jl
+++ b/src/counts.jl
@@ -356,7 +356,7 @@ function _addcounts_radix_sort_loop!(cm::Dict{T}, sx::AbstractVector{T}) where T
     # adding into the Dict
     @inbounds for i in start_i+1:lastindex(sx)
         sxi = sx[i]
-        if last_sx != sxi
+        if !isequal(last_sx, sxi)
             cm[last_sx] = get(cm, last_sx, 0) + i - start_i
             last_sx = sxi
             start_i = i

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -106,8 +106,6 @@ end
     xx = repeat([6, 1, 3, 1], outer=100_000)
     cm = countmap(xx)
     @test cm == Dict(1 => 200_000, 3 => 100_000, 6 => 100_000)
-    @test countmap([0.0, -0.0, 0.0, -0.0, -0.0]) == Dict(0.0 => 2, -0.0 => 3)
-    @test countmap([NaN, NaN]) == Dict(NaN => 2)
 
     # with iterator
     cm_missing = countmap(skipmissing(xx))
@@ -174,6 +172,14 @@ end
         @test cm_tx_missing == countmap(tx) == Dict(typemin(T) => 1, typemax(T) => 1, 8 => 2, 19 => 1)
         @test cm_tx_missing isa Dict{T, Int}
     end
+
+    # -0.0 and NaN
+    @test countmap([0.0, -0.0, 0.0, -0.0, -0.0], alg=:dict) ==
+        countmap([0.0, -0.0, 0.0, -0.0, -0.0], alg=:radixsort) ==
+        Dict(0.0 => 2, -0.0 => 3)
+    @test countmap([NaN, NaN], alg=:dict) ==
+        countmap([NaN, NaN], alg=:radixsort) ==
+        Dict(NaN => 2)
 end
 
 @testset "views" begin

--- a/test/counts.jl
+++ b/test/counts.jl
@@ -106,6 +106,8 @@ end
     xx = repeat([6, 1, 3, 1], outer=100_000)
     cm = countmap(xx)
     @test cm == Dict(1 => 200_000, 3 => 100_000, 6 => 100_000)
+    @test countmap([0.0, -0.0, 0.0, -0.0, -0.0]) == Dict(0.0 => 2, -0.0 => 3)
+    @test countmap([NaN, NaN]) == Dict(NaN => 2)
 
     # with iterator
     cm_missing = countmap(skipmissing(xx))


### PR DESCRIPTION
Radix sort algorithm treated `-0.0` and `0.0` as equal, but the dict algorithm treated them as different.

Fixes https://github.com/JuliaStats/StatsBase.jl/issues/809.

It's not completely clear which behavior is best. In the PR I adopted the most obvious one, following dict behavior, as it was originally the only behavior and radix sort was supposed to be an implementation. But in practice radix sort is used for `Float32` and `Float64`, so it would be less disruptive to use its behavior everywhere (by converting `-0.0` to `0.0` during lookup). That would destroy information though, while this PR leaves users the choice of how to handle this.