### PR TITLE
Fix `var`/`std` along a dimension with `UnitWeights`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsBase"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.34.11"
+version = "0.34.12"
 authors = ["JuliaStats"]
 
 [deps]

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -73,7 +73,7 @@ function var(A::AbstractArray{<:Real}, w::AbstractWeights, dim::Int; mean=nothin
 end
 function var(v::AbstractArray{<:Real}, w::UnitWeights, dim::Int; mean=nothing,
                   corrected::Union{Bool, Nothing}=nothing)
-    length(w) == length(v) || throw(DimensionMismatch("Inconsistent array lengths."))
+    size(v, dim) == length(w) || throw(DimensionMismatch("Inconsistent array lengths."))
     corrected = depcheck(:var, :corrected, corrected)
     return var(v; mean, corrected, dims=dim)
 end

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -482,7 +482,7 @@ end
 end
 
 @testset "weighted var/std along a dimension with UnitWeights" begin
-    x = reshape(collect(1.0:12.0), 3, 4)
+    x = reshape(1.0:12.0, 3, 4)
 
     # `UnitWeights` along a dimension must match the unweighted result and must
     # not erroneously compare the weight length against the total array length.

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -481,4 +481,20 @@ end
     end
 end
 
+@testset "weighted var/std along a dimension with UnitWeights" begin
+    x = reshape(collect(1.0:12.0), 3, 4)
+
+    # `UnitWeights` along a dimension must match the unweighted result and must
+    # not erroneously compare the weight length against the total array length.
+    @test var(x, uweights(3), 1; corrected=true) ≈ var(x; dims=1)
+    @test var(x, uweights(4), 2; corrected=true) ≈ var(x; dims=2)
+    @test var(x, uweights(3), 1; corrected=false) ≈ var(x; dims=1, corrected=false)
+    @test std(x, uweights(3), 1; corrected=true) ≈ std(x; dims=1)
+    @test std(x, uweights(4), 2; corrected=true) ≈ std(x; dims=2)
+
+    # A weight vector whose length does not match the reduction dimension errors.
+    @test_throws DimensionMismatch var(x, uweights(4), 1; corrected=true)
+    @test_throws DimensionMismatch var(x, uweights(3), 2; corrected=true)
+end
+
 end # @testset "StatsBase.Moments"


### PR DESCRIPTION
`var(A::AbstractArray, w::UnitWeights, dim::Int)` — and therefore `std` along a dimension, which dispatches to it — compared the weight length against the *total* number of array elements (`length(v)`) instead of the size along the reduction dimension (`size(v, dim)`):

```julia
function var(v::AbstractArray{<:Real}, w::UnitWeights, dim::Int; mean=nothing,
                  corrected::Union{Bool, Nothing}=nothing)
    length(w) == length(v) || throw(DimensionMismatch("Inconsistent array lengths."))
    ...
end
```

As a result the method threw `DimensionMismatch("Inconsistent array lengths.")` for essentially any multidimensional array, even when the weight vector correctly matched the reduced dimension:

```julia
julia> using StatsBase

julia> var(reshape(1.0:12.0, 3, 4), uweights(3), 1)
ERROR: DimensionMismatch: Inconsistent array lengths.
```

This compares against `size(v, dim)` instead, consistent with the existing `mean(A, w::UnitWeights; dims)` method which already checks `size(A, dims) == length(w)`.

`weight_funcs` in `test/moments.jl` is `(weights, aweights, fweights, pweights)` and does not include `uweights`, so the matrix `var(x, w, dim)` / `std(x, w, dim)` tests never exercised `UnitWeights` — hence the gap. Added a regression testset covering weighted `var`/`std` along a dimension with `UnitWeights`, including the mismatched-length error case.

Also bumped the patch version to 0.34.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)