### PR TITLE
Don't run CI on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         version:
           - '1.0'
           - '1' # automatically expands to the latest stable 1.x release of Julia
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
It makes the CI status unreliable. We can test upcoming Julia releases in separate PRs.