### PR TITLE
Raise `DimensionMismatch` if lengths don't match

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -59,7 +59,9 @@ run lengths.
 """
 function inverse_rle(vals::AbstractVector{T}, lens::AbstractVector{<:Integer}) where T
     m = length(vals)
-    length(lens) == m || raise_dimerror()
+    mlens = length(lens)
+    mlens == m || throw(DimensionMismatch(
+                        "number of vals ($m) does not match the number of lens ($mlens)"))
     n = sum(lens)
     n >= 0 || throw(ArgumentError("lengths must be non-negative"))
 

--- a/src/ranking.jl
+++ b/src/ranking.jl
@@ -8,7 +8,10 @@
 
 function _check_randparams(rks, x, p)
     n = length(rks)
-    length(x) == length(p) == n || raise_dimerror()
+    nx = length(x)
+    np = length(p)
+    nx == np == n || throw(
+        DimensionMismatch("lengths of x $nx and p $np do not match that of ranks $n"))
     return n
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -9,6 +9,7 @@ z = [1, 1, 2, 2, 2, 3, 1, 2, 2, 3, 3, 3, 3]
 @test lens == [2, 3, 1, 1, 2, 4]
 @test inverse_rle(vals, lens) == z
 @test_throws ArgumentError inverse_rle(vals, fill(-1, length(lens)))
+@test_throws DimensionMismatch inverse_rle(vals, [1])
 
 z = [true, true, false, false, true, false, true, true, true]
 vals, lens = rle(z)

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -37,3 +37,6 @@ s = ["c", "a", "b", "d", "d", "b", "e", "d"] # s is a vector of strings ordered 
 @test tiedrank(s) == tiedrank(x)
 @test tiedrank(x, rev = true) == tiedrank(-x)
 @test tiedrank(x, lt = (x, y) -> isless(y, x)) == tiedrank(-x)
+
+
+@test_throws DimensionMismatch StatsBase._check_randparams([1,2], [1,2], [1])


### PR DESCRIPTION
`raise_dimerror` was not defined, so the error path used to raise an `UndefVarError` on master. This fixes it to actually raise a `DimensionMismatch`