### PR TITLE
Fix `mean_and_var` and `mean_and_std` docstring signature

### DIFF
--- a/src/moments.jl
+++ b/src/moments.jl
@@ -90,7 +90,7 @@ std(v::RealArray, w::AbstractWeights, dim::Int;
 
 ##### Fused statistics
 """
-    mean_and_var(x, [w::AbstractWeights], [dim]; corrected=false) -> (mean, var)
+    mean_and_var(x, [w::AbstractWeights], [dim]; corrected=true) -> (mean, var)
 
 Return the mean and variance of collection `x`. If `x` is an `AbstractArray`,
 `dim` can be specified as a tuple to compute statistics over these dimensions.

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -105,7 +105,7 @@ function mean_and_var(x; corrected::Bool=true)
 end
 
 """
-    mean_and_std(x, [w::AbstractWeights], [dim]; corrected=false) -> (mean, std)
+    mean_and_std(x, [w::AbstractWeights], [dim]; corrected=true) -> (mean, std)
 
 Return the mean and standard deviation of collection `x`. If `x` is an `AbstractArray`,
 `dim` can be specified as a tuple to compute statistics over these dimensions.


### PR DESCRIPTION
The default value for the argument `corrected` in the docstring signature of `mean_and_var` and `mean_and_std` is `false`, but it is actually `true` in the code.

https://github.com/JuliaStats/StatsBase.jl/blob/a0e6f1e807a84a09b5f74431bb0099f4aaed5ae0/src/moments.jl#L153-L165
https://github.com/JuliaStats/StatsBase.jl/blob/a0e6f1e807a84a09b5f74431bb0099f4aaed5ae0/src/moments.jl#L167-L180