### PR TITLE
Fix tests on Julia nightly

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"

--- a/test/scalarstats.jl
+++ b/test/scalarstats.jl
@@ -201,8 +201,8 @@ x = sort!(vcat([5:-1:i for i in 1:5]...))
 @test @inferred(isnan(sem(Int[], ProbabilityWeights(Int[]); mean=0f0)))
 
 @test @inferred(isnan(sem(skipmissing(Union{Int,Missing}[missing, missing]))))
-@test_throws MethodError sem(Any[])
-@test_throws MethodError sem(skipmissing([missing]))
+@test_throws Exception sem(Any[])
+@test_throws Exception sem(skipmissing([missing]))
 
 @test mad(1:5; center=3, normalize=true) ≈ 1.4826022185056018
 @test mad(skipmissing([missing; 1:5; missing]); center=3, normalize=true) ≈ 1.4826022185056018
@@ -221,7 +221,14 @@ x = sort!(vcat([5:-1:i for i in 1:5]...))
 @test_throws ArgumentError mad(Int[], normalize = true)
 @test mad(Iterators.repeated(4, 10)) == 0
 @test mad(Integer[1,2,3,4]) === mad(1:4)
-@test (@benchmark mad((i for i in 1:10000))).allocs < 200
+let itr = (i for i in 1:10000)
+    if VERSION >= v"1.10.0-"
+        # FIXME: Allocations are closer to 10x this on 1.10
+        @test_broken (@benchmark mad($itr)).allocs < 200
+    else
+        @test (@benchmark mad($itr)).allocs < 200
+    end
+end
 
 # Issue 197
 @test mad(1:2, normalize=true) ≈ 0.7413011092528009


### PR DESCRIPTION
The tests for specific exception types in `sem` are relying on the exceptions thrown from deeper in the call stack, outside of this package's control. We do still expect these cases to throw, but since we can't actually control the type of the exception, we can instead test that any exception is thrown.

The test of the number of allocations from calling `mad` on a generator fails because there are nearly 10x more allocations than the upper bound used in the test. We can mark this test broken with Julia v1.10, and the test will fail if the allocations for this case are improved, be it upstream or in the implementation of `mad` (if applicable).