### PR TITLE
Temporarily deploy docs with Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: nightly  # needed until https://github.com/JuliaLang/julia/issues/49620 is in a release
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:


### PR DESCRIPTION
The documentation builds on CI are currently failing due to https://github.com/JuliaLang/julia/issues/49620. That issue has been fixed upstream but the change has not been backported to any current releases, so documentation deployment is still affected with anything prior to Julia v1.10.0-DEV.1229. We may still experience issues due to the inherent instability of nightly but that's better than not being able to build docs at all.

~~While touching the GitHub Actions setup, I also bumped the versions of a couple of the actions we're using.~~ Dropped that commit and rebased on master now that #875 has been merged.