### PR TITLE
allow `transform` to avoid Z-score transforming when `sigma=0`

### DIFF
--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -123,9 +123,21 @@ function fit(::Type{ZScoreTransform}, X::AbstractMatrix{<:Real};
     else
         throw(DomainError(dims, "fit only accept dims to be 1 or 2."))
     end
-    return ZScoreTransform(l, dims, (center ? vec(m) : similar(m, 0)),
-                                    (scale ? vec(s) : similar(s, 0)))
+    if scale
+        s_vec = vec(s)
+        # avoid z-score transforming when sigma=0
+        if any(s_vec .== 0.0)
+            zero_variance_indices = s_vec .== 0.0
+            s_vec[zero_variance_indices] .= 1.0
+        end
+    else
+        s_vec = similar(s, 0)
+    end
+
+    return ZScoreTransform(l, dims, (center ? vec(m) : similar(m, 0)), s_vec)
 end
+
+
 
 function fit(::Type{ZScoreTransform}, X::AbstractVector{<:Real};
              dims::Integer=1, center::Bool=true, scale::Bool=true)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -137,8 +137,6 @@ function fit(::Type{ZScoreTransform}, X::AbstractMatrix{<:Real};
     return ZScoreTransform(l, dims, (center ? vec(m) : similar(m, 0)), s_vec)
 end
 
-
-
 function fit(::Type{ZScoreTransform}, X::AbstractVector{<:Real};
              dims::Integer=1, center::Bool=true, scale::Bool=true)
     if dims != 1

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -70,6 +70,20 @@ using Test
     @test reconstruct!(t, Y) === Y
     @test Y ≈ X_
 
+    # zero standard deviations
+    X = ones(5, 8)
+    t = fit(ZScoreTransform, X, dims=2)
+    Y = transform(t, X)
+    @test length(t.mean) == 5
+    @test length(t.scale) == 5
+    @test Y ≈ zeros(5, 8)
+    @test reconstruct(t, Y) ≈ X
+    @test Y ≈ standardize(ZScoreTransform, X, dims=2)
+    @test transform!(t, X) === X
+    @test isequal(X, Y)
+    @test reconstruct!(t, Y) === Y
+    @test Y ≈ ones(5, 8)
+
     X = copy(X_)
     t = fit(UnitRangeTransform, X, dims=1, unit=false)
     Y = transform(t, X)


### PR DESCRIPTION
Ref: https://github.com/JuliaStats/StatsBase.jl/issues/910

Here is my attempt to prevent NaNs when transforming data with 0 variance.

Here is the result:

```julia
julia> X = ones(5,8)
5×8 Matrix{Float64}:
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0

julia> feature_transform = fit(ZScoreTransform, X, dims=1)
ZScoreTransform{Float64, Vector{Float64}}(8, 1, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])

julia> StatsBase.transform(feature_transform, X)
5×8 Matrix{Float64}:
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
```