### PR TITLE
Add mvue and mom estimators of N

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,7 +22,8 @@ makedocs(
              "multivariate.md",
              "misc.md",
              "statmodels.md",
-             "transformations.md"],
+             "transformations.md",
+             "nestimate.md"],
     strict=true,
     checkdocs=:exports
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ end
 
 
 ```@contents
-Pages = ["weights.md", "scalarstats.md", "robust.md", "deviation.md", "cov.md", "counts.md", "ranking.md", "sampling.md", "empirical.md", "signalcorr.md", "misc.md", "statmodels.md", "transformations.md"]
+Pages = ["weights.md", "scalarstats.md", "robust.md", "deviation.md", "cov.md", "counts.md", "ranking.md", "sampling.md", "empirical.md", "signalcorr.md", "misc.md", "statmodels.md", "transformations.md", "nestimate.md"]
 Depth = 2
 ```
 

--- a/docs/src/nestimate.md
+++ b/docs/src/nestimate.md
@@ -1,0 +1,6 @@
+# Estimate of N
+
+
+```@docs
+nestimate
+```

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -240,7 +240,10 @@ export
 
     # reliability
     CronbachAlpha,        # the type to represent Cronbach's alpha scores
-    cronbachalpha         # function to compute Cronbach's alpha scores
+    cronbachalpha,         # function to compute Cronbach's alpha scores
+
+    # nestimate: Minimum-variance unbiased and Method of Moments Estimatino (of N)
+    nestimate
 
 # source files
 
@@ -267,6 +270,8 @@ include("sampling.jl")
 include("statmodels.jl")
 
 include("transformations.jl")
+
+include("nestimate.jl")
 
 include("deprecates.jl")
 

--- a/src/nestimate.jl
+++ b/src/nestimate.jl
@@ -23,7 +23,7 @@ is the estimate of ``N`` where ``n`` is the sample size and  ``m`` is the sample
 If the method is selected as "mom" then the the estimate of ``N``is 
 
 ```math
-2 + \\bar{x} - 1
+2 * \\bar{x} - 1
 ```
 
 where ``\\bar{x}`` is the sample mean.

--- a/src/nestimate.jl
+++ b/src/nestimate.jl
@@ -10,7 +10,7 @@ end
 
 
 """
-    nestimate(x::AbstractArray; method = "mvue")
+    nestimate(x::AbstractVector; method = "mvue")
 
 Estimate ``N`` using an ``n`` sample of integer IDs. If the method is mvue 
 (Minimum-variance unbiased estimator) then 
@@ -28,7 +28,7 @@ If the method is selected as "mom" then the the estimate of ``N``is
 
 where ``\\bar{x}`` is the sample mean.
 
-* `x::AbstractArray`: Vector of samples. 
+* `x::AbstractVector`: Vector of samples. 
 * `method::String`: Either "mvue" or "mom". Default is "mvue".
 
 # Description 

--- a/src/nestimate.jl
+++ b/src/nestimate.jl
@@ -1,0 +1,51 @@
+function mvue(sampl::AbstractVector)::Float64
+    mx = maximum(sampl)
+    estimate = mx + mx / length(sampl) - 1.0
+    return estimate
+end 
+
+function mom(sampl::AbstractVector)::Float64
+    return 2.0 * mean(sampl) - 1.0
+end 
+
+
+"""
+    nestimate(x::AbstractArray; method = "mvue")
+
+Estimate ``N`` using an ``n`` sample of integer IDs. If the method is mvue 
+(Minimum-variance unbiased estimator) then 
+
+```math
+m + \\frac{m}{n} - 1
+```
+
+is the estimate of ``N`` where ``n`` is the sample size and  ``m`` is the sample maximum. 
+If the method is selected as "mom" then the the estimate of ``N``is 
+
+```math
+2 + \\bar{x} - 1
+```
+
+where ``\\bar{x}`` is the sample mean.
+
+* `x::AbstractArray`: Vector of samples. 
+* `method::String`: Either "mvue" or "mom". Default is "mvue".
+
+# Description 
+
+The problem is well-known as the German Tank problem, which is basically a special 
+example of the problem of estimating ``N`` using a sample. 
+
+# References: 
+- https://en.wikipedia.org/wiki/German_tank_problem
+
+"""
+function nestimate(sampl::AbstractVector; method = "mvue")::Float64
+    if method == "mvue"
+        return mvue(sampl)
+    elseif method == "mom"
+        return mom(sampl)
+    else
+        throw(ArgumentError("Unknown method: $method"))
+    end
+end

--- a/src/nestimate.jl
+++ b/src/nestimate.jl
@@ -1,16 +1,6 @@
-function mvue(sampl::AbstractVector)::Float64
-    mx = maximum(sampl)
-    estimate = mx + mx / length(sampl) - 1.0
-    return estimate
-end 
-
-function mom(sampl::AbstractVector)::Float64
-    return 2.0 * mean(sampl) - 1.0
-end 
-
 
 """
-    nestimate(x::AbstractVector; method = "mvue")
+    nestimate(x::AbstractArray; method = "mvue")
 
 Estimate ``N`` using an ``n`` sample of integer IDs. If the method is mvue 
 (Minimum-variance unbiased estimator) then 
@@ -28,7 +18,7 @@ If the method is selected as "mom" then the the estimate of ``N``is
 
 where ``\\bar{x}`` is the sample mean.
 
-* `x::AbstractVector`: Vector of samples. 
+* `x::AbstractArray`: Vector of samples. 
 * `method::String`: Either "mvue" or "mom". Default is "mvue".
 
 # Description 
@@ -40,7 +30,18 @@ example of the problem of estimating ``N`` using a sample.
 - https://en.wikipedia.org/wiki/German_tank_problem
 
 """
-function nestimate(sampl::AbstractVector; method = "mvue")::Float64
+function nestimate(sampl::AbstractArray; method = "mvue")::Float64
+    
+    function mvue(sampl::AbstractArray)::Float64
+        mx = maximum(sampl)
+        estimate = mx + mx / length(sampl) - 1.0
+        return estimate
+    end 
+
+    function mom(sampl::AbstractArray)::Float64
+        return 2.0 * mean(sampl) - 1.0
+    end 
+   
     if method == "mvue"
         return mvue(sampl)
     elseif method == "mom"

--- a/test/nestimate.jl
+++ b/test/nestimate.jl
@@ -1,0 +1,21 @@
+using StatsBase 
+using Test 
+
+@testset "nestimate (MVUE and MOM estimators)" begin 
+    @testset "mvue: Minimum-variance unbiased istimator (of N)" begin 
+        vect = [19, 40, 42, 60]
+        result = nestimate(vect)
+
+        @test result == nestimate(vect, method = "mvue")
+        @test result isa Float64
+        @test result == 74 
+    end 
+
+    @testset "Method of moments (mom) estimate of N" begin 
+        vect = [19, 40, 42, 60]
+        result = nestimate(vect, method = "mom")
+
+        @test result isa Float64 
+        @test result == 79.5
+    end  
+end 

--- a/test/nestimate.jl
+++ b/test/nestimate.jl
@@ -18,4 +18,13 @@ using Test
         @test result isa Float64 
         @test result == 79.5
     end  
+
+    @testset "Unknown method" begin 
+        vect = [19, 40, 42, 60]
+        try
+            result = nestimate(vect, method = "wrongmethodname")
+        catch e 
+            @test e isa ArgumentError
+        end
+    end 
 end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,13 +23,13 @@ tests = ["ambiguous",
          "wsampling",
          "statmodels",
          "partialcor",
-         "mvue",
+         "nestimate",
          "transformations"]
          #"statquiz"]
 
 println("Running tests:")
 
-tests = ["nestimate"]
+
 for t in tests
     tfile = string(t, ".jl")
     println(" * $(tfile) ...")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,11 +23,13 @@ tests = ["ambiguous",
          "wsampling",
          "statmodels",
          "partialcor",
+         "mvue",
          "transformations"]
          #"statquiz"]
 
 println("Running tests:")
 
+tests = ["nestimate"]
 for t in tests
     tfile = string(t, ".jl")
     println(" * $(tfile) ...")


### PR DESCRIPTION
This PR implements two methods for estimating $N$ using a sample of integer IDs:

- Minimum-variance unbiased estimator (mvue)
- Methods of moments estimator (mom)

using a simple dispatcher function `nestimate()`.

The problem of estimating $N$ has a famous and well-known use case, the German Tank Problem, is also referenced in the doc string of the method.

Basic tests are added. 

Functions for confidence intervals are not yet implemented. 

In my opinion, it would be nice to see these basic functions in StatsBase as they are the basics of their family of estimators. 

I am so sorry If I am bothering the development team or doing something inconvenient.

Thank you in advance.  