### PR TITLE
Faster algorithm for ordered sampling with replacement

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -522,10 +522,10 @@ function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
 
     if replace  # with replacement
         if ordered
-            if k < 10
-                sample_ordered!(direct_sample!, rng, a, x)
-            else
+            if k > 10
                 uniform_orderstat_sample!(rng, a, x)
+            else
+                sample_ordered!(direct_sample!, rng, a, x)
             end
         else
             direct_sample!(rng, a, x)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -525,7 +525,7 @@ function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
             if k <= 10
                 sample_ordered!(direct_sample!, rng, a, x)
             else
-                uniform_orderdist_sample!(rng, a, x)
+                uniform_orderstat_sample!(rng, a, x)
             end        
         else
             direct_sample!(rng, a, x)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -522,11 +522,7 @@ function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
 
     if replace  # with replacement
         if ordered
-            if k > 10
-                uniform_orderstat_sample!(rng, a, x)
-            else
-                sample_ordered!(direct_sample!, rng, a, x)
-            end
+            uniform_orderstat_sample!(rng, a, x)
         else
             direct_sample!(rng, a, x)
         end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -522,7 +522,11 @@ function sample!(rng::AbstractRNG, a::AbstractArray, x::AbstractArray;
 
     if replace  # with replacement
         if ordered
-            uniform_orderstat_sample!(rng, a, x)
+            if k <= 10
+                sample_ordered!(direct_sample!, rng, a, x)
+            else
+                uniform_orderdist_sample!(rng, a, x)
+            end        
         else
             direct_sample!(rng, a, x)
         end

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -74,15 +74,16 @@ test_rng_use(direct_sample!, 1:10, zeros(Int, 6))
 a = sample(3:12, n)
 check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 
+rng = StableRNG(1)
 for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
     r = rev ? reverse(3:12) : (3:12)
     r = T===Int ? r : T.(r)
-    aa = Int.(sample(r, n; ordered=true))
+    aa = Int.(sample(rng, r, n; ordered=true))
     check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=true, rev=rev)
 
     aa = Int[]
     for i in 1:Int(n/10)
-        bb = Int.(sample(r, 10; ordered=true))
+        bb = Int.(sample(rng, r, 10; ordered=true))
         append!(aa, bb)
     end
     check_sample_wrep(sort!(aa, rev=rev), (3, 12), 5.0e-3; ordered=true, rev=rev)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -85,7 +85,7 @@ for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64
         bb = Int.(sample(r, 10; ordered=true))
         append!(aa, bb)
     end
-    check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=false, rev=rev)
+    check_sample_wrep(sort!(aa), (3, 12), 5.0e-3; ordered=true, rev=rev)
 end
 
 @test StatsBase._storeindices(1, 1, BigFloat) == StatsBase._storeindices(1, 1, BigFloat) == false

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -85,7 +85,7 @@ for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64
         bb = Int.(sample(r, 10; ordered=true))
         append!(aa, bb)
     end
-    check_sample_wrep(sort!(aa), (3, 12), 5.0e-3; ordered=true, rev=rev)
+    check_sample_wrep(sort!(aa, rev=rev), (3, 12), 5.0e-3; ordered=true, rev=rev)
 end
 
 @test StatsBase._storeindices(1, 1, BigFloat) == StatsBase._storeindices(1, 1, BigFloat) == false

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -77,11 +77,11 @@ check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
     r = rev ? reverse(3:12) : (3:12)
     r = T===Int ? r : T.(r)
-    aa = Int.(sample(r, n; ordered=true))
-    check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=true, rev=rev)
-
     aa = Int.(sample(r, 10; ordered=true))
     check_sample_wrep(aa, (3, 12), 0; ordered=true, rev=rev)
+    
+    aa = Int.(sample(r, n; ordered=true))
+    check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=true, rev=rev)
 end
 
 @test StatsBase._storeindices(1, 1, BigFloat) == StatsBase._storeindices(1, 1, BigFloat) == false

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -77,11 +77,15 @@ check_sample_wrep(a, (3, 12), 5.0e-3; ordered=false)
 for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
     r = rev ? reverse(3:12) : (3:12)
     r = T===Int ? r : T.(r)
-    aa = Int.(sample(r, 10; ordered=true))
-    check_sample_wrep(aa, (3, 12), 0; ordered=true, rev=rev)
-    
     aa = Int.(sample(r, n; ordered=true))
     check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=true, rev=rev)
+
+    aa = Int[]
+    for i in 1:Int(n/10)
+        bb = Int.(sample(r, 10; ordered=true))
+        append!(aa, bb)
+    end
+    check_sample_wrep(aa, (3, 12), 5.0e-3; ordered=false, rev=rev)
 end
 
 @test StatsBase._storeindices(1, 1, BigFloat) == StatsBase._storeindices(1, 1, BigFloat) == false


### PR DESCRIPTION
This is based on a classical result for example described here https://stats.stackexchange.com/questions/348358/a-fast-uniform-order-statistic-generator (and in the reference of the most upvoted answer). I wasn't able to find a reference describing its modification for sampling a finite population, but I adapted it to such a case.

In particular, the performance increase is substantial, more than 5 times faster when the performance increase stabilize, e.g.

This PR:

```julia
julia> using StatsBase, BenchmarkTools

julia> a = [1:1000;];

julia> @btime sample($a, 10^2, ordered=true);
  453.017 ns (2 allocations: 1.75 KiB)

julia> @btime sample($a, 10^6, ordered=true);
  3.491 ms (4 allocations: 15.26 MiB)
```

Main:

```julia
julia> using StatsBase, BenchmarkTools

julia> a = [1:1000;];

julia> @btime sample($a, 10^2, ordered=true);
  1.564 μs (2 allocations: 1.75 KiB)

julia> @btime sample($a, 10^6, ordered=true);
  21.273 ms (4 allocations: 15.26 MiB)
```

the switching point between this algorithm and the one implemented in main is set at `k=10` because I found that empirically at that point the timings were almost equal.

Numerically it should be stable enough, but let me know what you think


