### PR TITLE
functions that only support finite weights now throw errors for non-finites

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -729,7 +729,7 @@ function alias_sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, 
     # sampling
     s = Sampler(rng, 1:n)
     for i = 1:length(x)
-        j = rand(rng, wsum)
+        j = rand(rng, s)
         x[i] = rand(rng) < ap[j] ? a[j] : a[alias[j]]
     end
     return x

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -724,7 +724,7 @@ function alias_sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, 
     # create alias table
     ap = Vector{Float64}(undef, n)
     alias = Vector{Int}(undef, n)
-    make_alias_table!(wv, s, ap, alias)
+    make_alias_table!(wv, wsum, ap, alias)
 
     # sampling
     s = Sampler(rng, 1:n)
@@ -757,7 +757,7 @@ function naive_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
     1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
     wsum = sum(wv)
-    isfinite(s) || throw(ArgumentError("only finite weights are supported"))
+    isfinite(wsum) || throw(ArgumentError("only finite weights are supported"))
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
     k = length(x)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -590,6 +590,7 @@ Optionally specify a random number generator `rng` as the first argument
 function sample(rng::AbstractRNG, wv::AbstractWeights)
     1 == firstindex(wv) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     t = rand(rng) * sum(wv)
     n = length(wv)
     i = 1
@@ -714,6 +715,7 @@ function alias_sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, 
         throw(ArgumentError("output array x must not share memory with weights array wv"))
     1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
 
@@ -752,6 +754,7 @@ function naive_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
         throw(ArgumentError("output array x must not share memory with weights array wv"))
     1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
     k = length(x)
@@ -798,6 +801,7 @@ function efraimidis_a_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
         throw(ArgumentError("output array x must not share memory with weights array wv"))
     1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
@@ -839,6 +843,7 @@ function efraimidis_ares_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
         throw(ArgumentError("output array x must not share memory with weights array wv"))
     1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)
@@ -912,6 +917,7 @@ function efraimidis_aexpj_wsample_norep!(rng::AbstractRNG, a::AbstractArray,
         throw(ArgumentError("output array x must not share memory with weights array wv"))
     1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     n = length(a)
     length(wv) == n || throw(DimensionMismatch("a and wv must be of same length (got $n and $(length(wv)))."))
     k = length(x)

--- a/src/scalarstats.jl
+++ b/src/scalarstats.jl
@@ -163,6 +163,7 @@ end
 # Weighted mode of arbitrary vectors of values
 function mode(a::AbstractVector, wv::AbstractWeights{T}) where T <: Real
     isempty(a) && throw(ArgumentError("mode is not defined for empty collections"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     length(a) == length(wv) ||
         throw(ArgumentError("data and weight vectors must be the same size, got $(length(a)) and $(length(wv))"))
 
@@ -184,6 +185,7 @@ end
 
 function modes(a::AbstractVector, wv::AbstractWeights{T}) where T <: Real
     isempty(a) && throw(ArgumentError("mode is not defined for empty collections"))
+    isfinite(sum(wv)) || throw(ArgumentError("only finite weights are supported"))
     length(a) == length(wv) ||
         throw(ArgumentError("data and weight vectors must be the same size, got $(length(a)) and $(length(wv))"))
 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -716,6 +716,7 @@ function quantile(v::AbstractVector{<:Real}{V}, w::AbstractWeights{W}, p::Abstra
     # checks
     isempty(v) && throw(ArgumentError("quantile of an empty array is undefined"))
     isempty(p) && throw(ArgumentError("empty quantile array"))
+    isfinite(sum(w)) || throw(ArgumentError("only finite weights are supported"))
     all(x -> 0 <= x <= 1, p) || throw(ArgumentError("input probability out of [0,1] range"))
 
     w.sum == 0 && throw(ArgumentError("weight vector cannot sum to zero"))

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -1,6 +1,15 @@
 using StatsBase
 using LinearAlgebra, Random, SparseArrays, Test
 
+
+# minimal custom weights type for tests below
+struct MyWeights <: AbstractWeights{Float64, Float64, Vector{Float64}}
+    values::Vector{Float64}
+    sum::Float64
+end
+MyWeights(values) = MyWeights(values, sum(values))
+
+
 @testset "StatsBase.Weights" begin
 weight_funcs = (weights, aweights, fweights, pweights)
 
@@ -611,12 +620,6 @@ end
 end
 
 @testset "custom weight types" begin
-    struct MyWeights <: AbstractWeights{Float64, Float64, Vector{Float64}}
-        values::Vector{Float64}
-        sum::Float64
-    end
-    MyWeights(values) = MyWeights(values, sum(values))
-
     @test mean([1, 2, 3], MyWeights([1, 4, 10])) ≈ 2.6
     @test mean([1, 2, 3], MyWeights([NaN, 4, 10])) |> isnan
     @test mode([1, 2, 3], MyWeights([1, 4, 10])) == 3

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -610,4 +610,17 @@ end
     end
 end
 
+@testset "custom weight types" begin
+    struct MyWeights <: AbstractWeights{Float64, Float64, Vector{Float64}}
+        values::Vector{Float64}
+        sum::Float64
+    end
+    MyWeights(values) = MyWeights(values, sum(values))
+
+    @test mean([1, 2, 3], MyWeights([1, 4, 10])) ≈ 2.6
+    @test mean([1, 2, 3], MyWeights([NaN, 4, 10])) |> isnan
+    @test mode([1, 2, 3], MyWeights([1, 4, 10])) == 3
+    @test_throws ArgumentError mode([1, 2, 3], MyWeights([NaN, 4, 10]))
+end
+
 end # @testset StatsBase.Weights


### PR DESCRIPTION
AbstractWeights can contain any values, including NaNs – and many StatsBase functions work with them just fine. But not all, for some like `sample` it doesn't make sense. So, here I make these functions throw an exception instead of returning a potentially incorrect result.

Some docstrings, like the one for `quantile`, even explicitly say that

> An error is raised if `w` contains any `NaN` values.

but this wasn't the case without this PR.


Ideally, NaNs should also be supported by concrete weights types included into StatsBase (https://github.com/JuliaStats/StatsBase.jl/issues/904), but this PR is independent of that.