### PR TITLE
Use a faster and safer implementation of `alias_sample!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["JuliaStats"]
 version = "0.34.3"
 
 [deps]
+AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,6 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
+AliasTables = "1"
 DataAPI = "1"
 DataStructures = "0.10, 0.11, 0.12, 0.13, 0.14, 0.17, 0.18"
 LinearAlgebra = "<0.0.1, 1"

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -5,6 +5,7 @@
 #
 ###########################################################
 
+using AliasTables
 using Random: Sampler
 
 if VERSION < v"1.3.0-DEV.565"
@@ -704,29 +705,23 @@ Build an alias table, and sample therefrom.
 Reference: Walker, A. J. "An Efficient Method for Generating Discrete Random Variables
 with General Distributions." *ACM Transactions on Mathematical Software* 3 (3): 253, 1977.
 
-Noting `k=length(x)` and `n=length(a)`, this algorithm takes ``O(n \\log n)`` time
-for building the alias table, and then ``O(1)`` to draw each sample. It consumes ``2 k`` random numbers.
+Noting `k=length(x)` and `n=length(a)`, this algorithm takes ``O(n)`` time
+for building the alias table, and then ``O(1)`` to draw each sample. It consumes ``k`` random numbers.
 """
 function alias_sample!(rng::AbstractRNG, a::AbstractArray, wv::AbstractWeights, x::AbstractArray)
     Base.mightalias(a, x) &&
         throw(ArgumentError("output array x must not share memory with input array a"))
-    Base.mightalias(x, wv) &&
-        throw(ArgumentError("output array x must not share memory with weights array wv"))
-    1 == firstindex(a) == firstindex(wv) == firstindex(x) ||
+    1 == firstindex(a) == firstindex(wv) ||
         throw(ArgumentError("non 1-based arrays are not supported"))
-    n = length(a)
-    length(wv) == n || throw(DimensionMismatch("Inconsistent lengths."))
+    length(wv) == length(a) || throw(DimensionMismatch("Inconsistent lengths."))
 
     # create alias table
-    ap = Vector{Float64}(undef, n)
-    alias = Vector{Int}(undef, n)
-    make_alias_table!(wv, sum(wv), ap, alias)
+    at = AliasTable(wv)
 
     # sampling
-    s = Sampler(rng, 1:n)
-    for i = 1:length(x)
-        j = rand(rng, s)
-        x[i] = rand(rng) < ap[j] ? a[j] : a[alias[j]]
+    for i in eachindex(x)
+        j = rand(rng, at)
+        x[i] = a[j]
     end
     return x
 end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -636,65 +636,6 @@ end
 direct_sample!(a::AbstractArray, wv::AbstractWeights, x::AbstractArray) =
     direct_sample!(default_rng(), a, wv, x)
 
-function make_alias_table!(w::AbstractVector, wsum,
-                           a::AbstractVector{Float64},
-                           alias::AbstractVector{Int})
-    # Arguments:
-    #
-    #   w [in]:         input weights
-    #   wsum [in]:      pre-computed sum(w)
-    #
-    #   a [out]:        acceptance probabilities
-    #   alias [out]:    alias table
-    #
-    # Note: a and w can be the same array, then that array will be
-    #       overwritten inplace by acceptance probabilities
-    #
-    # Returns nothing
-    #
-
-    n = length(w)
-    length(a) == length(alias) == n ||
-        throw(DimensionMismatch("Inconsistent array lengths."))
-
-    ac = n / wsum
-    for i = 1:n
-        @inbounds a[i] = w[i] * ac
-    end
-
-    larges = Vector{Int}(undef, n)
-    smalls = Vector{Int}(undef, n)
-    kl = 0  # actual number of larges
-    ks = 0  # actual number of smalls
-
-    for i = 1:n
-        @inbounds ai = a[i]
-        if ai > 1.0
-            larges[kl+=1] = i  # push to larges
-        elseif ai < 1.0
-            smalls[ks+=1] = i  # push to smalls
-        end
-    end
-
-    while kl > 0 && ks > 0
-        s = smalls[ks]; ks -= 1  # pop from smalls
-        l = larges[kl]; kl -= 1  # pop from larges
-        @inbounds alias[s] = l
-        @inbounds al = a[l] = (a[l] - 1.0) + a[s]
-        if al > 1.0
-            larges[kl+=1] = l  # push to larges
-        else
-            smalls[ks+=1] = l  # push to smalls
-        end
-    end
-
-    # this loop should be redundant, except for rounding
-    for i = 1:ks
-        @inbounds a[smalls[i]] = 1.0
-    end
-    nothing
-end
-
 """
     alias_sample!([rng], a::AbstractArray, wv::AbstractWeights, x::AbstractArray)
 

--- a/test/wsampling.jl
+++ b/test/wsampling.jl
@@ -55,6 +55,9 @@ for wv in (
     check_wsample_wrep(a, (4, 7), wv, 5.0e-3; ordered=false)
 end
 
+@test_throws ArgumentError alias_sample!(rand(10), weights(fill(0, 10)), rand(10))
+@test_throws ArgumentError alias_sample!(rand(100), weights(randn(100)), rand(10))
+
 for rev in (true, false), T in (Int, Int16, Float64, Float16, BigInt, ComplexF64, Rational{Int})
     r = rev ? reverse(4:7) : (4:7)
     r = T===Int ? r : T.(r)


### PR DESCRIPTION
Safer:

Before

```julia
julia> StatsBase.alias_sample!(rand(10), weights(randn(10)), rand(10))
10-element Vector{Float64}:
 0.5676653052762575
 0.5676653052762575
 0.5676653052762575
 0.5676653052762575
 0.5676653052762575
 0.5676653052762575
 0.1984287484280587
 0.5676653052762575
 0.1984287484280587
 0.8567391687334422

julia> StatsBase.alias_sample!(rand(10), weights(fill(0, 10)), rand(10))
ERROR: BoundsError: attempt to access 10-element Vector{Float64} at index [281471800382896] # This came from reading undef memory
Stacktrace:
 [1] throw_boundserror(A::Vector{Float64}, I::Tuple{Int64})
   @ Base ./essentials.jl:14
 [2] getindex
   @ ./essentials.jl:891 [inlined]
 [3] alias_sample!(rng::TaskLocalRNG, a::Vector{Float64}, wv::Weights{Int64, Int64, Vector{Int64}}, x::Vector{Float64})
   @ StatsBase ~/.julia/packages/StatsBase/ebrT3/src/sampling.jl:729
 [4] top-level scope
   @ REPL[10]:1

julia> StatsBase.alias_sample!(rand(10), weights(fill(0, 10)), rand(10)) # Got "lucky" this time
10-element Vector{Float64}:
 0.07577419536126007
 0.9233876530591941
 0.1530016664475169
 0.07577419536126007
 0.07577419536126007
 0.3159766423652197
 0.1530016664475169
 0.6780730450968911
 0.01012788415877619
 0.6780730450968911
```

After

```julia
julia> StatsBase.alias_sample!(rand(10), weights(randn(10)), rand(10))
ERROR: ArgumentError: found negative weight -0.1164833812103052
Stacktrace:
 [1] checked_sum
   @ ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:437 [inlined]
 [2] AliasTables.AliasTable{UInt64, Int64}(weights::Weights{Float64, Float64, Vector{Float64}}; _normalize::Bool)
   @ AliasTables ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:81
 [3] AliasTable
   @ ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:78 [inlined]
 [4] AliasTable
   @ ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:76 [inlined]
 [5] alias_sample!(rng::TaskLocalRNG, a::Vector{Float64}, wv::Weights{Float64, Float64, Vector{Float64}}, x::Vector{Float64})
   @ StatsBase ~/.julia/dev/StatsBase/src/sampling.jl:719
 [6] top-level scope
   @ REPL[33]:1

julia> StatsBase.alias_sample!(rand(10), weights(fill(0, 10)), rand(10))
ERROR: ArgumentError: all weights are zero
Stacktrace:
 [1] checked_sum
   @ ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:418 [inlined]
 [2] AliasTables.AliasTable{UInt64, Int64}(weights::Weights{Int64, Int64, Vector{Int64}}; _normalize::Bool)
   @ AliasTables ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:81
 [3] AliasTable
   @ ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:78 [inlined]
 [4] AliasTable
   @ ~/.julia/packages/AliasTables/yt2Qj/src/AliasTables.jl:76 [inlined]
 [5] alias_sample!(rng::TaskLocalRNG, a::Vector{Float64}, wv::Weights{Int64, Int64, Vector{Int64}}, x::Vector{Float64})
   @ StatsBase ~/.julia/dev/StatsBase/src/sampling.jl:719
 [6] top-level scope
   @ REPL[38]:1
```

Faster (benchmarks from https://github.com/JuliaStats/StatsBase.jl/issues/695#issuecomment-853816909)

Before
```julia
julia> using Chairmarks

julia> @b sample(1:5030, StatsBase.Weights(rand(Float32,5030)), 141230, replace=true)
1.558 ms (19 allocs: 1.251 MiB)

julia> @b sample(1:5030, StatsBase.Weights(rand(Float64,5030)), 141230, replace=true)
1.575 ms (19 allocs: 1.270 MiB)
```

After
```julia
julia> @b sample(1:5030, StatsBase.Weights(rand(Float32,5030)), 141230, replace=true)
294.460 μs (12 allocs: 1.260 MiB)

julia> @b sample(1:5030, StatsBase.Weights(rand(Float64,5030)), 141230, replace=true)
296.418 μs (12 allocs: 1.280 MiB)
```

Closes #630 (AliasTables.jl [uses `@inbounds` in sampling](https://github.com/LilithHafner/AliasTables.jl/blob/cb7b2d64bae60b92931cd1ddadfcfd20a8d0ba91/src/AliasTables.jl#L255) and contains a [correctness proof](https://github.com/LilithHafner/AliasTables.jl/blob/cb7b2d64bae60b92931cd1ddadfcfd20a8d0ba91/src/AliasTables.jl#L260-L300) that relies only on local information and basic properties of unsigned integers)

Closes #916 by making `alias_sample!` much faster than even using `ifelse` would. See https://aliastables.lilithhafner.com/dev/#Implementation-details for how.

See also: https://github.com/JuliaStats/Distributions.jl/pull/1848

cc @devmotion

