### PR TITLE
Implement `Base.allequal` and `Base.allunique` for weight vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.34.1"
+version = "0.34.2"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -28,12 +28,6 @@ isempty(wv::AbstractWeights) = isempty(wv.values)
 size(wv::AbstractWeights) = size(wv.values)
 Base.axes(wv::AbstractWeights) = Base.axes(wv.values)
 
-# https://github.com/JuliaLang/julia/pull/43354
-if VERSION >= v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
-    Base.allequal(wv::AbstractWeights) = allequal(wv.values)
-end
-Base.allunique(wv::AbstractWeights) = allunique(wv.values)
-
 Base.IndexStyle(::Type{<:AbstractWeights{S,T,V}}) where {S,T,V} = IndexStyle(V)
 
 Base.dataids(wv::AbstractWeights) = Base.dataids(wv.values)
@@ -319,12 +313,6 @@ length(wv::UnitWeights) = wv.len
 size(wv::UnitWeights) = tuple(length(wv))
 Base.axes(wv::UnitWeights) = tuple(Base.OneTo(length(wv)))
 
-# https://github.com/JuliaLang/julia/pull/43354
-if VERSION >= v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
-    Base.allequal(::UnitWeights) = true
-end
-Base.allunique(wv::UnitWeights) = length(wv) <= 1
-
 Base.dataids(::UnitWeights) = ()
 Base.convert(::Type{Vector}, wv::UnitWeights{T}) where {T} = ones(T, length(wv))
 
@@ -396,6 +384,14 @@ Base.:(==)(x::UnitWeights, y::UnitWeights)   = (x.len == y.len)
 
 Base.isequal(x::AbstractWeights, y::AbstractWeights) = false
 Base.:(==)(x::AbstractWeights, y::AbstractWeights)   = false
+
+# https://github.com/JuliaLang/julia/pull/43354
+if VERSION >= v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
+    Base.allequal(wv::AbstractWeights) = allequal(wv.values)
+    Base.allequal(::UnitWeights) = true
+end
+Base.allunique(wv::AbstractWeights) = allunique(wv.values)
+Base.allunique(wv::UnitWeights) = length(wv) <= 1
 
 ##### Weighted sum #####
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -28,6 +28,12 @@ isempty(wv::AbstractWeights) = isempty(wv.values)
 size(wv::AbstractWeights) = size(wv.values)
 Base.axes(wv::AbstractWeights) = Base.axes(wv.values)
 
+# https://github.com/JuliaLang/julia/pull/43354
+if VERSION >= v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
+    Base.allequal(wv::AbstractWeights) = allequal(wv.values)
+end
+Base.allunique(wv::AbstractWeights) = allunique(wv.values)
+
 Base.IndexStyle(::Type{<:AbstractWeights{S,T,V}}) where {S,T,V} = IndexStyle(V)
 
 Base.dataids(wv::AbstractWeights) = Base.dataids(wv.values)
@@ -312,6 +318,12 @@ isempty(wv::UnitWeights) = iszero(wv.len)
 length(wv::UnitWeights) = wv.len
 size(wv::UnitWeights) = tuple(length(wv))
 Base.axes(wv::UnitWeights) = tuple(Base.OneTo(length(wv)))
+
+# https://github.com/JuliaLang/julia/pull/43354
+if VERSION >= v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
+    Base.allequal(::UnitWeights) = true
+end
+Base.allunique(wv::UnitWeights) = length(wv) <= 1
 
 Base.dataids(::UnitWeights) = ()
 Base.convert(::Type{Vector}, wv::UnitWeights{T}) where {T} = ones(T, length(wv))

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -574,4 +574,40 @@ end
     end
 end
 
+@testset "allequal and allunique" begin
+    # General weights
+    for f in (weights, aweights, fweights, pweights)
+        @test allunique(f(Float64[]))
+        @test allunique(f([0.4]))
+        @test allunique(f([0.4, 0.3]))
+        @test !allunique(f([0.4, 0.4]))
+        @test allunique(f([0.4, 0.3, 0.5]))
+        @test !allunique(f([0.4, 0.4, 0.5]))
+        @test allunique(f([0.4, 0.3, 0.5, 0.35]))
+        @test !allunique(f([0.4, 0.3, 0.5, 0.4]))
+
+        if isdefined(Base, :allequal)
+            @test allequal(f(Float64[]))
+            @test allequal(f([0.4]))
+            @test allequal(f([0.4, 0.4]))
+            @test !allequal(f([0.4, 0.3]))
+            @test allequal(f([0.4, 0.4, 0.4, 0.4]))
+            @test !allunique(f([0.4, 0.4, 0.3, 0.4]))
+        end
+    end
+
+    # Uniform weights
+    @test allunique(uweights(0))
+    @test allunique(uweights(1))
+    @test !allunique(uweights(2))
+    @test !allunique(uweights(5))
+
+    if isdefined(Base, :allequal)
+        @test allequal(uweights(0))
+        @test allequal(uweights(1))
+        @test allequal(uweights(2))
+        @test allequal(uweights(5))
+    end
+end
+
 end # @testset StatsBase.Weights


### PR DESCRIPTION
In this PR I propose to define `allequal` and `allunique` for weight vectors by falling back on `allequal(weights.values)` and `allunique(weights.values)` (this means optimizations for types of `weights.values` will be exploited instead of falling back to the generic iterative algorithm) and implement the optimizations for `UnitWeights`.

In a project I wanted to check `allequal(weights)` to avoid an expensive computation for this special case. However, to make this performant for `UnitWeights` currently I have to write `weights isa UnitWeights || allequal(weights)`.