### PR TITLE
Build docs with Documenter v1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,6 @@ makedocs(
              "misc.md",
              "statmodels.md",
              "transformations.md"],
-    strict=true,
     checkdocs=:exports
 )
 


### PR DESCRIPTION
Documenter v1 has been out for a while, but the docs are still built with v0.27. Recent improvements to Documenter (like auto-building an inventory of methods for other packages to interlink docs with StatsBase) are then not available. This PR updates to build docs with Documenter v1.