### PR TITLE
Fix `sample` with wide integer types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.34.0"
+version = "0.34.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -105,12 +105,12 @@ Draw a pair of distinct integers between 1 and `n` without replacement.
 Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).
 """
-function samplepair(rng::AbstractRNG, n::Int)
-    i1 = rand(rng, 1:n)
-    i2 = rand(rng, 1:n-1)
+function samplepair(rng::AbstractRNG, n::Integer)
+    i1 = rand(rng, Base.OneTo(n))
+    i2 = rand(rng, Base.OneTo(n - one(n)))
     return (i1, ifelse(i2 == i1, n, i2))
 end
-samplepair(n::Int) = samplepair(Random.GLOBAL_RNG, n)
+samplepair(n::Integer) = samplepair(Random.GLOBAL_RNG, n)
 
 """
     samplepair([rng], a)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -106,8 +106,8 @@ Optionally specify a random number generator `rng` as the first argument
 (defaults to `Random.GLOBAL_RNG`).
 """
 function samplepair(rng::AbstractRNG, n::Integer)
-    i1 = rand(rng, Base.OneTo(n))
-    i2 = rand(rng, Base.OneTo(n - one(n)))
+    i1 = rand(rng, one(n):n)
+    i2 = rand(rng, one(n):(n - one(n)))
     return (i1, ifelse(i2 == i1, n, i2))
 end
 samplepair(n::Integer) = samplepair(Random.GLOBAL_RNG, n)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -92,7 +92,9 @@ test_rng_use(sample, 1:10, 10)
     @test samplepair(rng, [3, 4, 2, 6, 8]) === (3, 8)
     @test samplepair(rng, [1, 2])          === (1, 2)
 
-    @test extrema(samplepair(rng, UInt128(2))) == UInt128.((1, 2))
+    onetwo = samplepair(rng, UInt128(2))
+    @test extrema(onetwo) == (1, 2)
+    @test eltype(onetwo) === UInt128
 end
 
 test_rng_use(samplepair, 1000)
@@ -273,9 +275,21 @@ end
     for T in [Int8, Int16, Int32, Int64, Int128, BigInt], f in [identity, unsigned]
         T == BigInt && f == unsigned && continue
         T = f(T)
-        samp = sample(T(1):T(10), T(2); replace=false, ordered=false)
-        @test all(x -> x isa T, samp)
-        @test all(x -> T(1) <= x <= T(10), samp)
-        @test length(samp) == 2
+        # The type of the second argument should not affect the return type
+        let samp = sample(T(1):T(10), T(2); replace=false, ordered=false)
+            @test all(x -> x isa T, samp)
+            @test all(x -> T(1) <= x <= T(10), samp)
+            @test length(samp) == 2
+        end
+        let samp = sample(T(1):T(10), 2; replace=false, ordered=false)
+            @test all(x -> x isa T, samp)
+            @test all(x -> T(1) <= x <= T(10), samp)
+            @test length(samp) == 2
+        end
+        let samp = sample(1:10, T(2); replace=false, ordered=false)
+            @test all(x -> x isa Int, samp)
+            @test all(x -> 1 <= x <= 10, samp)
+            @test length(samp) == 2
+        end
     end
 end

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -91,6 +91,8 @@ test_rng_use(sample, 1:10, 10)
 
     @test samplepair(rng, [3, 4, 2, 6, 8]) === (3, 8)
     @test samplepair(rng, [1, 2])          === (1, 2)
+
+    @test extrema(samplepair(rng, UInt128(2))) == UInt128.((1, 2))
 end
 
 test_rng_use(samplepair, 1000)
@@ -264,5 +266,16 @@ test_same(replace=false, ordered=false)
         @test_throws ArgumentError f(view(x, 2:4), view(x, 3:5))
         # This corner case should succeed
         f(view(x, 2:4), view(x, 5:6))
+    end
+end
+
+@testset "issue #872" begin
+    for T in [Int8, Int16, Int32, Int64, Int128, BigInt], f in [identity, unsigned]
+        T == BigInt && f == unsigned && continue
+        T = f(T)
+        samp = sample(T(1):T(10), T(2); replace=false, ordered=false)
+        @test all(x -> x isa T, samp)
+        @test all(x -> T(1) <= x <= T(10), samp)
+        @test length(samp) == 2
     end
 end


### PR DESCRIPTION
As observed in #872, an unordered sample without replacement with a type 64 bits or wider (notably excluding `Int64`, at least on a 64-bit system) hits a `MethodError` in `samplepair`, which had been restricted to `Int` inputs. Relaxing this restriction and adjusting the `samplepair` implementation accordingly allows these cases to succeed.

Fixes #872.