### PR TITLE
Disable CI on Julia pre

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         version:
           - 'min'
           - '1' # automatically expands to the latest stable 1.x release of Julia
-          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
JET does not support Julia 1.13- and hence the test environment can't be instantiate on Julia pre currently, which causes tests to fail immediately: https://github.com/aviatesk/JET.jl/issues/796

I assume that will be a recurring problem as JET is so tightly dependent on Julia internals. Moreover, IMO it's generally a bit questionable whether testing StatsBase on Julia pre provides any benefit to package developers.