### PR TITLE
Fix test errors on Julia nightly

### DIFF
--- a/test/rankcorr.jl
+++ b/test/rankcorr.jl
@@ -152,10 +152,10 @@ end
 @test_throws DimensionMismatch corspearman([1], [1, 2])
 @test_throws DimensionMismatch corspearman([1], [1 2; 3 4])
 @test_throws DimensionMismatch corspearman([1 2; 3 4], [1])
-@test_throws ArgumentError corspearman([1 2; 3 4: 4 6], [1 2; 3 4])
+@test_throws ArgumentError corspearman([1 2; 3 4; 4 6], [1 2; 3 4])
 
 # TODO: fix corkendall to match corspearman (PR#659)
 @test_throws ErrorException corkendall([1], [1, 2])
 @test_throws ErrorException corkendall([1], [1 2; 3 4])
 @test_throws ErrorException corkendall([1 2; 3 4], [1])
-@test_throws ArgumentError corkendall([1 2; 3 4: 4 6], [1 2; 3 4])
+@test_throws ErrorException corkendall([1 2; 3 4; 4 6], [1 2; 3 4])


### PR DESCRIPTION
This PR fixes the test error on Julia nightly that I observed in #894. It's quite interesting: the tests fail because the error type of the modified `@test_throws` tests is different on nightly - but that's unrelated to StatsBase internals and caused by the construction of the matrix-valued arguments to the tested function calls. On Julia 1.9, we have
```julia
julia> [1 2; 3 4: 4 6]
ERROR: ArgumentError: number of columns of each array must match (got (2, 3))
Stacktrace:
 [1] _typed_vcat(#unused#::Type{Int64}, A::Tuple{Matrix{Int64}, Matrix{Int64}})
   @ Base ./abstractarray.jl:1689
 [2] typed_vcat(::Type{Int64}, ::Matrix{Int64}, ::Matrix{Int64})
   @ Base ./abstractarray.jl:1703
 [3] typed_hvcat(::Type{Int64}, ::Tuple{Int64, Int64}, ::Int64, ::Vararg{Any})
   @ Base ./abstractarray.jl:2168
 [4] hvcat(::Tuple{Int64, Int64}, ::Int64, ::Vararg{Union{Number, AbstractVecOrMat}})
   @ Base ./abstractarray.jl:2147
 [5] top-level scope
   @ REPL[9]:1
```
whereas on e.g. Julia 1.10 (beta2) we have
```julia
julia> [1 2; 3 4: 4 6]
ERROR: DimensionMismatch: number of columns of each array must match (got (2, 3))
Stacktrace:
 [1] _typed_vcat(::Type{Int64}, A::Tuple{Matrix{Int64}, Matrix{Int64}})
   @ Base ./abstractarray.jl:1689
 [2] typed_vcat(::Type{Int64}, ::Matrix{Int64}, ::Matrix{Int64})
   @ Base ./abstractarray.jl:1703
 [3] typed_hvcat(::Type{Int64}, ::Tuple{Int64, Int64}, ::Int64, ::Vararg{Any})
   @ Base ./abstractarray.jl:2166
 [4] hvcat(::Tuple{Int64, Int64}, ::Int64, ::Vararg{Union{Number, AbstractVecOrMat{<:Number}}})
   @ SparseArrays ~/.asdf/installs/julia/1.10.0-beta2/share/julia/stdlib/v1.10/SparseArrays/src/sparsevector.jl:1239
 [5] top-level scope
   @ REPL[8]:1
```

I assume it's simply a typo in our tests and it was always the intention to rather test the errors thrown by StatsBase instead of Base. It seems the tests were added in https://github.com/JuliaStats/StatsBase.jl/pull/659 originally.