### PR TITLE
Fix `cov2cor` and `cor2cov` with `Hermitian` and `Symmetric` matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 authors = ["JuliaStats"]
-version = "0.34.4"
+version = "0.34.5"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/docs/src/cov.md
+++ b/docs/src/cov.md
@@ -13,7 +13,9 @@ std(::CovarianceEstimator, ::AbstractVector)
 cor
 mean_and_cov
 cov2cor
+StatsBase.cov2cor!
 cor2cov
+StatsBase.cor2cov!
 CovarianceEstimator
 SimpleCovariance
 ```

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -18,7 +18,7 @@ using SparseArrays
 import Random: rand, rand!
 import LinearAlgebra: BlasReal, BlasFloat
 import Statistics: mean, mean!, var, varm, varm!, std, stdm, cov, covm,
-                   cor, corm, cov2cor!, unscaled_covzm, quantile, sqrt!,
+                   cor, corm, unscaled_covzm, quantile, sqrt!,
                    median, middle
 using StatsAPI: StatisticalModel, RegressionModel
 import StatsAPI: pairwise, pairwise!, params, params!,

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -242,14 +242,6 @@ export
     CronbachAlpha,        # the type to represent Cronbach's alpha scores
     cronbachalpha         # function to compute Cronbach's alpha scores
 
-# https://github.com/JuliaLang/julia/pull/30630
-if VERSION < v"1.2.0-DEV.125" # 1da48c2e4028c1514ed45688be727efbef1db884
-    require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError(
-        "offset arrays are not supported but got an array with index other than 1"))
-else
-    using Base: require_one_based_indexing
-end
-
 # source files
 
 include("common.jl")

--- a/src/StatsBase.jl
+++ b/src/StatsBase.jl
@@ -242,6 +242,14 @@ export
     CronbachAlpha,        # the type to represent Cronbach's alpha scores
     cronbachalpha         # function to compute Cronbach's alpha scores
 
+# https://github.com/JuliaLang/julia/pull/30630
+if VERSION < v"1.2.0-DEV.125" # 1da48c2e4028c1514ed45688be727efbef1db884
+    require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError(
+        "offset arrays are not supported but got an array with index other than 1"))
+else
+    using Base: require_one_based_indexing
+end
+
 # source files
 
 include("common.jl")

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -144,7 +144,7 @@ Convert the covariance matrix `C` to a correlation matrix in-place, optionally u
 standard deviations `s`.
 """
 function cov2cor!(C::AbstractMatrix, s::AbstractArray = map(sqrt, view(C, diagind(C))))
-    require_one_based_indexing(C, s)
+    Base.require_one_based_indexing(C, s)
     n = length(s)
     size(C) == (n, n) || throw(DimensionMismatch("inconsistent dimensions"))
     for j = 1:n
@@ -206,7 +206,7 @@ Convert the correlation matrix `C` to a covariance matrix in-place using a vecto
 standard deviations `s`.
 """
 function cor2cov!(C::AbstractMatrix, s::AbstractArray)
-    require_one_based_indexing(C, s)
+    Base.require_one_based_indexing(C, s)
     n = length(s)
     size(C) == (n, n) || throw(DimensionMismatch("inconsistent dimensions"))
     for j in 1:n

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -144,7 +144,7 @@ Convert the covariance matrix `C` to a correlation matrix in-place, optionally u
 standard deviations `s`.
 """
 function cov2cor!(C::AbstractMatrix, s::AbstractArray = map(sqrt, view(C, diagind(C))))
-    Base.require_one_based_indexing(C, s)
+    require_one_based_indexing(C, s)
     n = length(s)
     size(C) == (n, n) || throw(DimensionMismatch("inconsistent dimensions"))
     for j = 1:n
@@ -206,7 +206,7 @@ Convert the correlation matrix `C` to a covariance matrix in-place using a vecto
 standard deviations `s`.
 """
 function cor2cov!(C::AbstractMatrix, s::AbstractArray)
-    Base.require_one_based_indexing(C, s)
+    require_one_based_indexing(C, s)
     n = length(s)
     size(C) == (n, n) || throw(DimensionMismatch("inconsistent dimensions"))
     for j in 1:n

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -130,7 +130,14 @@ end
 Compute the correlation matrix from the covariance matrix `C` and, optionally, a vector
 of standard deviations `s`. Use `StatsBase.cov2cor!` for an in-place version.
 """
-cov2cor(C::AbstractMatrix, s::AbstractArray=sqrt.(view(C, diagind(C)))) = cov2cor!(copy(C), s)
+cov2cor(C::AbstractMatrix, s::AbstractArray) = cov2cor!(copyto!(similar(C), C), s)
+function cov2cor(C::LinearAlgebra.HermOrSym, s::AbstractArray)
+    D = copyto!(similar(C), C)
+    cov2cor!(parent(D), s)
+    return D
+end
+
+cov2cor(C::AbstractMatrix) = cov2cor(C, map(sqrt, view(C, diagind(C))))
 
 """
     cor2cov(C, s)
@@ -138,7 +145,12 @@ cov2cor(C::AbstractMatrix, s::AbstractArray=sqrt.(view(C, diagind(C)))) = cov2co
 Compute the covariance matrix from the correlation matrix `C` and a vector of standard
 deviations `s`. Use `StatsBase.cor2cov!` for an in-place version.
 """
-cor2cov(C::AbstractMatrix, s::AbstractArray) = cor2cov!(copy(C), s)
+cor2cov(C::AbstractMatrix, s::AbstractArray) = cor2cov!(copyto!(similar(C), C), s)
+function cor2cov(C::LinearAlgebra.HermOrSym, s::AbstractArray)
+    D = copyto!(similar(C), C)
+    cor2cov!(parent(D), s)
+    return D
+end
 
 """
     cor2cov!(C, s)

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -120,18 +120,22 @@ weight_funcs = (weights, aweights, fweights, pweights)
             cor2 = cor(X, wv2, 2)
 
             @testset "cov2cor" begin
-                @test cov2cor(cov(X, dims = 1), std(X, dims = 1)) ≈ cor(X, dims = 1)
-                @test cov2cor(cov(X, dims = 2), std(X, dims = 2)) ≈ cor(X, dims = 2)
-                @test cov2cor(cov1) ≈ cor1
-                @test cov2cor(cov2) ≈ cor2
-                @test cov2cor(cov1, std1) ≈ cor1
-                @test cov2cor(cov2, std2) ≈ cor2
+                for wrapper in (identity, Symmetric, Hermitian)
+                    @test cov2cor(wrapper(cov(X, dims = 1)), std(X, dims = 1)) ≈ cor(X, dims = 1)
+                    @test cov2cor(wrapper(cov(X, dims = 2)), std(X, dims = 2)) ≈ cor(X, dims = 2)
+                    @test cov2cor(wrapper(cov1)) ≈ cor1
+                    @test cov2cor(wrapper(cov2)) ≈ cor2
+                    @test cov2cor(wrapper(cov1), std1) ≈ cor1
+                    @test cov2cor(wrapper(cov2), std2) ≈ cor2
+                end
             end
             @testset "cor2cov" begin
-                @test cor2cov(cor(X, dims = 1), std(X, dims = 1)) ≈ cov(X, dims = 1)
-                @test cor2cov(cor(X, dims = 2), std(X, dims = 2)) ≈ cov(X, dims = 2)
-                @test cor2cov(cor1, std1) ≈ cov1
-                @test cor2cov(cor2, std2) ≈ cov2
+                for wrapper in (identity, Symmetric, Hermitian)
+                    @test cor2cov(wrapper(cor(X, dims = 1)), std(X, dims = 1)) ≈ cov(X, dims = 1)
+                    @test cor2cov(wrapper(cor(X, dims = 2)), std(X, dims = 2)) ≈ cov(X, dims = 2)
+                    @test cor2cov(wrapper(cor1), std1) ≈ cov1
+                    @test cor2cov(wrapper(cor2), std2) ≈ cov2
+                end
             end
         end
     end
@@ -198,10 +202,12 @@ weight_funcs = (weights, aweights, fweights, pweights)
                 cor2 = cor(X, wv2, 2)
 
                 @testset "cov2cor" begin
-                    @test cov2cor(cov(X, dims = 1), std(X, dims = 1)) ≈ cor(X, dims = 1)
-                    @test cov2cor(cov(X, dims = 2), std(X, dims = 2)) ≈ cor(X, dims = 2)
-                    @test cov2cor(cov1, std1) ≈ cor1
-                    @test cov2cor(cov2, std2) ≈ cor2
+                    for wrapper in (identity, Symmetric, Hermitian)
+                        @test cov2cor(wrapper(cov(X, dims = 1)), std(X, dims = 1)) ≈ cor(X, dims = 1)
+                        @test cov2cor(wrapper(cov(X, dims = 2)), std(X, dims = 2)) ≈ cor(X, dims = 2)
+                        @test cov2cor(wrapper(cov1), std1) ≈ cor1
+                        @test cov2cor(wrapper(cov2), std2) ≈ cor2
+                    end
                 end
 
                 @testset "cov2cor!" begin
@@ -217,10 +223,12 @@ weight_funcs = (weights, aweights, fweights, pweights)
                 end
 
                 @testset "cor2cov" begin
-                    @test cor2cov(cor(X, dims = 1), std(X, dims = 1)) ≈ cov(X, dims = 1)
-                    @test cor2cov(cor(X, dims = 2), std(X, dims = 2)) ≈ cov(X, dims = 2)
-                    @test cor2cov(cor1, std1) ≈ cov1
-                    @test cor2cov(cor2, std2) ≈ cov2
+                    for wrapper in (identity, Symmetric, Hermitian)
+                        @test cor2cov(wrapper(cor(X, dims = 1)), std(X, dims = 1)) ≈ cov(X, dims = 1)
+                        @test cor2cov(wrapper(cor(X, dims = 2)), std(X, dims = 2)) ≈ cov(X, dims = 2)
+                        @test cor2cov(wrapper(cor1), std1) ≈ cov1
+                        @test cor2cov(wrapper(cor2), std2) ≈ cov2
+                    end
                 end
 
                 @testset "cor2cov!" begin

--- a/test/cov.jl
+++ b/test/cov.jl
@@ -6,6 +6,27 @@ struct EmptyCovarianceEstimator <: CovarianceEstimator end
 @testset "StatsBase.Covariance" begin
 weight_funcs = (weights, aweights, fweights, pweights)
 
+function test_isapprox_preserves_symherm_structure(f::F, x::AbstractMatrix, y::AbstractMatrix, args...) where F
+    for wrapper in (identity, x -> Symmetric(x, :U), x -> Symmetric(x, :L), x -> Hermitian(x, :U), x -> Hermitian(x, :L))
+        A = wrapper(copy(x))
+        fA = @inferred(f(A, args...))
+        @test fA ≈ y
+        if f === StatsBase.cov2cor! || f === StatsBase.cor2cov!
+            @test fA === A
+            if A isa Union{Symmetric,Hermitian}
+                @test parent(fA) != fA # only active triangle is written to
+            end
+        else
+            @test fA !== A
+            if A isa Union{Symmetric,Hermitian}
+                @test fA isa (A isa Symmetric ? Symmetric : Hermitian)
+                @test fA.uplo == A.uplo
+                @test parent(fA) != fA # only active triangle is written to
+            end
+        end
+    end
+end
+
 @testset "$f" for f in weight_funcs
     X = randn(3, 8)
 
@@ -120,22 +141,32 @@ weight_funcs = (weights, aweights, fweights, pweights)
             cor2 = cor(X, wv2, 2)
 
             @testset "cov2cor" begin
-                for wrapper in (identity, Symmetric, Hermitian)
-                    @test cov2cor(wrapper(cov(X, dims = 1)), std(X, dims = 1)) ≈ cor(X, dims = 1)
-                    @test cov2cor(wrapper(cov(X, dims = 2)), std(X, dims = 2)) ≈ cor(X, dims = 2)
-                    @test cov2cor(wrapper(cov1)) ≈ cor1
-                    @test cov2cor(wrapper(cov2)) ≈ cor2
-                    @test cov2cor(wrapper(cov1), std1) ≈ cor1
-                    @test cov2cor(wrapper(cov2), std2) ≈ cor2
-                end
+                test_isapprox_preserves_symherm_structure(cov2cor, cov(X, dims = 1), cor(X, dims = 1), std(X, dims = 1))
+                test_isapprox_preserves_symherm_structure(cov2cor, cov(X, dims = 2), cor(X, dims = 2), std(X, dims = 2))
+                test_isapprox_preserves_symherm_structure(cov2cor, cov1, cor1)
+                test_isapprox_preserves_symherm_structure(cov2cor, cov2, cor2)
+                test_isapprox_preserves_symherm_structure(cov2cor, cov1, cor1, std1)
+                test_isapprox_preserves_symherm_structure(cov2cor, cov2, cor2, std2)
+            end
+            @testset "StatsBase.cov2cor!" begin
+                test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov(X, dims = 1), cor(X, dims = 1), std(X, dims = 1))
+                test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov(X, dims = 2), cor(X, dims = 2), std(X, dims = 2))
+                test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov1, cor1)
+                test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov2, cor2)
+                test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov1, cor1, std1)
+                test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov2, cor2, std2)
             end
             @testset "cor2cov" begin
-                for wrapper in (identity, Symmetric, Hermitian)
-                    @test cor2cov(wrapper(cor(X, dims = 1)), std(X, dims = 1)) ≈ cov(X, dims = 1)
-                    @test cor2cov(wrapper(cor(X, dims = 2)), std(X, dims = 2)) ≈ cov(X, dims = 2)
-                    @test cor2cov(wrapper(cor1), std1) ≈ cov1
-                    @test cor2cov(wrapper(cor2), std2) ≈ cov2
-                end
+                test_isapprox_preserves_symherm_structure(cor2cov, cor(X, dims = 1), cov(X, dims = 1), std(X, dims = 1))
+                test_isapprox_preserves_symherm_structure(cor2cov, cor(X, dims = 2), cov(X, dims = 2), std(X, dims = 2))
+                test_isapprox_preserves_symherm_structure(cor2cov, cor1, cov1, std1)
+                test_isapprox_preserves_symherm_structure(cor2cov, cor2, cov2, std2)
+            end
+            @testset "StatsBase.cor2cov!" begin
+                test_isapprox_preserves_symherm_structure(StatsBase.cor2cov!, cor(X, dims = 1), cov(X, dims = 1), std(X, dims = 1))
+                test_isapprox_preserves_symherm_structure(StatsBase.cor2cov!, cor(X, dims = 2), cov(X, dims = 2), std(X, dims = 2))
+                test_isapprox_preserves_symherm_structure(StatsBase.cor2cov!, cor1, cov1, std1)
+                test_isapprox_preserves_symherm_structure(StatsBase.cor2cov!, cor2, cov2, std2)
             end
         end
     end
@@ -202,45 +233,24 @@ weight_funcs = (weights, aweights, fweights, pweights)
                 cor2 = cor(X, wv2, 2)
 
                 @testset "cov2cor" begin
-                    for wrapper in (identity, Symmetric, Hermitian)
-                        @test cov2cor(wrapper(cov(X, dims = 1)), std(X, dims = 1)) ≈ cor(X, dims = 1)
-                        @test cov2cor(wrapper(cov(X, dims = 2)), std(X, dims = 2)) ≈ cor(X, dims = 2)
-                        @test cov2cor(wrapper(cov1), std1) ≈ cor1
-                        @test cov2cor(wrapper(cov2), std2) ≈ cor2
-                    end
+                    test_isapprox_preserves_symherm_structure(cov2cor, cov1, cor1)
+                    test_isapprox_preserves_symherm_structure(cov2cor, cov2, cor2)
+                    test_isapprox_preserves_symherm_structure(cov2cor, cov1, cor1, std1)
+                    test_isapprox_preserves_symherm_structure(cov2cor, cov2, cor2, std2)
                 end
-
-                @testset "cov2cor!" begin
-                    tmp_cov1 = copy(cov1)
-                    @test !(tmp_cov1 ≈ cor1)
-                    StatsBase.cov2cor!(tmp_cov1, std1)
-                    @test tmp_cov1 ≈ cor1
-
-                    tmp_cov2 = copy(cov2)
-                    @test !(tmp_cov2 ≈ cor2)
-                    StatsBase.cov2cor!(tmp_cov2, std2)
-                    @test tmp_cov2 ≈ cor2
+                @testset "StatsBase.cov2cor!" begin
+                    test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov1, cor1)
+                    test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov2, cor2)
+                    test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov1, cor1, std1)
+                    test_isapprox_preserves_symherm_structure(StatsBase.cov2cor!, cov2, cor2, std2)
                 end
-
                 @testset "cor2cov" begin
-                    for wrapper in (identity, Symmetric, Hermitian)
-                        @test cor2cov(wrapper(cor(X, dims = 1)), std(X, dims = 1)) ≈ cov(X, dims = 1)
-                        @test cor2cov(wrapper(cor(X, dims = 2)), std(X, dims = 2)) ≈ cov(X, dims = 2)
-                        @test cor2cov(wrapper(cor1), std1) ≈ cov1
-                        @test cor2cov(wrapper(cor2), std2) ≈ cov2
-                    end
+                    test_isapprox_preserves_symherm_structure(cor2cov, cor1, cov1, std1)
+                    test_isapprox_preserves_symherm_structure(cor2cov, cor2, cov2, std2)
                 end
-
-                @testset "cor2cov!" begin
-                    tmp_cor1 = copy(cor1)
-                    @test !(tmp_cor1 ≈ cov1)
-                    StatsBase.cor2cov!(tmp_cor1, std1)
-                    @test tmp_cor1 ≈ cov1
-
-                    tmp_cor2 = copy(cor2)
-                    @test !(tmp_cor2 ≈ cov2)
-                    StatsBase.cor2cov!(tmp_cor2, std2)
-                    @test tmp_cor2 ≈ cov2
+                @testset "StatsBase.cor2cov!" begin
+                    test_isapprox_preserves_symherm_structure(StatsBase.cor2cov!, cor1, cov1, std1)
+                    test_isapprox_preserves_symherm_structure(StatsBase.cor2cov!, cor2, cov2, std2)
                 end
             end
         end


### PR DESCRIPTION
Currently, `cov2cor` and `cor2cov` error for `Hermitian` and `Symmetric` matrices:

```julia
julia> using StatsBase, LinearAlgebra

julia> X = rand(3, 10);

julia> cov2cor(Symmetric(cov(X)))
ERROR: ArgumentError: Cannot set a non-diagonal index in a symmetric matrix
Stacktrace:
 [1] setindex!
   @ ~/.local/share/mise/installs/julia/1.11.5/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:258 [inlined]
 [2] cov2cor!(C::Symmetric{Float64, Matrix{Float64}}, xsd::Vector{Float64})
   @ Statistics ~/.julia/packages/Statistics/gbcbG/src/Statistics.jl:642
 [3] cov2cor
   @ ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:133 [inlined]
 [4] cov2cor(C::Symmetric{Float64, Matrix{Float64}})
   @ StatsBase ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:133
 [5] top-level scope
   @ REPL[11]:1

julia> cov2cor(Hermitian(cov(X)))
ERROR: ArgumentError: Cannot set a non-diagonal index in a Hermitian matrix
Stacktrace:
 [1] setindex!
   @ ~/.local/share/mise/installs/julia/1.11.5/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:264 [inlined]
 [2] cov2cor!(C::Hermitian{Float64, Matrix{Float64}}, xsd::Vector{Float64})
   @ Statistics ~/.julia/packages/Statistics/gbcbG/src/Statistics.jl:642
 [3] cov2cor
   @ ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:133 [inlined]
 [4] cov2cor(C::Hermitian{Float64, Matrix{Float64}})
   @ StatsBase ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:133
 [5] top-level scope
   @ REPL[12]:1

julia> cor2cov(Symmetric(cor(X)), rand(10))
ERROR: ArgumentError: Cannot set a non-diagonal index in a symmetric matrix
Stacktrace:
 [1] setindex!
   @ ~/.local/share/mise/installs/julia/1.11.5/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:258 [inlined]
 [2] _setindex!
   @ ./abstractarray.jl:1443 [inlined]
 [3] setindex!
   @ ./abstractarray.jl:1413 [inlined]
 [4] cor2cov!(C::Symmetric{Float64, Matrix{Float64}}, s::Vector{Float64})
   @ StatsBase ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:153
 [5] cor2cov(C::Symmetric{Float64, Matrix{Float64}}, s::Vector{Float64})
   @ StatsBase ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:141
 [6] top-level scope
   @ REPL[14]:1

julia> cor2cov(Hermitian(cor(X)), rand(10))
ERROR: ArgumentError: Cannot set a non-diagonal index in a Hermitian matrix
Stacktrace:
 [1] setindex!
   @ ~/.local/share/mise/installs/julia/1.11.5/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:264 [inlined]
 [2] _setindex!
   @ ./abstractarray.jl:1443 [inlined]
 [3] setindex!
   @ ./abstractarray.jl:1413 [inlined]
 [4] cor2cov!(C::Hermitian{Float64, Matrix{Float64}}, s::Vector{Float64})
   @ StatsBase ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:153
 [5] cor2cov(C::Hermitian{Float64, Matrix{Float64}}, s::Vector{Float64})
   @ StatsBase ~/.julia/packages/StatsBase/xgoZ5/src/cov.jl:141
 [6] top-level scope
   @ REPL[15]:1
```

The PR fixes this issue.

Fixes https://github.com/JuliaStats/StatsBase.jl/issues/444.