### PR TITLE
Add :percentage normalization mode for hist

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -475,11 +475,12 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
 
         if mode == :none
             # nothing to do
-        elseif mode == :pdf || mode == :density || mode == :probability
+        elseif mode == :pdf || mode == :density || mode == :probability || mode == :percentage
             if h.isdensity
-                if mode == :pdf || mode == :probability
+                if mode == :pdf || mode == :probability || mode == :percentage
                     # histogram already represents a density, just divide weights by norm
-                    s = 1/norm(h)
+                    multiplier = mode == :percentage ? 100.0 : 1.0
+                    s = 1 / norm(h) * multiplier
                     weights .*= s
                     for A in aux_weights
                         A .*= s
@@ -502,7 +503,8 @@ arrays appropriately. See description of `normalize` for details. Returns `h`.
                 else
                     # :probability - divide weights by sum of weights
                     nf = inv(sum(weights))
-                    weights .*= nf
+                    multiplier = mode == :percentage ? 100.0 : 1.0
+                    weights .*= nf * multiplier
                     for A in aux_weights
                         A .*= nf
                     end
@@ -531,7 +533,8 @@ Valid values for `mode` are:
 * `:probability`: Normalize by sum of weights only. Resulting histogram
    represents the fraction of probability mass for each bin and does not have
    norm 1.
-*  `:none`: Leaves histogram unchanged. Useful to simplify code that has to
+* `:percentage`: Normalize as a percentage of the sum of weights. 
+* `:none`: Leaves histogram unchanged. Useful to simplify code that has to
    conditionally apply different modes of normalization.
 
 Successive application of both `:probability` and `:density` normalization (in

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -173,6 +173,7 @@ end
     @test normalize(h_density, mode = :pdf).weights ≈ h_pdf.weights
     @test normalize(h_density, mode = :density) == h_density
     @test normalize(h_density, mode = :probability).weights ≈ h_pdf.weights
+    @test normalize(h_density, mode = :percentage).weights ≈ h_pdf.weights * 100
 
     h_fraction = normalize(h, mode = :probability)
     @test sum(h_fraction.weights) ≈ 1
@@ -180,6 +181,7 @@ end
     @test normalize(h_fraction, mode = :pdf).weights ≈ h_pdf.weights
     @test normalize(h_fraction, mode = :density).weights ≈ h_pdf.weights
     @test normalize(h_fraction, mode = :probability).weights ≈ h_fraction.weights
+    @test normalize(h_fraction, mode = :percentage).weights ≈ h_fraction.weights * 100
 
     h_copy = deepcopy(float(h))
     @test @inferred(normalize!(h_copy, mode = :density)) == h_copy


### PR DESCRIPTION
This adds the option to normalise Histograms by percentage. This is typically useful for reporting data and plotting.

This is my first contribution here so please let me know if I missed something (tests, docs, etc).

