### PR TITLE
Docs `sample`: clarify that `a` is an array

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -461,9 +461,9 @@ seqsample_d!(a::AbstractArray, x::AbstractArray) = seqsample_d!(default_rng(), a
 
 ### Interface functions (poly-algorithms)
 """
-    sample([rng], a, [wv::AbstractWeights])
+    sample([rng], a::AbstractArray, [wv::AbstractWeights])
 
-Select a single random element of array `a`. Sampling probabilities are proportional to
+Select a single random element of `a`. Sampling probabilities are proportional to
 the weights given in `wv`, if provided.
 
 Optionally specify a random number generator `rng` as the first argument

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -463,7 +463,7 @@ seqsample_d!(a::AbstractArray, x::AbstractArray) = seqsample_d!(default_rng(), a
 """
     sample([rng], a, [wv::AbstractWeights])
 
-Select a single random element of `a`. Sampling probabilities are proportional to
+Select a single random element of array `a`. Sampling probabilities are proportional to
 the weights given in `wv`, if provided.
 
 Optionally specify a random number generator `rng` as the first argument


### PR DESCRIPTION
Hey! Beginner here!

I tried to sample from a distribution and it took a while to get that `sample` does not work on distributions. This should fix that!