### PR TITLE
Add tests with JET

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 AliasTables = "1"
 DataAPI = "1"
 DataStructures = "0.10, 0.11, 0.12, 0.13, 0.14, 0.17, 0.18"
+JET = "0.9.18, 0.10"
 LinearAlgebra = "<0.0.1, 1"
 LogExpFunctions = "0.3"
 Missings = "0.3, 0.4, 1.0"
@@ -35,9 +36,10 @@ julia = "1.10"
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dates", "DelimitedFiles", "OffsetArrays", "StableRNGs", "Test"]
+test = ["Dates", "DelimitedFiles", "JET", "OffsetArrays", "StableRNGs", "Test"]

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -23,11 +23,7 @@ end
 
 ## scatter matrix
 
-_unscaled_covzm(x::DenseMatrix, dims::Colon)   = unscaled_covzm(x)
 _unscaled_covzm(x::DenseMatrix, dims::Integer) = unscaled_covzm(x, dims)
-
-_unscaled_covzm(x::DenseMatrix, wv::AbstractWeights, dims::Colon)   =
-    _symmetrize!(unscaled_covzm(x, _scalevars(x, wv)))
 _unscaled_covzm(x::DenseMatrix, wv::AbstractWeights, dims::Integer) =
     _symmetrize!(unscaled_covzm(x, _scalevars(x, wv, dims), dims))
 

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -5,7 +5,7 @@ if !isdefined(Base, :stderr)
 else
     function (io::typeof(stderr))(obj::StatisticalModel)
         Base.depwarn("stderr(obj::StatisticalModel) is deprecated, use stderror(obj) instead", :stderr)
-        io === stderr ? stderror(obj) : throw(MethodErrror(io, (obj,)))
+        io === stderr ? stderror(obj) : throw(MethodError(io, (obj,)))
     end
 end
 
@@ -22,8 +22,6 @@ end
 @deprecate scattermatm(x::DenseMatrix, mean, wv::AbstractWeights, dims::Int) scattermat(x, wv, mean=mean, dims=dims)
 @deprecate scattermat(x::DenseMatrix, dims::Int) scattermat(x, dims=dims)
 @deprecate scattermat(x::DenseMatrix, wv::AbstractWeights, dims::Int) scattermat(x, wv, dims=dims)
-@deprecate scattermat_zm(x::DenseMatrix, dims::Int) scattermat_zm(x, dims=dims)
-@deprecate scattermat_zm(x::DenseMatrix, wv::AbstractWeights, dims::Int) scattermat_zm(x::DenseMatrix, wv::AbstractWeights, dims=dims)
 @deprecate mean!(R::AbstractArray, A::AbstractArray, w::AbstractWeights, dims::Int) mean!(R, A, w, dims=dims)
 @deprecate mean(A::AbstractArray{T}, w::AbstractWeights{W}, dims::Int) where {T<:Number,W<:Real} mean(A, w, dims=dims)
 

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,0 +1,22 @@
+using StatsBase, Test
+import JET
+
+# JET has only experimental support for Julia 1.12 currently
+# It throws an internal `AssertionError` in the tests below
+if VERSION < v"1.12-"
+    @testset "JET" begin
+        # Check that there are no undefined global references and undefined field accesses
+        JET.test_package("StatsBase"; target_defined_modules = true, mode = :typo)
+
+        # Default error analysis for common problem fails since JET errors on interface definitions
+        # The (deprecated) `model_response(::StatisticalModel)` calls the interface
+        # function `response(::StatisticalModel)` for which no method exists yet
+        # Note: This analysis is not enough strict to guarantee that there are no runtime errors!
+        # Ref https://github.com/aviatesk/JET.jl/issues/495
+        res = JET.report_package("StatsBase"; target_defined_modules = true, mode = :basic, toplevel_logger = nothing)
+        println(res)
+        reports = JET.get_reports(res)
+        @test_broken isempty(reports)
+        @test length(reports) <= 1
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,9 @@ tests = ["ambiguous",
          "wsampling",
          "statmodels",
          "partialcor",
-         "transformations"]
+         "transformations",
+         # Test with JET after all other tests since it has side effects
+         "jet"] 
          #"statquiz"]
 
 println("Running tests:")


### PR DESCRIPTION
Based on and opened against #954.

The most basic JET tests revealed a typo and few issues (calls of non-existing methods):

```julia
julia> using StatsBase, JET

julia> report_package(StatsBase; target_defined_modules = true)
...
═════ 6 possible errors found ═════
┌ _unscaled_covzm(x::DenseMatrix, dims::Colon) @ StatsBase /Users/david/.julia/packages/StatsBase/uvhDX/src/cov.jl:26
│ no matching method found `unscaled_covzm(::DenseMatrix)`: StatsBase.unscaled_covzm(x::DenseMatrix)
└────────────────────
┌ _unscaled_covzm(x::DenseMatrix, wv::StatsBase.AbstractWeights, dims::Colon) @ StatsBase /Users/david/.julia/packages/StatsBase/uvhDX/src/cov.jl:29
│ no matching method found `_scalevars(::DenseMatrix, ::StatsBase.AbstractWeights)`: StatsBase._scalevars(x::DenseMatrix, wv::StatsBase.AbstractWeights)
└────────────────────
┌ (::Base.TTY)(obj::StatisticalModel) @ StatsBase /Users/david/.julia/packages/StatsBase/uvhDX/src/deprecates.jl:8
│ `StatsBase.MethodErrror` is not defined: StatsBase.MethodErrror
└────────────────────
┌ model_response(obj::StatisticalModel) @ StatsBase ./deprecated.jl:105
│ no matching method found `response(::StatisticalModel)`: response(obj::StatisticalModel)
└────────────────────
┌ scattermat_zm(x::DenseMatrix, dims::Int64) @ StatsBase ./deprecated.jl:105
│ no matching method found `kwcall(::@NamedTuple{dims::Int64}, ::typeof(StatsBase.scattermat_zm), ::DenseMatrix)`: Core.kwcall(NamedTuple{(:dims,)}(tuple(dims::Int64)::Tuple{Int64})::@NamedTuple{dims::Int64}, scattermat_zm, x::DenseMatrix)
└────────────────────
┌ scattermat_zm(x::DenseMatrix, wv::StatsBase.AbstractWeights, dims::Int64) @ StatsBase ./deprecated.jl:105
│ no matching method found `kwcall(::@NamedTuple{dims::Int64}, ::typeof(StatsBase.scattermat_zm), ::DenseMatrix, ::StatsBase.AbstractWeights)`: Core.kwcall(NamedTuple{(:dims,)}(tuple(dims::Int64)::Tuple{Int64})::@NamedTuple{dims::Int64}, scattermat_zm, typeassert(x::DenseMatrix, StatsBase.DenseMatrix)::DenseMatrix, typeassert(wv::StatsBase.AbstractWeights, AbstractWeights)::StatsBase.AbstractWeights)
└────────────────────
```

Edit: Tests currently fail on 1.12 (only somewhat experimental support for JET, an internal `AssertionError` is thrown) and on the other Julia versions since JET triggers method redefinitions (e.g. https://github.com/JuliaStats/StatsBase.jl/actions/runs/14743207189/job/41385529150?pr=955#step:6:178) that cause other subsequent tests to fail. See https://aviatesk.github.io/JET.jl/v0.9/jetanalysis/#jetanalysis-toplevel-entry

Edit 2: "Fixed" by disabling JET tests on Julia 1.12 and moving the JET tests to the end, after all other tests.