### PR TITLE
Fix OOM/hang in histrange when bin width is below floating-point res

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -43,10 +43,18 @@ function histrange(lo::F, hi::F, n::Integer, closed::Symbol=:left) where F
     if hi == lo
         start = F(hi)
         step = one(F)
+        if start + step == start
+            # step is below the floating-point spacing at `hi`: the endpoint
+            # adjustments below would grow `len` to ~eps(hi)/2
+            step = exp10(ceil(log10(eps(start))))
+        end
         divisor = one(F)
         len = one(F)
     else
         bw = (F(hi) - F(lo)) / n
+        # a bin width below the floating-point spacing of the data would
+        # stall the endpoint adjustments below
+        bw = max(bw, 2*eps(float(max(abs(lo), abs(hi)))))
         lbw = log10(bw)
         if lbw >= 0
             step = exp10(floor(lbw))

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -44,9 +44,8 @@ function histrange(lo::F, hi::F, n::Integer, closed::Symbol=:left) where F
         start = F(hi)
         step = one(F)
         if start + step == start
-            # step is below the floating-point spacing at `hi`: the endpoint
-            # adjustments below would grow `len` to ~eps(hi)/2
-            step = exp10(ceil(log10(eps(start))))
+            # step is below the floating-point spacing at `hi`: bump it up
+            step = eps(start)
         end
         divisor = one(F)
         len = one(F)
@@ -54,7 +53,7 @@ function histrange(lo::F, hi::F, n::Integer, closed::Symbol=:left) where F
         bw = (F(hi) - F(lo)) / n
         # a bin width below the floating-point spacing of the data would
         # stall the endpoint adjustments below
-        bw = max(bw, 2*eps(float(max(abs(lo), abs(hi)))))
+        bw = max(bw, eps(float(max(abs(lo), abs(hi)))))
         lbw = log10(bw)
         if lbw >= 0
             step = exp10(floor(lbw))

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -42,18 +42,15 @@ end
 function histrange(lo::F, hi::F, n::Integer, closed::Symbol=:left) where F
     if hi == lo
         start = F(hi)
-        step = one(F)
-        if start + step == start
-            # step is below the floating-point spacing at `hi`: bump it up
-            step = eps(start)
-        end
+        # if step is below the floating-point spacing at `hi`, bump it up
+        step = max(one(F), eps(start))
         divisor = one(F)
         len = one(F)
     else
         bw = (F(hi) - F(lo)) / n
         # a bin width below the floating-point spacing of the data would
         # stall the endpoint adjustments below
-        bw = max(bw, eps(float(max(abs(lo), abs(hi)))))
+        bw = max(bw, eps(F(hi)), eps(F(lo)))
         lbw = log10(bw)
         if lbw >= 0
             step = exp10(floor(lbw))

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -62,6 +62,9 @@ end
     d = collect(0:99)
     v = view(d, fill(true, 100))
     @test fit(Histogram{Float32},v,weights(2*ones(100)),nbins=5).weights == [40,40,40,40,40]
+
+    # Issue 972: OutOfMemoryError for identical values of large magnitude
+    @test sum(fit(Histogram, [-5.603325961434038e25, -5.603325961434038e25]).weights) == 2
 end
 
 
@@ -110,6 +113,33 @@ end
     # Issue 616/667
     @test StatsBase.histrange([1.0 for i in 1:100], 10, :left) == 1.0:1.0:2.0
     @test StatsBase.histrange([1.05 for i in 1:100], 10, :left) == 1.05:1.0:2.05
+
+    # Issue 972: values whose magnitude is so large that a bin width of
+    # one (or the requested width) is below the floating-point spacing
+    let x = -5.603325961434038e25
+        r = StatsBase.histrange([x, x], 10, :left)
+        @test first(r) == x
+        @test length(r) == 2
+        @test step(r) >= eps(x)
+        for closed in (:left, :right), n in (10, 100, 1000)
+            r = StatsBase.histrange(x, nextfloat(x, 3), n, closed)
+            @test length(r) < 100
+            if closed == :left
+                @test first(r) <= x
+                @test last(r) > nextfloat(x, 3)
+            else
+                @test first(r) < x
+                @test last(r) >= nextfloat(x, 3)
+            end
+        end
+    end
+    # tiny spans relative to the magnitude used to stall in the fractional
+    # bin width branch
+    let r = StatsBase.histrange(1.0e15, 1.0e15 + 0.001, 10, :left)
+        @test length(r) < 100
+        @test first(r) <= 1.0e15
+        @test last(r) > 1.0e15 + 0.001
+    end
 
     @test_throws ArgumentError StatsBase.histrange([1, 10], 0, :left)
     @test_throws ArgumentError StatsBase.histrange([1, 10], -1, :left)

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -115,7 +115,7 @@ end
     @test StatsBase.histrange([1.05 for i in 1:100], 10, :left) == 1.05:1.0:2.05
 
     # Issue 972: values whose magnitude is so large that a bin width of
-    # one (or the requested width) is below the floating-point spacing
+    # one (or the computed width) is below the floating-point spacing
     let x = -5.603325961434038e25
         r = StatsBase.histrange([x, x], 10, :left)
         @test first(r) == x
@@ -124,6 +124,7 @@ end
         for closed in (:left, :right), n in (10, 100, 1000)
             r = StatsBase.histrange(x, nextfloat(x, 3), n, closed)
             @test length(r) < 100
+            @test step(r) >= eps(x)
             if closed == :left
                 @test first(r) <= x
                 @test last(r) > nextfloat(x, 3)


### PR DESCRIPTION
`fit(Histogram, x)` threw an `OutOfMemoryError` when all values were identical with a large magnitude. The hardcoded `step = 1` in histrange is below the floating-point spacing at that magnitude, so the endpoint adjustment loop ran for billions of iterations and produced a very large weights array.

The same root cause could also make the `hi != lo` branch hang forever when the computed bin width falls below the resolution of the data.

This PR fixes both cases by ensuring the step is never smaller than the floating-point spacing of the data.

Generated with the help of Claude Code (Fable) and manually adjusted and verified.

Fixes #972 