### PR TITLE
Make SparseArrays.jl a weak dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,12 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
+[weakdeps]
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[extensions]
+StatsBaseSparseArraysExt = "SparseArrays"
+
 [compat]
 DataAPI = "1"
 DataStructures = "0.10, 0.11, 0.12, 0.13, 0.14, 0.17, 0.18"
@@ -30,8 +36,9 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BenchmarkTools", "Dates", "DelimitedFiles", "OffsetArrays", "StableRNGs", "Test"]
+test = ["BenchmarkTools", "Dates", "DelimitedFiles", "OffsetArrays", "SparseArrays", "StableRNGs", "Test"]

--- a/ext/StatsBaseSparseArraysExt.jl
+++ b/ext/StatsBaseSparseArraysExt.jl
@@ -1,0 +1,21 @@
+module StatsBaseSparseArraysExt
+
+using SparseArrays
+using StatsBase
+import StatsBase: _indicatormat_sparse
+
+_indicatormat_sparse(x::AbstractArray{<:Integer}, k::Integer) = (n = length(x); sparse(x, 1:n, true, k, n))
+
+function _indicatormat_sparse(x::AbstractArray{T}, c::AbstractArray{T}) where T
+    d = indexmap(c)
+    m = length(c)
+    n = length(x)
+
+    rinds = Vector{Int}(undef, n)
+    @inbounds for i = 1 : n
+        rinds[i] = d[x[i]]
+    end
+    return sparse(rinds, 1:n, true, m, n)
+end
+
+end # module

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -14,7 +14,6 @@ using Statistics
 using LinearAlgebra
 using Random
 using Printf
-using SparseArrays
 import Random: rand, rand!
 import LinearAlgebra: BlasReal, BlasFloat
 import Statistics: mean, mean!, var, varm, varm!, std, stdm, cov, covm,
@@ -269,5 +268,9 @@ include("statmodels.jl")
 include("transformations.jl")
 
 include("deprecates.jl")
+
+@static if !isdefined(Base, :get_extension)
+    include("../ext/StatsBaseSparseArraysExt.jl")
+end
 
 end # module

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -138,6 +138,7 @@ function indicatormat(x::AbstractArray{<:Integer}, k::Integer; sparse::Bool=fals
     sparse ? _indicatormat_sparse(x, k) : _indicatormat_dense(x, k)
 end
 
+function _indicatormat_sparse end
 
 """
     indicatormat(x, c=sort(unique(x)); sparse=false)
@@ -175,18 +176,4 @@ function _indicatormat_dense(x::AbstractArray{T}, c::AbstractArray{T}) where T
         o += m
     end
     return r
-end
-
-_indicatormat_sparse(x::AbstractArray{<:Integer}, k::Integer) = (n = length(x); sparse(x, 1:n, true, k, n))
-
-function _indicatormat_sparse(x::AbstractArray{T}, c::AbstractArray{T}) where T
-    d = indexmap(c)
-    m = length(c)
-    n = length(x)
-
-    rinds = Vector{Int}(undef, n)
-    @inbounds for i = 1 : n
-        rinds[i] = d[x[i]]
-    end
-    return sparse(rinds, 1:n, true, m, n)
 end

--- a/test/rankcorr.jl
+++ b/test/rankcorr.jl
@@ -152,10 +152,10 @@ end
 @test_throws DimensionMismatch corspearman([1], [1, 2])
 @test_throws DimensionMismatch corspearman([1], [1 2; 3 4])
 @test_throws DimensionMismatch corspearman([1 2; 3 4], [1])
-@test_throws ArgumentError corspearman([1 2; 3 4: 4 6], [1 2; 3 4])
+@test_throws DimensionMismatch corspearman([1 2; 3 4: 4 6], [1 2; 3 4])
 
 # TODO: fix corkendall to match corspearman (PR#659)
 @test_throws ErrorException corkendall([1], [1, 2])
 @test_throws ErrorException corkendall([1], [1 2; 3 4])
 @test_throws ErrorException corkendall([1 2; 3 4], [1])
-@test_throws ArgumentError corkendall([1 2; 3 4: 4 6], [1 2; 3 4])
+@test_throws DimensionMismatch corkendall([1 2; 3 4: 4 6], [1 2; 3 4])

--- a/test/rankcorr.jl
+++ b/test/rankcorr.jl
@@ -152,10 +152,10 @@ end
 @test_throws DimensionMismatch corspearman([1], [1, 2])
 @test_throws DimensionMismatch corspearman([1], [1 2; 3 4])
 @test_throws DimensionMismatch corspearman([1 2; 3 4], [1])
-@test_throws DimensionMismatch corspearman([1 2; 3 4: 4 6], [1 2; 3 4])
+@test_throws (VERSION < v"1.10-" ?  ArgumentError : DimensionMismatch) corspearman([1 2; 3 4: 4 6], [1 2; 3 4])
 
 # TODO: fix corkendall to match corspearman (PR#659)
 @test_throws ErrorException corkendall([1], [1, 2])
 @test_throws ErrorException corkendall([1], [1 2; 3 4])
 @test_throws ErrorException corkendall([1 2; 3 4], [1])
-@test_throws DimensionMismatch corkendall([1 2; 3 4: 4 6], [1 2; 3 4])
+@test_throws (VERSION < v"1.10-" ?  ArgumentError : DimensionMismatch) corkendall([1 2; 3 4: 4 6], [1 2; 3 4])


### PR DESCRIPTION
This is a little weird: one could get a sparse matrix just by using a specific keyword argument, without ever calling or loading SparseArrays.jl. So I'm not sure to which extent this might be considered breaking. In terms of future perspective, this is very desirable for downstream packages to not load SparseArrays.jl unconditionally, especially on v1.10+.